### PR TITLE
ci(dcm): make DCM analyze non-blocking

### DIFF
--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -40,6 +40,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: DCM analyze (blocking)
+        continue-on-error: true
         run: >-
           dcm analyze lib
           --ci-key=${{ secrets.DCM_CI_KEY }}


### PR DESCRIPTION
## Summary

Make `DCM analyze` non-blocking in CI — the DCM CI key monthly quota can be exhausted, which should not prevent PRs from merging. Added `continue-on-error: true` to the `DCM analyze (blocking)` step.

## Test plan

- [x] `dart analyze --fatal-infos` — no issues
- [x] `dcm analyze lib` — no issues (clean locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)