### PR TITLE
fix: promote compileCode SyntaxError to MontySyntaxError

### DIFF
--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -190,8 +190,19 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   Future<Uint8List> compileCode(String code) async {
     assertNotDisposed('compileCode');
     await _ensureInitialized();
+    try {
+      return await _bindings.compileCode(code);
+    } on MontyScriptError catch (e) {
+      if (e.excType == 'SyntaxError') {
+        throw MontySyntaxError(
+          e.message,
+          excType: e.excType,
+          exception: e.exception,
+        );
+      }
 
-    return _bindings.compileCode(code);
+      rethrow;
+    }
   }
 
   @override

--- a/test/unit/platform/monty_compile_test.dart
+++ b/test/unit/platform/monty_compile_test.dart
@@ -8,8 +8,40 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:dart_monty_core/src/platform/base_monty_platform.dart';
+import 'package:dart_monty_core/src/platform/core_bindings.dart';
 import 'package:dart_monty_core/src/platform/mock_monty_platform.dart';
 import 'package:test/test.dart';
+
+// Throws [MontyScriptError] from compileCode with the given excType;
+// used to test SyntaxError promotion in BaseMontyPlatform.compileCode.
+final class _ThrowingBindings implements MontyCoreBindings {
+  _ThrowingBindings(this._excType);
+  final String _excType;
+
+  @override
+  Future<bool> init() async => true;
+
+  @override
+  Future<Uint8List> compileCode(String code) async => throw MontyScriptError(
+    '$_excType: stub error',
+    excType: _excType,
+  );
+
+  @override
+  Future<void> dispose() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('${invocation.memberName}');
+}
+
+final class _StubPlatform extends BaseMontyPlatform {
+  _StubPlatform(MontyCoreBindings bindings) : super(bindings: bindings);
+
+  @override
+  String get backendName => '_StubPlatform';
+}
 
 const _zeroUsage = MontyResourceUsage(
   memoryBytesUsed: 0,
@@ -139,6 +171,33 @@ void main() {
       // The bytes encode the code — verify round-trip through JSON.
       final decoded = jsonDecode(utf8.decode(bytes)) as Map<String, dynamic>;
       expect(decoded['code'], '42');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  group('BaseMontyPlatform.compileCode error promotion', () {
+    test('SyntaxError is promoted to MontySyntaxError', () async {
+      final platform = _StubPlatform(_ThrowingBindings('SyntaxError'));
+      addTearDown(platform.dispose);
+      await expectLater(
+        platform.compileCode('bad code'),
+        throwsA(isA<MontySyntaxError>()),
+      );
+    });
+
+    test('non-SyntaxError is rethrown as MontyScriptError', () async {
+      final platform = _StubPlatform(_ThrowingBindings('ValueError'));
+      addTearDown(platform.dispose);
+      await expectLater(
+        platform.compileCode('bad code'),
+        throwsA(
+          isA<MontyScriptError>().having(
+            (e) => e is MontySyntaxError,
+            'is not MontySyntaxError',
+            isFalse,
+          ),
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
## Summary

- `BaseMontyPlatform.compileCode` was silently swallowing the `SyntaxError→MontySyntaxError` promotion that `run`/`start` already do via `_throwError`
- `NativeBindingsFfi.create` throws `MontyScriptError` for **all** compile failures (including syntax errors), so `compileCode` callers could never catch the more-specific `MontySyntaxError`
- Added a `try/catch` in `compileCode` that checks `excType == 'SyntaxError'` and rethrows as `MontySyntaxError`; non-syntax errors are rethrown unchanged

## Test plan

- [ ] `dart test test/unit/platform/monty_compile_test.dart` — 15/15 pass (2 new: `SyntaxError promoted`, `non-SyntaxError rethrown`)
- [ ] `dart analyze --fatal-infos lib/ test/` — no issues
- [ ] No integration files included; pressure tests validated this fix on branch `feat/pressure-test-snapshot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)