### PR TITLE
feat(wasm): compile/runPrecompiled/startPrecompiled + MontySession snapshot

### DIFF
--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -391,6 +391,76 @@ async function restore(dataBase64) {
 }
 
 /**
+ * Compile Python code and return the bytecode as a snapshot buffer.
+ *
+ * Creates a temporary handle, snapshots compiled bytecode, and frees
+ * the handle. Returns a raw JS object (ArrayBuffer is not JSON-safe).
+ *
+ * @param {string} code       Python source code.
+ * @param {string} scriptName Script name for tracebacks (optional).
+ * @returns {Promise<Object>} Raw JS object with snapshotBuffer ArrayBuffer.
+ */
+async function compile(code, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) {
+    return { ok: false, error: 'Not initialized' };
+  }
+
+  const session = sessions.get(sid);
+  const msg = { type: 'compile', code };
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  // Return raw JS object — snapshotBuffer is an ArrayBuffer, not JSON-safe.
+  return result;
+}
+
+/**
+ * Run precompiled bytecode to completion.
+ *
+ * @param {string} dataBase64 Base64-encoded compiled snapshot bytes.
+ * @param {string} limitsJson JSON-encoded limits map (optional).
+ * @param {string} scriptName Script name for tracebacks (optional).
+ * @returns {Promise<string>} JSON result.
+ */
+async function runPrecompiled(dataBase64, limitsJson, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const hardTimeout = parseHardTimeout(limitsJson);
+  if (hardTimeout != null) session.timeoutMs = hardTimeout;
+
+  const limits = limitsJson ? JSON.parse(limitsJson) : null;
+  const msg = { type: 'runPrecompiled', dataBase64, limits };
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
+ * Start iterative execution from precompiled bytecode.
+ *
+ * @param {string} dataBase64 Base64-encoded compiled snapshot bytes.
+ * @param {string} limitsJson JSON-encoded limits map (optional).
+ * @param {string} scriptName Script name for tracebacks (optional).
+ * @returns {Promise<string>} JSON result.
+ */
+async function startPrecompiled(dataBase64, limitsJson, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const hardTimeout = parseHardTimeout(limitsJson);
+  if (hardTimeout != null) session.timeoutMs = hardTimeout;
+
+  const limits = limitsJson ? JSON.parse(limitsJson) : null;
+  const msg = { type: 'startPrecompiled', dataBase64, limits };
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
  * Resume a name lookup by providing a value for the looked-up name.
  *
  * @param {string} valueJson JSON-encoded value.
@@ -577,6 +647,9 @@ window.DartMontyBridge = {
   resumeNameLookupUndefined,
   snapshot,
   restore,
+  compile,
+  runPrecompiled,
+  startPrecompiled,
   discover,
   cancel,
   dispose,

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -759,6 +759,276 @@ function handleRestore(id, dataBase64) {
   self.postMessage({ type: 'result', id, ok: true });
 }
 
+function handleCompile(id, code, scriptName) {
+  let cCode = null;
+  let cName = null;
+  let outError = null;
+
+  let handle;
+  try {
+    outError = allocOutPtr();
+    cCode = allocCString(code);
+    cName = scriptName ? allocCString(scriptName) : null;
+    handle = wasm.monty_create(cCode.ptr, 0, cName ? cName.ptr : 0, outError.ptr);
+  } catch (e) {
+    if (outError) outError.free();
+    throw e;
+  } finally {
+    if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
+    if (cName) wasm.monty_dealloc(cName.ptr, cName.size);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_create failed',
+      errorType: 'CompileError',
+      excType: excTypeFromMsg(errMsg),
+    });
+    return;
+  }
+  outError.free();
+
+  // Snapshot the compiled (pre-execution) handle — captures bytecode only.
+  // Does NOT set activeHandle; handle is freed after snapshotting.
+  const outLen = allocOutPtr();
+  let ptr;
+  try {
+    ptr = wasm.monty_snapshot(handle, outLen.ptr);
+  } catch (e) {
+    outLen.free();
+    wasm.monty_free(handle);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+  wasm.monty_free(handle);
+
+  if (ptr === 0) {
+    outLen.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'monty_snapshot returned null after compile',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const len = outLen.read();
+  outLen.free();
+
+  const wasmBytes = new Uint8Array(wasm.memory.buffer, ptr, len);
+  let copy;
+  try {
+    copy = wasmBytes.slice();
+  } finally {
+    wasm.monty_bytes_free(ptr, len);
+  }
+
+  // Transfer ArrayBuffer to main thread (zero-copy move)
+  self.postMessage(
+    { type: 'result', id, ok: true, snapshotBuffer: copy.buffer },
+    [copy.buffer],
+  );
+}
+
+function handleRunPrecompiled(id, dataBase64, limits, scriptName) {
+  // Decode base64 to Uint8Array
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  const outError = allocOutPtr();
+
+  const ptr = wasm.monty_alloc(bytes.length);
+  if (ptr === 0) {
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: `monty_alloc(${bytes.length}) returned null — OOM`,
+      errorType: 'MemoryError',
+    });
+    return;
+  }
+  new Uint8Array(wasm.memory.buffer).set(bytes, ptr);
+
+  let handle;
+  try {
+    handle = wasm.monty_restore(ptr, bytes.length, outError.ptr);
+  } catch (e) {
+    outError.free();
+    throw e;
+  } finally {
+    wasm.monty_dealloc(ptr, bytes.length);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_restore failed',
+      errorType: 'RestoreError',
+    });
+    return;
+  }
+  outError.free();
+
+  // Apply limits
+  if (limits) {
+    if (limits.memory_bytes != null) wasm.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+
+  let outResult = null;
+  let outErrMsg = null;
+
+  let resultTag;
+  try {
+    outResult = allocOutPtr();
+    outErrMsg = allocOutPtr();
+    resultTag = wasm.monty_run(handle, outResult.ptr, outErrMsg.ptr);
+  } catch (e) {
+    if (outResult) outResult.free();
+    if (outErrMsg) outErrMsg.free();
+    wasm.monty_free(handle);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  const resultPtr = outResult.read();
+  const errorPtr = outErrMsg.read();
+  const resultJson = readAndFreeCString(resultPtr);
+  const errorMsg = readAndFreeCString(errorPtr);
+  outResult.free();
+  outErrMsg.free();
+  wasm.monty_free(handle);
+
+  if (resultTag === RESULT_OK && resultJson) {
+    const adapted = adaptResultForDart(resultJson, false);
+    self.postMessage({ type: 'result', id, ...adapted });
+  } else if (resultJson) {
+    const adapted = adaptResultForDart(resultJson, true);
+    self.postMessage({ type: 'result', id, ...adapted });
+  } else {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errorMsg || 'monty_run failed',
+      errorType: 'MontyException',
+    });
+  }
+}
+
+function handleStartPrecompiled(id, dataBase64, limits, scriptName) {
+  // Free any abandoned execution before starting a new one.
+  if (activeHandle) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+
+  // Decode base64 to Uint8Array
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  const outError = allocOutPtr();
+
+  const ptr = wasm.monty_alloc(bytes.length);
+  if (ptr === 0) {
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: `monty_alloc(${bytes.length}) returned null — OOM`,
+      errorType: 'MemoryError',
+    });
+    return;
+  }
+  new Uint8Array(wasm.memory.buffer).set(bytes, ptr);
+
+  let handle;
+  try {
+    handle = wasm.monty_restore(ptr, bytes.length, outError.ptr);
+  } catch (e) {
+    outError.free();
+    throw e;
+  } finally {
+    wasm.monty_dealloc(ptr, bytes.length);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_restore failed',
+      errorType: 'RestoreError',
+    });
+    return;
+  }
+  outError.free();
+
+  // Apply limits
+  if (limits) {
+    if (limits.memory_bytes != null) wasm.monty_set_memory_limit(handle, limits.memory_bytes);
+    if (limits.timeout_ms != null) wasm.monty_set_time_limit_ms(handle, BigInt(limits.timeout_ms));
+    if (limits.stack_depth != null) wasm.monty_set_stack_limit(handle, limits.stack_depth);
+  }
+
+  activeHandle = handle;
+
+  let outErr;
+  let tag;
+  try {
+    outErr = allocOutPtr();
+    tag = wasm.monty_start(handle, outErr.ptr);
+  } catch (e) {
+    if (outErr) outErr.free();
+    activeHandle = null;
+    wasm.monty_free(handle);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, handle, tag, errMsg);
+  } catch (e) {
+    activeHandle = null;
+    wasm.monty_free(handle);
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    activeHandle = null;
+    wasm.monty_free(handle);
+  }
+  self.postMessage(msg);
+}
+
 function handleResumeNameLookupValue(id, valueJson) {
   if (!activeHandle) {
     self.postMessage({
@@ -1070,6 +1340,15 @@ self.onmessage = (e) => {
         break;
       case 'restore':
         handleRestore(id, dataBase64);
+        break;
+      case 'compile':
+        handleCompile(id, code, scriptName);
+        break;
+      case 'runPrecompiled':
+        handleRunPrecompiled(id, dataBase64, limits, scriptName);
+        break;
+      case 'startPrecompiled':
+        handleStartPrecompiled(id, dataBase64, limits, scriptName);
         break;
       case 'resumeNameLookupValue':
         handleResumeNameLookupValue(id, valueJson);

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -99,9 +99,6 @@ class Monty {
   ///
   /// State is **not** preserved across [runPrecompiled] calls. For stateful
   /// execution, use [run] instead.
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   Future<MontyResult> runPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,
@@ -111,6 +108,25 @@ class Monty {
     limits: limits,
     scriptName: scriptName,
   );
+
+  /// Captures all Python variables persisted by this session.
+  ///
+  /// Returns a self-contained binary snapshot. Pass to [restore] on the same
+  /// or a new [Monty] instance to recreate the Python variable state.
+  ///
+  /// Safe to call between [run] calls — no live interpreter handle is
+  /// required. See [MontySession.snapshot] for details.
+  ///
+  /// **Note on external functions:** Dart [MontyCallback] closures registered
+  /// via `externals:` cannot be serialised. Re-provide them in the
+  /// `externals:` parameter of subsequent [run] calls after [restore].
+  Uint8List snapshot() => _session.snapshot();
+
+  /// Restores Python variables from a snapshot produced by [snapshot].
+  ///
+  /// The next [run] call will inject the restored variables into the Python
+  /// scope. Throws [ArgumentError] if [bytes] is not a valid snapshot.
+  void restore(Uint8List bytes) => _session.restore(bytes);
 
   /// Clears all persisted state.
   ///
@@ -130,9 +146,6 @@ class Monty {
   /// same script.
   ///
   /// Equivalent to `Monty.dump()` in the JS `@pydantic/monty` SDK.
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   ///
   /// ```dart
   /// final binary = await Monty.compile('x * 2 + y');

--- a/lib/src/monty_session.dart
+++ b/lib/src/monty_session.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dart_monty_core/src/externals.dart';
@@ -176,9 +177,6 @@ class MontySession {
   /// State is **not** preserved across [runPrecompiled] calls — the compiled
   /// code runs in isolation without `__restore_state__`/`__persist_state__`
   /// wrapping. For stateful execution use [run] instead.
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   Future<MontyResult> runPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,
@@ -190,6 +188,52 @@ class MontySession {
       compiled,
       limits: limits,
       scriptName: scriptName,
+    );
+  }
+
+  /// Captures all Python variables persisted by this session.
+  ///
+  /// Returns a self-contained binary snapshot that can be passed to [restore]
+  /// on a new [MontySession] backed by the same or a different platform.
+  ///
+  /// After each [run] call completes, `MontySession` state lives entirely in
+  /// the Dart-side `_state` map — the Rust execution handle is freed. This
+  /// snapshot therefore serialises only the Dart state; no live Rust heap is
+  /// required and the method is safe to call between [run] calls.
+  ///
+  /// **Note on external functions:** Dart [MontyCallback] closures registered
+  /// via `externals:` cannot be serialised. Re-provide them in the
+  /// `externals:` parameter of subsequent [run] calls after [restore].
+  Uint8List snapshot() {
+    _checkNotDisposed();
+    final envelope = jsonEncode({
+      'v': 1,
+      'dartState': _state,
+    });
+
+    return Uint8List.fromList(utf8.encode(envelope));
+  }
+
+  /// Restores Python variables from a snapshot produced by [snapshot].
+  ///
+  /// Replaces the Dart-side Python globals. The next [run] call after
+  /// [restore] will inject the restored variables into the Python scope.
+  ///
+  /// Throws [ArgumentError] if [bytes] is not a valid session snapshot or
+  /// if the snapshot format version is unsupported.
+  void restore(Uint8List bytes) {
+    _checkNotDisposed();
+    final Map<String, dynamic> envelope;
+    try {
+      envelope = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+    } on FormatException catch (e) {
+      throw ArgumentError('Not a valid MontySession snapshot: $e');
+    }
+    if (envelope['v'] != 1) {
+      throw ArgumentError('Unsupported snapshot version: ${envelope['v']}');
+    }
+    _state = (envelope['dartState'] as Map<String, dynamic>).map(
+      (k, v) => MapEntry(k, v as Object?),
     );
   }
 

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -190,8 +190,19 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   Future<Uint8List> compileCode(String code) async {
     assertNotDisposed('compileCode');
     await _ensureInitialized();
+    try {
+      return await _bindings.compileCode(code);
+    } on MontyScriptError catch (e) {
+      if (e.excType == 'SyntaxError') {
+        throw MontySyntaxError(
+          e.message,
+          excType: e.excType,
+          exception: e.exception,
+        );
+      }
 
-    return _bindings.compileCode(code);
+      rethrow;
+    }
   }
 
   @override

--- a/lib/src/platform/core_bindings.dart
+++ b/lib/src/platform/core_bindings.dart
@@ -217,7 +217,12 @@ abstract class MontyCoreBindings {
   /// The engine raises NameError.
   Future<CoreProgressResult> resumeNameLookupUndefined();
 
-  /// Captures the current execution state as a snapshot.
+  /// Captures the current Rust interpreter heap as a raw snapshot.
+  ///
+  /// **Rust heap only.** Python globals held Dart-side by `MontySession` are
+  /// not included. For a self-contained snapshot that preserves all variables,
+  /// use `MontySession.snapshot()` or `Monty.snapshot()`. `MontyRepl` users
+  /// can call this method directly — the REPL heap is complete.
   Future<Uint8List> snapshot();
 
   /// Restores execution state from [data].

--- a/lib/src/platform/monty_platform.dart
+++ b/lib/src/platform/monty_platform.dart
@@ -93,9 +93,6 @@ abstract class MontyPlatform {
   /// script with different `inputs` values.
   ///
   /// Equivalent to `Monty.dump()` in the JS `@pydantic/monty` SDK.
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   Future<Uint8List> compileCode(String code) {
     throw UnimplementedError('compileCode() has not been implemented.');
   }
@@ -105,9 +102,6 @@ abstract class MontyPlatform {
   /// Equivalent to `Monty.load(binary).run()` in the JS `@pydantic/monty`
   /// SDK. The [compiled] bytes are self-contained and may be used across
   /// sessions and calls.
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   Future<MontyResult> runPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,
@@ -120,9 +114,6 @@ abstract class MontyPlatform {
   ///
   /// Use [MontyPlatform.resume] or [MontyPlatform.resumeWithError] to
   /// continue after each [MontyPending].
-  ///
-  /// On WASM, throws [UnsupportedError] — snapshot support requires a
-  /// future update to the WASM JS bridge.
   Future<MontyProgress> startPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -272,6 +272,45 @@ abstract class WasmBindings {
   /// the default.
   Future<void> restore(Uint8List data, {int? sessionId});
 
+  /// Compiles [code] and returns the bytecode as a binary snapshot.
+  ///
+  /// Creates a temporary handle, snapshots compiled bytecode, and frees the
+  /// handle. The returned bytes can be passed to [runPrecompiled] or
+  /// [startPrecompiled] to execute without re-parsing.
+  ///
+  /// When [sessionId] is non-null, routes to that specific session instead of
+  /// the default.
+  Future<Uint8List> compile(String code, {String? scriptName, int? sessionId});
+
+  /// Runs precompiled [compiled] bytes to completion.
+  ///
+  /// Restores a handle from the snapshot bytes, applies [limitsJson] if
+  /// provided, runs to completion, and frees the handle.
+  ///
+  /// When [sessionId] is non-null, routes to that specific session instead of
+  /// the default.
+  Future<WasmRunResult> runPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  });
+
+  /// Starts iterative execution from precompiled [compiled] bytes.
+  ///
+  /// Restores a handle from the snapshot bytes, applies [limitsJson] if
+  /// provided, and starts execution. The handle is stored for subsequent
+  /// [resume] calls.
+  ///
+  /// When [sessionId] is non-null, routes to that specific session instead of
+  /// the default.
+  Future<WasmProgressResult> startPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  });
+
   /// Discovers the bridge API surface.
   Future<WasmDiscoverResult> discover();
 

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -84,6 +84,29 @@ external JSPromise<JSString> _jsRestore(
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.compile')
+external JSPromise<JSAny> _jsCompile(
+  JSString code, [
+  JSString? scriptName,
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.runPrecompiled')
+external JSPromise<JSString> _jsRunPrecompiled(
+  JSString dataBase64, [
+  JSString? limitsJson,
+  JSString? scriptName,
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.startPrecompiled')
+external JSPromise<JSString> _jsStartPrecompiled(
+  JSString dataBase64, [
+  JSString? limitsJson,
+  JSString? scriptName,
+  JSNumber? sessionId,
+]);
+
 @JS('DartMontyBridge.discover')
 external JSString _jsDiscover();
 
@@ -315,6 +338,75 @@ class WasmBindingsJs extends WasmBindings {
     if (map['ok'] != true) {
       throw StateError(map['error'] as String? ?? 'Restore failed');
     }
+  }
+
+  @override
+  Future<Uint8List> compile(
+    String code, {
+    String? scriptName,
+    int? sessionId,
+  }) async {
+    final jsAny = await _jsCompile(
+      code.toJS,
+      scriptName?.toJS,
+      sessionId?.toJS,
+    ).toDart;
+    final result = jsAny as _SnapshotResult;
+    if (!result.ok.toDart) {
+      throw StateError(result.error?.toDart ?? 'compile failed');
+    }
+
+    return result.snapshotBuffer!.toDart.asUint8List();
+  }
+
+  @override
+  Future<WasmRunResult> runPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  }) async {
+    final dataBase64 = base64Encode(compiled);
+    final resultJson = await _jsRunPrecompiled(
+      dataBase64.toJS,
+      limitsJson?.toJS,
+      scriptName?.toJS,
+      sessionId?.toJS,
+    ).toDart;
+    final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
+    final rawTraceback = map['traceback'] as List<Object?>?;
+
+    return WasmRunResult(
+      ok: map['ok'] as bool,
+      value: map['value'],
+      printOutput: map['print_output'] as String?,
+      error: map['error'] as String?,
+      errorType: map['errorType'] as String?,
+      excType: map['excType'] as String?,
+      traceback: rawTraceback,
+      filename: map['filename'] as String?,
+      lineNumber: map['line_number'] as int?,
+      columnNumber: map['column_number'] as int?,
+      sourceCode: map['source_code'] as String?,
+    );
+  }
+
+  @override
+  Future<WasmProgressResult> startPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  }) async {
+    final dataBase64 = base64Encode(compiled);
+    final resultJson = await _jsStartPrecompiled(
+      dataBase64.toJS,
+      limitsJson?.toJS,
+      scriptName?.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
   }
 
   @override

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -81,6 +81,29 @@ class WasmBindingsJs extends WasmBindings {
       throw UnimplementedError();
 
   @override
+  Future<Uint8List> compile(
+    String code, {
+    String? scriptName,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmRunResult> runPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> startPrecompiled(
+    Uint8List compiled, {
+    String? limitsJson,
+    String? scriptName,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
   Future<WasmDiscoverResult> discover() => throw UnimplementedError();
 
   @override

--- a/lib/src/wasm/wasm_core_bindings.dart
+++ b/lib/src/wasm/wasm_core_bindings.dart
@@ -139,23 +139,25 @@ class WasmCoreBindings implements MontyCoreBindings {
   }
 
   @override
-  Future<Uint8List> compileCode(String code) {
-    throw UnsupportedError(
-      'compileCode() is not supported on WASM — snapshot support requires '
-      'a future update to the WASM JS bridge.',
-    );
-  }
+  Future<Uint8List> compileCode(String code) =>
+      _bindings.compile(code, sessionId: _sessionId);
 
   @override
   Future<CoreRunResult> runPrecompiled(
     Uint8List compiled, {
     String? limitsJson,
     String? scriptName,
-  }) {
-    throw UnsupportedError(
-      'runPrecompiled() is not supported on WASM — snapshot support requires '
-      'a future update to the WASM JS bridge.',
+  }) async {
+    final sw = Stopwatch()..start();
+    final result = await _bindings.runPrecompiled(
+      compiled,
+      limitsJson: limitsJson,
+      scriptName: scriptName,
+      sessionId: _sessionId,
     );
+    sw.stop();
+
+    return _translateRunResult(result, sw.elapsedMilliseconds);
   }
 
   @override
@@ -163,11 +165,17 @@ class WasmCoreBindings implements MontyCoreBindings {
     Uint8List compiled, {
     String? limitsJson,
     String? scriptName,
-  }) {
-    throw UnsupportedError(
-      'startPrecompiled() is not supported on WASM — snapshot support '
-      'requires a future update to the WASM JS bridge.',
+  }) async {
+    final sw = Stopwatch()..start();
+    final progress = await _bindings.startPrecompiled(
+      compiled,
+      limitsJson: limitsJson,
+      scriptName: scriptName,
+      sessionId: _sessionId,
     );
+    sw.stop();
+
+    return _translateProgressResult(progress, sw.elapsedMilliseconds);
   }
 
   @override

--- a/test/unit/platform/monty_compile_test.dart
+++ b/test/unit/platform/monty_compile_test.dart
@@ -8,8 +8,40 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:dart_monty_core/src/platform/base_monty_platform.dart';
+import 'package:dart_monty_core/src/platform/core_bindings.dart';
 import 'package:dart_monty_core/src/platform/mock_monty_platform.dart';
 import 'package:test/test.dart';
+
+// Throws [MontyScriptError] from compileCode with the given excType;
+// used to test SyntaxError promotion in BaseMontyPlatform.compileCode.
+final class _ThrowingBindings implements MontyCoreBindings {
+  _ThrowingBindings(this._excType);
+  final String _excType;
+
+  @override
+  Future<bool> init() async => true;
+
+  @override
+  Future<Uint8List> compileCode(String code) async => throw MontyScriptError(
+    '$_excType: stub error',
+    excType: _excType,
+  );
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+final class _StubPlatform extends BaseMontyPlatform {
+  _StubPlatform(MontyCoreBindings bindings) : super(bindings: bindings);
+
+  @override
+  String get backendName => '_StubPlatform';
+}
 
 const _zeroUsage = MontyResourceUsage(
   memoryBytesUsed: 0,
@@ -139,6 +171,33 @@ void main() {
       // The bytes encode the code — verify round-trip through JSON.
       final decoded = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
       expect(decoded['code'], '42');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('BaseMontyPlatform.compileCode error promotion', () {
+    test('SyntaxError is promoted to MontySyntaxError', () async {
+      final platform = _StubPlatform(_ThrowingBindings('SyntaxError'));
+      addTearDown(platform.dispose);
+      await expectLater(
+        platform.compileCode('bad code'),
+        throwsA(isA<MontySyntaxError>()),
+      );
+    });
+
+    test('non-SyntaxError is rethrown as MontyScriptError', () async {
+      final platform = _StubPlatform(_ThrowingBindings('ValueError'));
+      addTearDown(platform.dispose);
+      await expectLater(
+        platform.compileCode('bad code'),
+        throwsA(
+          isA<MontyScriptError>().having(
+            (e) => e is MontySyntaxError,
+            'is not MontySyntaxError',
+            isFalse,
+          ),
+        ),
+      );
     });
   });
 }

--- a/test/unit/session/monty_session_snapshot_test.dart
+++ b/test/unit/session/monty_session_snapshot_test.dart
@@ -1,0 +1,207 @@
+// Unit tests for MontySession.snapshot() and MontySession.restore().
+//
+// Uses MockMontyPlatform — no native dylib required.
+@Tags(['unit'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:dart_monty_core/src/platform/mock_monty_platform.dart';
+import 'package:test/test.dart';
+
+const _zeroUsage = MontyResourceUsage(
+  memoryBytesUsed: 0,
+  timeElapsedMs: 0,
+  stackDepthUsed: 0,
+);
+
+const _nullResult = MontyResult(value: MontyNone(), usage: _zeroUsage);
+
+/// Enqueues the three progress items consumed by a simple MontySession run
+/// with the given [persistedState] dict returned by __persist_state__.
+void _enqueueSimpleRun(
+  MockMontyPlatform mock, {
+  MontyResult result = _nullResult,
+  Map<String, MontyValue> persistedState = const {},
+}) {
+  mock
+    ..enqueueProgress(
+      const MontyPending(
+        functionName: '__restore_state__',
+        arguments: [],
+      ),
+    )
+    ..enqueueProgress(
+      MontyPending(
+        functionName: '__persist_state__',
+        arguments: [MontyDict(persistedState)],
+      ),
+    )
+    ..enqueueProgress(MontyComplete(result: result));
+}
+
+MontySession _makeSession() => MontySession(platform: MockMontyPlatform());
+
+void main() {
+  group('MontySession.snapshot / restore', () {
+    test('snapshot of empty session produces valid envelope', () {
+      final session = _makeSession();
+      final bytes = session.snapshot();
+      expect(bytes, isNotEmpty);
+
+      final envelope = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
+      expect(envelope['v'], equals(1));
+      expect(envelope['dartState'], equals({}));
+    });
+
+    test(
+      'round-trip: variable defined in run survives snapshot/restore',
+      () async {
+        final mock = MockMontyPlatform();
+        final session = MontySession(platform: mock);
+
+        _enqueueSimpleRun(
+          mock,
+          persistedState: {'x': const MontyInt(42)},
+        );
+        await session.run('x = 42');
+
+        final bytes = session.snapshot();
+
+        // Restore into a new session backed by a fresh mock.
+        final session2 = MontySession(platform: MockMontyPlatform())
+          ..restore(bytes);
+
+        expect(session2.state, equals({'x': 42}));
+      },
+    );
+
+    test('round-trip: multiple variables all restored', () async {
+      final mock = MockMontyPlatform();
+      final session = MontySession(platform: mock);
+
+      _enqueueSimpleRun(
+        mock,
+        persistedState: {
+          'x': const MontyInt(1),
+          'y': const MontyInt(2),
+          'name': const MontyString('Alice'),
+        },
+      );
+      await session.run('x = 1\ny = 2\nname = "Alice"');
+
+      final bytes = session.snapshot();
+
+      final session2 = MontySession(platform: MockMontyPlatform())
+        ..restore(bytes);
+
+      expect(session2.state, equals({'x': 1, 'y': 2, 'name': 'Alice'}));
+    });
+
+    test('restore replaces existing state', () async {
+      final mock = MockMontyPlatform();
+      final session = MontySession(platform: mock);
+
+      _enqueueSimpleRun(
+        mock,
+        persistedState: {'x': const MontyInt(1)},
+      );
+      await session.run('x = 1');
+      final snapshot1 = session.snapshot();
+
+      _enqueueSimpleRun(
+        mock,
+        persistedState: {'x': const MontyInt(99)},
+      );
+      await session.run('x = 99');
+      expect(session.state['x'], equals(99));
+
+      // Restore back to snapshot1
+      session.restore(snapshot1);
+      expect(session.state['x'], equals(1));
+    });
+
+    test('after restore the next run injects the restored state', () async {
+      final mock = MockMontyPlatform();
+      final session = MontySession(platform: mock);
+
+      _enqueueSimpleRun(
+        mock,
+        persistedState: {'x': const MontyInt(7)},
+      );
+      await session.run('x = 7');
+      final bytes = session.snapshot();
+
+      // Create a new session, restore, then run.
+      final mock2 = MockMontyPlatform();
+      final session2 = MontySession(platform: mock2)..restore(bytes);
+
+      _enqueueSimpleRun(
+        mock2,
+        persistedState: {'x': const MontyInt(7)},
+        result: const MontyResult(value: MontyInt(7), usage: _zeroUsage),
+      );
+      await session2.run('x');
+
+      // The start code passed to the mock should include the restore section.
+      final startCode = mock2.history.startCodes.first;
+      expect(startCode, contains('__restore_state__'));
+      expect(startCode, contains('x = __d["x"]'));
+    });
+
+    test('invalid bytes throw ArgumentError', () {
+      final session = _makeSession();
+      expect(
+        () => session.restore(Uint8List.fromList([1, 2, 3])),
+        throwsArgumentError,
+      );
+    });
+
+    test('wrong version throws ArgumentError', () {
+      final session = _makeSession();
+      final badEnvelope = utf8.encode(
+        jsonEncode(<String, Object?>{
+          'v': 99,
+          'dartState': <String, Object?>{},
+        }),
+      );
+      expect(
+        () => session.restore(Uint8List.fromList(badEnvelope)),
+        throwsArgumentError,
+      );
+    });
+
+    test('snapshot on disposed session throws StateError', () {
+      final session = _makeSession()..dispose();
+      expect(session.snapshot, throwsStateError);
+    });
+
+    test('restore on disposed session throws StateError', () {
+      final session = _makeSession();
+      final bytes = session.snapshot();
+      session.dispose();
+      expect(() => session.restore(bytes), throwsStateError);
+    });
+  });
+
+  group('Monty.snapshot / restore', () {
+    test('round-trip preserves state', () async {
+      final mock = MockMontyPlatform();
+      final monty = Monty.withPlatform(mock);
+
+      _enqueueSimpleRun(
+        mock,
+        persistedState: {'answer': const MontyInt(42)},
+      );
+      await monty.run('answer = 42');
+
+      final bytes = monty.snapshot();
+
+      final monty2 = Monty.withPlatform(MockMontyPlatform())..restore(bytes);
+
+      expect(monty2.state, equals(<String, Object?>{'answer': 42}));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

- **W1 — WASM compile/runPrecompiled/startPrecompiled**: Removes `UnsupportedError` stubs throughout the WASM stack. `wasm.monty_create` was always available in the Worker; the three missing operations (`handleCompile`, `handleRunPrecompiled`, `handleStartPrecompiled`) are now wired from Worker → bridge.js → `WasmBindings` → `WasmCoreBindings`. `compile` returns raw bytes via `ArrayBuffer` transfer (same pattern as `snapshot`).
- **W2 — Document snapshot gap**: `MontyCoreBindings.snapshot()` doc comment now clearly says "Rust heap only" and redirects to `MontySession.snapshot()` for the full-state case. Removed stale "WASM not supported" notes from `monty_platform.dart`.
- **W3 — `MontySession.snapshot()` / `Monty.snapshot()`**: Between `run()` calls, all Python variables live in Dart's `_state` map — the Rust handle is freed on completion. Snapshot therefore serialises only `_state` as a versioned JSON envelope `{v:1, dartState:{...}}`. Restore simply deserialises `_state`; the next `run()` injects it via `__restore_state__`. No Rust bytes needed, no platform interaction required. API is synchronous.

## Changes

| File | Change |
|---|---|
| `js/src/worker_src.js` | Add `handleCompile`, `handleRunPrecompiled`, `handleStartPrecompiled` + 3 dispatch cases |
| `js/src/bridge.js` | Add `compile`, `runPrecompiled`, `startPrecompiled` + export on `DartMontyBridge` |
| `lib/src/wasm/wasm_bindings.dart` | 3 new abstract method signatures |
| `lib/src/wasm/wasm_bindings_js.dart` | `@JS` interop declarations + 3 implementations |
| `lib/src/wasm/wasm_bindings_js_stub.dart` | 3 stub implementations |
| `lib/src/wasm/wasm_core_bindings.dart` | Replace 3 `UnsupportedError` stubs with real delegates |
| `lib/src/monty_session.dart` | Add `snapshot()` / `restore()` (synchronous) |
| `lib/src/monty.dart` | Delegate `snapshot()` / `restore()` to `_session` |
| `lib/src/platform/core_bindings.dart` | Doc: "Rust heap only" on `snapshot()` |
| `lib/src/platform/monty_platform.dart` | Remove stale UnsupportedError notes |
| `test/unit/session/monty_session_snapshot_test.dart` | 10 new unit tests |

## Test plan

- [x] `dart analyze --fatal-infos lib/ test/` — no issues
- [x] `dart test --exclude-tags=ffi,wasm,integration` — 94/94 pass (10 new snapshot tests)
- [x] `dart test test/integration/oracle_ffi_test.dart -p vm --run-skipped --tags=ffi` — 464/464 pass
- [ ] WASM integration: `Monty.compile()` on WASM → non-empty `Uint8List` (was `UnsupportedError`)
- [ ] WASM integration: `session.runPrecompiled(binary)` on WASM → expected result

🤖 Generated with [Claude Code](https://claude.com/claude-code)