### PR TITLE
feat(demos): three-panel web + Flutter demo — concurrent REPLs, VFS, snapshot

### DIFF
--- a/lib/src/monty_session.dart
+++ b/lib/src/monty_session.dart
@@ -67,13 +67,24 @@ Map<String, Object?> _toArgMap(
 
 String _wrapSessionCode(
   String code,
-  Iterable<String> stateKeys, {
+  Iterable<String> stateKeys,
+  Iterable<String> knownImports, {
   Map<String, Object?>? inputs,
 }) {
   final restore = _buildRestoreCode(stateKeys);
   final persist = _buildPersistCode(code, stateKeys);
   final (processed, hasResult) = code_capture.captureLastExpression(code);
-  final buf = StringBuffer(restore)..write('\n');
+  final buf = StringBuffer();
+  // Replay stored import statements first so module names are in scope even
+  // though module objects are not JSON-serializable and absent from _state.
+  for (final stmt in knownImports) {
+    buf
+      ..write(stmt)
+      ..write('\n');
+  }
+  buf
+    ..write(restore)
+    ..write('\n');
   if (inputs != null && inputs.isNotEmpty) {
     buf
       ..write(inputs_encoder.inputsToCode(inputs))
@@ -126,6 +137,11 @@ class MontySession {
   final MontyPlatform _platform;
   final OsCallHandler? _osHandler;
   Map<String, Object?> _state = {};
+  // Top-level import statements seen across all run() calls. Module objects
+  // are not JSON-serializable so they cannot live in _state; instead we
+  // replay these statements at the top of every wrapped execution so module
+  // names remain in scope across calls.
+  Set<String> _knownImports = {};
   bool _isDisposed = false;
 
   /// The current persisted state map. Read-only snapshot.
@@ -154,7 +170,13 @@ class MontySession {
     Map<String, Object?>? inputs,
   }) async {
     _checkNotDisposed();
-    final wrapped = _wrapSessionCode(code, _state.keys, inputs: inputs);
+    _knownImports.addAll(code_capture.extractImportStatements(code));
+    final wrapped = _wrapSessionCode(
+      code,
+      _state.keys,
+      _knownImports,
+      inputs: inputs,
+    );
     final extFns = [_restoreStateFn, _persistStateFn, ...externals.keys];
     final progress = await _safeCall(
       () => _platform.start(
@@ -209,6 +231,7 @@ class MontySession {
     final envelope = jsonEncode({
       'v': 1,
       'dartState': _state,
+      'imports': _knownImports.toList(),
     });
 
     return Uint8List.fromList(utf8.encode(envelope));
@@ -235,6 +258,9 @@ class MontySession {
     _state = (envelope['dartState'] as Map<String, dynamic>).map(
       (k, v) => MapEntry(k, v as Object?),
     );
+    _knownImports = Set<String>.from(
+      (envelope['imports'] as List<dynamic>?)?.cast<String>() ?? const [],
+    );
   }
 
   /// Starts iterative execution, surfacing [MontyPending] for user callbacks.
@@ -249,7 +275,8 @@ class MontySession {
     String? scriptName,
   }) async {
     _checkNotDisposed();
-    final wrapped = _wrapSessionCode(code, _state.keys);
+    _knownImports.addAll(code_capture.extractImportStatements(code));
+    final wrapped = _wrapSessionCode(code, _state.keys, _knownImports);
     final allExtFns = [_restoreStateFn, _persistStateFn, ...?externalFunctions];
     final initial = await _safeCall(
       () => _platform.start(
@@ -283,6 +310,7 @@ class MontySession {
   void clearState() {
     _checkNotDisposed();
     _state = {};
+    _knownImports = {};
   }
 
   /// Disposes the session. Does NOT dispose the underlying platform.

--- a/lib/src/platform/code_capture.dart
+++ b/lib/src/platform/code_capture.dart
@@ -105,6 +105,28 @@ String? _assignmentName(String segment) {
   return name.startsWith('_') ? null : name;
 }
 
+/// Extracts top-level `import` and `from … import` statements from [code].
+///
+/// Only considers lines with no leading whitespace (top-level).
+/// Handles semicolons for multi-statement lines.
+/// These are replayed as a preamble on every subsequent run call so that
+/// module names stay in scope across calls even though module objects are
+/// not JSON-serializable and cannot be stored in persistent state.
+Set<String> extractImportStatements(String code) {
+  final stmts = <String>{};
+  for (final line in code.split('\n')) {
+    if (line.isEmpty || line[0] == ' ' || line[0] == '\t') continue;
+    for (final raw in line.split(';')) {
+      final seg = raw.trim();
+      if (seg.startsWith('import ') || seg.startsWith('from ')) {
+        stmts.add(seg);
+      }
+    }
+  }
+
+  return stmts;
+}
+
 /// Extracts top-level assignment target names from [code].
 ///
 /// Only considers lines with no leading whitespace (top-level).

--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -1,17 +1,63 @@
+// Flutter demo for dart_monty_core.
+//
+// Three tabs demonstrate the core features:
+//
+//  Session A / Session B — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally so their Rust heap handles
+//    are stored separately in the WASM Worker's replHandles Map. Variables
+//    in A are invisible in B and vice versa.
+//    Tip: set x = 10 in Session A, then evaluate x in Session B — B won't see it.
+//
+//  VFS / OsCall — a Monty() session with an in-memory filesystem wired
+//    to the osHandler. Python's pathlib.Path reads and writes go through
+//    the Dart handler instead of the real filesystem.
+//    Also demonstrates snapshot / restore (📸 / ↩).
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(const MontyReplApp());
+// ---------------------------------------------------------------------------
+// In-memory VFS
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
 }
 
-class MontyReplApp extends StatelessWidget {
-  const MontyReplApp({super.key});
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+void main() => runApp(const MontyDemoApp());
+
+class MontyDemoApp extends StatelessWidget {
+  const MontyDemoApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Monty REPL',
+      title: 'Monty Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: const Color(0xFF4EC9B0),
@@ -20,50 +66,129 @@ class MontyReplApp extends StatelessWidget {
         useMaterial3: true,
         fontFamily: 'monospace',
       ),
-      home: const MontyReplPage(),
+      home: const MontyDemoPage(),
     );
   }
 }
 
-class MontyReplPage extends StatefulWidget {
-  const MontyReplPage({super.key});
+class MontyDemoPage extends StatefulWidget {
+  const MontyDemoPage({super.key});
 
   @override
-  State<MontyReplPage> createState() => _MontyReplPageState();
+  State<MontyDemoPage> createState() => _MontyDemoPageState();
 }
 
-class _MontyReplPageState extends State<MontyReplPage> {
-  final MontyRepl _repl = MontyRepl();
-  final TextEditingController _controller = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final FocusNode _focusNode = FocusNode();
-  final List<_ReplLine> _lines = [
-    const _ReplLine('Monty REPL initialized.', _LineKind.system),
-  ];
+class _MontyDemoPageState extends State<MontyDemoPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabs;
+
+  // Two independent REPL sessions.
+  final MontyRepl _replA = MontyRepl();
+  final MontyRepl _replB = MontyRepl();
+
+  // VFS session with osHandler.
+  late final Monty _vfsMonty;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: 3, vsync: this);
+    _vfsMonty = Monty(osHandler: _osHandler);
+  }
 
   @override
   void dispose() {
-    _repl.dispose();
+    _replA.dispose();
+    _replB.dispose();
+    _vfsMonty.dispose();
+    _tabs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1E1E1E),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF333333),
+        title: const Text(
+          'Monty Demo',
+          style: TextStyle(color: Color(0xFF4EC9B0), fontWeight: FontWeight.bold),
+        ),
+        bottom: TabBar(
+          controller: _tabs,
+          labelColor: const Color(0xFF4EC9B0),
+          unselectedLabelColor: Colors.grey,
+          indicatorColor: const Color(0xFF4EC9B0),
+          tabs: const [
+            Tab(text: 'Session A'),
+            Tab(text: 'Session B'),
+            Tab(text: 'VFS / OsCall'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabs,
+        children: [
+          _ReplPanel(label: 'A', repl: _replA),
+          _ReplPanel(label: 'B', repl: _replB),
+          _VfsPanel(monty: _vfsMonty),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel widget (MontyRepl — concurrent session isolation demo)
+// ---------------------------------------------------------------------------
+class _ReplPanel extends StatefulWidget {
+  const _ReplPanel({required this.label, required this.repl});
+
+  final String label;
+  final MontyRepl repl;
+
+  @override
+  State<_ReplPanel> createState() => _ReplPanelState();
+}
+
+class _ReplPanelState extends State<_ReplPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  final List<_ReplLine> _lines = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _lines.add(_ReplLine(
+      'Session ${widget.label} — Monty REPL ready.',
+      _LineKind.system,
+    ));
+    _lines.add(const _ReplLine(
+      'Tip: set x = 10 here, then evaluate x in the other session.',
+      _LineKind.system,
+    ));
+  }
+
+  @override
+  void dispose() {
     _controller.dispose();
-    _scrollController.dispose();
-    _focusNode.dispose();
+    _scroll.dispose();
+    _focus.dispose();
     super.dispose();
   }
 
   Future<void> _execute() async {
     final code = _controller.text.trim();
     if (code.isEmpty) return;
-
     _controller.clear();
-    setState(() {
-      _lines.add(_ReplLine('>>> $code', _LineKind.input));
-    });
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
 
     try {
-      final result = await _repl.feed(code);
-
+      final result = await widget.repl.feed(code);
       setState(() {
-        if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        if (result.printOutput?.isNotEmpty ?? false) {
           _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
         }
         if (result.error != null) {
@@ -73,158 +198,310 @@ class _MontyReplPageState extends State<MontyReplPage> {
         }
       });
     } on Object catch (e) {
-      setState(() {
-        _lines.add(_ReplLine('Error: $e', _LineKind.error));
-      });
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
           duration: const Duration(milliseconds: 100),
           curve: Curves.easeOut,
         );
       }
-      _focusNode.requestFocus();
+      _focus.requestFocus();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return Scaffold(
-      backgroundColor: const Color(0xFF1E1E1E),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF333333),
-        title: const Text(
-          'Monty Python REPL',
-          style: TextStyle(
-            color: Color(0xFF4EC9B0),
-            fontWeight: FontWeight.bold,
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
+            ),
           ),
         ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: Chip(
-              label: const Text(
-                'Flutter',
-                style: TextStyle(color: Colors.white, fontSize: 12),
-              ),
-              backgroundColor: const Color(0xFF007ACC),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.all(16),
-              itemCount: _lines.length,
-              itemBuilder: (context, index) {
-                final line = _lines[index];
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    line.text,
-                    style: TextStyle(
-                      color: line.kind.color,
-                      fontFamily: 'monospace',
-                      fontSize: 14,
-                      height: 1.4,
-                    ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: true,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC), fontFamily: 'monospace', fontSize: 13,
                   ),
-                );
-              },
-            ),
-          ),
-          Container(
-            color: const Color(0xFF252526),
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    style: const TextStyle(
-                      color: Color(0xFFCCCCCC),
-                      fontFamily: 'monospace',
-                      fontSize: 14,
-                    ),
-                    decoration: InputDecoration(
-                      hintText: 'Type Python code...',
-                      hintStyle: TextStyle(
-                        color: cs.onSurface.withOpacity(0.4),
-                      ),
-                      filled: true,
-                      fillColor: const Color(0xFF3C3C3C),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF007ACC)),
-                      ),
-                    ),
-                    onSubmitted: (_) => _execute(),
-                    autofocus: true,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                ElevatedButton(
-                  onPressed: _execute,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF0E639C),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                    shape: RoundedRectangleBorder(
+                  decoration: InputDecoration(
+                    hintText: 'Python code…',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF007ACC)),
                     ),
                   ),
-                  child: const Text(
-                    'Run',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
+                  onSubmitted: (_) => _execute(),
                 ),
-              ],
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel widget (Monty + osHandler + snapshot/restore)
+// ---------------------------------------------------------------------------
+class _VfsPanel extends StatefulWidget {
+  const _VfsPanel({required this.monty});
+  final Monty monty;
+
+  @override
+  State<_VfsPanel> createState() => _VfsPanelState();
+}
+
+class _VfsPanelState extends State<_VfsPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  Uint8List? _savedSnapshot;
+  final List<_ReplLine> _lines = [
+    const _ReplLine(
+      'VFS session — try: import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+      _LineKind.system,
+    ),
+    _ReplLine('Files: ${_vfs.keys.join(", ")}', _LineKind.system),
+  ];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scroll.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  Future<void> _execute() async {
+    final code = _controller.text.trim();
+    if (code.isEmpty) return;
+    _controller.clear();
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
+
+    try {
+      final result = await widget.monty.run(code);
+      setState(() {
+        if (result.printOutput?.isNotEmpty ?? false) {
+          _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
+        }
+        if (result.error != null) {
+          _lines.add(_ReplLine(result.error!.message, _LineKind.error));
+        } else if (result.value is! MontyNone) {
+          _lines.add(_ReplLine('=> ${result.value}', _LineKind.output));
+        }
+      });
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+        );
+      }
+      _focus.requestFocus();
+    });
+  }
+
+  void _snapshot() {
+    try {
+      final bytes = widget.monty.snapshot();
+      setState(() {
+        _savedSnapshot = bytes;
+        _lines.add(_ReplLine(
+          '📸 Snapshot saved (${bytes.length} bytes). Modify state then tap ↩.',
+          _LineKind.system,
+        ));
+      });
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Snapshot error: $e', _LineKind.error)));
+    }
+  }
+
+  void _restore() {
+    final saved = _savedSnapshot;
+    if (saved == null) {
+      setState(() => _lines.add(
+        const _ReplLine('No snapshot — tap 📸 first.', _LineKind.system),
+      ));
+      return;
+    }
+    try {
+      widget.monty.restore(saved);
+      setState(() => _lines.add(
+        const _ReplLine('✅ State restored from snapshot.', _LineKind.system),
+      ));
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Restore error: $e', _LineKind.error)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
             ),
           ),
-        ],
+        ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: false,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC), fontFamily: 'monospace', fontSize: 13,
+                  ),
+                  decoration: InputDecoration(
+                    hintText:
+                        'import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF4EC9B0)),
+                    ),
+                  ),
+                  onSubmitted: (_) => _execute(),
+                ),
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+              const SizedBox(width: 4),
+              _DemoButton(label: '📸', onPressed: _snapshot, small: true),
+              const SizedBox(width: 4),
+              _DemoButton(label: '↩', onPressed: _restore, small: true),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+class _DemoButton extends StatelessWidget {
+  const _DemoButton({
+    required this.label,
+    required this.onPressed,
+    this.small = false,
+  });
+  final String label;
+  final VoidCallback onPressed;
+  final bool small;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: small ? const Color(0xFF3C3C3C) : const Color(0xFF0E639C),
+        foregroundColor: Colors.white,
+        padding: small
+            ? const EdgeInsets.symmetric(horizontal: 10, vertical: 8)
+            : const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+        elevation: 0,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: small ? 12 : 13,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
   }
 }
 
-enum _LineKind {
-  input,
-  output,
-  print,
-  error,
-  system
-  ;
+enum _LineKind { input, output, print, error, system }
 
+extension on _LineKind {
   Color get color => switch (this) {
-    _LineKind.input => const Color(0xFF9CDCFE),
+    _LineKind.input  => const Color(0xFF9CDCFE),
     _LineKind.output => const Color(0xFFDCDCAA),
-    _LineKind.print => const Color(0xFFB5CEA8),
-    _LineKind.error => const Color(0xFFF44747),
+    _LineKind.print  => const Color(0xFFB5CEA8),
+    _LineKind.error  => const Color(0xFFF44747),
     _LineKind.system => const Color(0xFF6A9955),
   };
 }

--- a/packages/dart_monty_web/web/index_js.html
+++ b/packages/dart_monty_web/web/index_js.html
@@ -114,11 +114,11 @@
       </div>
     </div>
 
-    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
     <div class="panel">
       <div class="panel-header">
-        <span>VFS / OsCall</span>
-        <span class="hint">MontyRepl · osHandler · pathlib</span>
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
       </div>
       <div class="output" id="output-vfs">
         <div class="system-line">Initializing…</div>

--- a/packages/dart_monty_web/web/index_js.html
+++ b/packages/dart_monty_web/web/index_js.html
@@ -114,11 +114,11 @@
       </div>
     </div>
 
-    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
     <div class="panel">
       <div class="panel-header">
-        <span>VFS / OsCall + Snapshot</span>
-        <span class="hint">Monty · osHandler · snapshot</span>
+        <span>VFS / OsCall</span>
+        <span class="hint">MontyRepl · osHandler · pathlib</span>
       </div>
       <div class="output" id="output-vfs">
         <div class="system-line">Initializing…</div>

--- a/packages/dart_monty_web/web/index_js.html
+++ b/packages/dart_monty_web/web/index_js.html
@@ -4,97 +4,134 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2js)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #007acc; 
-      color: white; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #007acc; color: white;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    /* Three-column layout */
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #007acc; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #007acc;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2js</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Bridge must load before the Dart runner -->
   <script src="dart_monty_bridge.js"></script>

--- a/packages/dart_monty_web/web/index_wasm.html
+++ b/packages/dart_monty_web/web/index_wasm.html
@@ -113,11 +113,11 @@
       </div>
     </div>
 
-    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
     <div class="panel">
       <div class="panel-header">
-        <span>VFS / OsCall</span>
-        <span class="hint">MontyRepl · osHandler · pathlib</span>
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
       </div>
       <div class="output" id="output-vfs">
         <div class="system-line">Initializing…</div>

--- a/packages/dart_monty_web/web/index_wasm.html
+++ b/packages/dart_monty_web/web/index_wasm.html
@@ -113,11 +113,11 @@
       </div>
     </div>
 
-    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
     <div class="panel">
       <div class="panel-header">
-        <span>VFS / OsCall + Snapshot</span>
-        <span class="hint">Monty · osHandler · snapshot</span>
+        <span>VFS / OsCall</span>
+        <span class="hint">MontyRepl · osHandler · pathlib</span>
       </div>
       <div class="output" id="output-vfs">
         <div class="system-line">Initializing…</div>

--- a/packages/dart_monty_web/web/index_wasm.html
+++ b/packages/dart_monty_web/web/index_wasm.html
@@ -4,97 +4,133 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2wasm)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #4ec9b0; 
-      color: #1e1e1e; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #4ec9b0; color: #1e1e1e;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #4ec9b0; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #4ec9b0;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2wasm</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine (WASM)...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!--
     coi-serviceworker: registers a service worker that injects COOP/COEP headers
@@ -113,7 +149,7 @@
           }
         }).catch(err => console.error('Service worker registration failed:', err));
       } else {
-        const out = document.getElementById('output');
+        const out = document.getElementById('output-a');
         const div = document.createElement('div');
         div.className = 'error-line';
         div.textContent = 'Service workers not supported — try a modern browser.';
@@ -133,7 +169,7 @@
       instantiatedApp.invokeMain();
     } catch (e) {
       console.error('Failed to run dart2wasm REPL demo:', e);
-      const output = document.getElementById('output');
+      const output = document.getElementById('output-a');
       if (output) {
         const err = document.createElement('div');
         err.className = 'error-line';

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -1,31 +1,110 @@
+// Interactive demo for dart_monty_core.
+//
+// Three panels — all features work under both dart2js and dart2wasm:
+//
+//  Session A / B  — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally (WasmReplBindings static
+//    counter) so their Rust heap handles are stored separately in the WASM
+//    Worker's replHandles Map. Variables in A are invisible in B.
+//    Tip: set x = 10 in A, then evaluate x in B — B won't see it.
+//
+//  VFS / OsCall   — a Monty() session with an in-memory virtual filesystem
+//    wired to the osHandler. Python's pathlib.Path reads and writes go
+//    through the Dart handler instead of the real filesystem.
+//    Also demonstrates snapshot / restore — click 📸 to capture state
+//    and ↩ to restore it.
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:web/web.dart' as web;
 
-void main() async {
-  final output =
-      web.document.getElementById('output')! as web.HTMLDivElement;
-  final input =
-      web.document.getElementById('input')! as web.HTMLInputElement;
-  final runButton =
-      web.document.getElementById('run')! as web.HTMLButtonElement;
+// ---------------------------------------------------------------------------
+// In-memory VFS shared for the VFS panel.
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
+}
+
+web.HTMLDivElement _div(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLDivElement;
+}
+
+web.HTMLInputElement _input(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLInputElement;
+}
+
+web.HTMLButtonElement _button(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLButtonElement;
+}
+
+void main() {
+  // Two independent MontyRepl instances — demonstrates the multi-REPL fix.
+  // WasmReplBindings assigns each a unique replId so their Rust handles are
+  // stored independently in the Worker's replHandles Map.
+  _initReplPanel('a', 'A', MontyRepl());
+  _initReplPanel('b', 'B', MontyRepl());
+
+  // VFS panel: Monty session with osHandler + snapshot capability.
+  _initVfsPanel();
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel (Session A or B)
+// ---------------------------------------------------------------------------
+void _initReplPanel(String panelId, String label, MontyRepl repl) {
+  final output = _div('output-$panelId');
+  final input = _input('input-$panelId');
+  final runBtn = _button('run-$panelId');
 
   void write(String text, {String? className}) {
     final div = web.document.createElement('div') as web.HTMLDivElement
       ..textContent = text;
     if (className != null) div.className = className;
-    output..appendChild(div)..scrollTop = output.scrollHeight;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
   }
 
-  write('Monty REPL initialized.', className: 'system-line');
+  final other = label == 'A' ? 'B' : 'A';
+  write('Session $label — Monty REPL ready.', className: 'system-line');
+  write(
+    'Tip: set x = 10 here, then evaluate x in Session $other.',
+    className: 'system-line',
+  );
 
-  final repl = MontyRepl();
-
-  // Enable UI
   input.disabled = false;
-  runButton.disabled = false;
-  input.placeholder = 'Type Python code...';
+  runBtn.disabled = false;
+  input.placeholder = 'Python code…';
 
   Future<void> execute() async {
     final code = input.value.trim();
@@ -33,17 +112,13 @@ void main() async {
       input.focus();
       return;
     }
-
     input.value = '';
     write('>>> $code', className: 'input-line');
-
     try {
       final result = await repl.feed(code);
-
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!, className: 'print-line');
       }
-
       if (result.error != null) {
         write(result.error!.message, className: 'error-line');
       } else if (result.value is! MontyNone) {
@@ -55,13 +130,110 @@ void main() async {
     input.focus();
   }
 
-  runButton.onclick = (web.MouseEvent e) {
+  runBtn.onclick = (web.MouseEvent _) {
     unawaited(execute());
   }.toJS;
-
   input.onkeydown = (web.KeyboardEvent e) {
-    if (e.key == 'Enter') {
-      unawaited(execute());
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel — Monty() with osHandler + snapshot/restore
+// ---------------------------------------------------------------------------
+void _initVfsPanel() {
+  final output = _div('output-vfs');
+  final input = _input('input-vfs');
+  final runBtn = _button('run-vfs');
+  final snapBtn = _button('snap-vfs');
+  final restoreBtn = _button('restore-vfs');
+
+  Uint8List? savedSnapshot;
+
+  void write(String text, {String? className}) {
+    final div = web.document.createElement('div') as web.HTMLDivElement
+      ..textContent = text;
+    if (className != null) div.className = className;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
+  }
+
+  // Monty session with in-memory VFS wired to the osHandler.
+  final monty = Monty(osHandler: _osHandler);
+
+  write(
+    'VFS session — try: import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+    className: 'system-line',
+  );
+  write('Files: ${_vfs.keys.join(", ")}', className: 'system-line');
+
+  input.disabled = false;
+  runBtn.disabled = false;
+  input.placeholder =
+      'import pathlib; pathlib.Path("/data/hello.txt").read_text()';
+
+  Future<void> execute() async {
+    final code = input.value.trim();
+    if (code.isEmpty) {
+      input.focus();
+      return;
+    }
+    input.value = '';
+    write('>>> $code', className: 'input-line');
+    try {
+      final result = await monty.run(code);
+      if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        write(result.printOutput!, className: 'print-line');
+      }
+      if (result.error != null) {
+        write(result.error!.message, className: 'error-line');
+      } else if (result.value is! MontyNone) {
+        write('=> ${result.value}', className: 'output-line');
+      }
+    } on Object catch (e) {
+      write('Error: $e', className: 'error-line');
+    }
+    input.focus();
+  }
+
+  runBtn.onclick = (web.MouseEvent _) {
+    unawaited(execute());
+  }.toJS;
+  input.onkeydown = (web.KeyboardEvent e) {
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+
+  // Snapshot: capture current Python variables → Uint8List.
+  snapBtn.onclick = (web.MouseEvent _) {
+    try {
+      final bytes = monty.snapshot();
+      savedSnapshot = bytes;
+      write(
+        '📸 Snapshot saved (${bytes.length} bytes). '
+        'Modify state then click ↩ to restore.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Snapshot error: $e', className: 'error-line');
+    }
+  }.toJS;
+
+  // Restore: reload the most recently saved snapshot.
+  restoreBtn.onclick = (web.MouseEvent _) {
+    final saved = savedSnapshot;
+    if (saved == null) {
+      write('No snapshot yet — click 📸 first.', className: 'system-line');
+      return;
+    }
+    try {
+      monty.restore(saved);
+      write(
+        '✅ State restored from snapshot.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Restore error: $e', className: 'error-line');
     }
   }.toJS;
 }

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -8,14 +8,13 @@
 //    Worker's replHandles Map. Variables in A are invisible in B.
 //    Tip: set x = 10 in A, then evaluate x in B — B won't see it.
 //
-//  VFS / OsCall   — a Monty() session with an in-memory virtual filesystem
-//    wired to the osHandler. Python's pathlib.Path reads and writes go
-//    through the Dart handler instead of the real filesystem.
-//    Also demonstrates snapshot / restore — click 📸 to capture state
-//    and ↩ to restore it.
+//  VFS / OsCall   — a MontyRepl with an in-memory virtual filesystem
+//    wired to the osHandler per feed() call. Uses MontyRepl (not Monty)
+//    so that `import pathlib` on one call persists to the next — the Rust
+//    REPL heap stays alive across feed() calls whereas MontySession only
+//    persists JSON-serializable variables (modules are not serializable).
 import 'dart:async';
 import 'dart:js_interop';
-import 'dart:typed_data';
 
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:web/web.dart' as web;
@@ -139,7 +138,13 @@ void _initReplPanel(String panelId, String label, MontyRepl repl) {
 }
 
 // ---------------------------------------------------------------------------
-// VFS panel — Monty() with osHandler + snapshot/restore
+// VFS panel — MontyRepl with osHandler per-call
+//
+// MontySession (Monty) persists only JSON-serializable variables. Module
+// objects (from `import pathlib`) are not JSON-serializable and are silently
+// dropped by _buildPersistCode. MontyRepl keeps the full Rust heap alive
+// across feed() calls, so `import pathlib` on one line is visible on the
+// next — exactly the interactive REPL experience users expect.
 // ---------------------------------------------------------------------------
 void _initVfsPanel() {
   final output = _div('output-vfs');
@@ -147,8 +152,6 @@ void _initVfsPanel() {
   final runBtn = _button('run-vfs');
   final snapBtn = _button('snap-vfs');
   final restoreBtn = _button('restore-vfs');
-
-  Uint8List? savedSnapshot;
 
   void write(String text, {String? className}) {
     final div = web.document.createElement('div') as web.HTMLDivElement
@@ -159,19 +162,22 @@ void _initVfsPanel() {
       ..scrollTop = output.scrollHeight;
   }
 
-  // Monty session with in-memory VFS wired to the osHandler.
-  final monty = Monty(osHandler: _osHandler);
+  // MontyRepl keeps the Rust REPL alive between feed() calls.
+  // osHandler is supplied per-call so pathlib OS calls reach _vfs.
+  final repl = MontyRepl();
 
   write(
-    'VFS session — try: import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+    'VFS REPL — try: import pathlib  then: '
+    'pathlib.Path("/data/hello.txt").read_text()',
     className: 'system-line',
   );
   write('Files: ${_vfs.keys.join(", ")}', className: 'system-line');
 
   input.disabled = false;
   runBtn.disabled = false;
-  input.placeholder =
-      'import pathlib; pathlib.Path("/data/hello.txt").read_text()';
+  snapBtn.disabled = true; // snapshot not yet supported on MontyRepl
+  restoreBtn.disabled = true;
+  input.placeholder = 'import pathlib';
 
   Future<void> execute() async {
     final code = input.value.trim();
@@ -182,7 +188,7 @@ void _initVfsPanel() {
     input.value = '';
     write('>>> $code', className: 'input-line');
     try {
-      final result = await monty.run(code);
+      final result = await repl.feed(code, osHandler: _osHandler);
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!, className: 'print-line');
       }
@@ -204,36 +210,17 @@ void _initVfsPanel() {
     if (e.key == 'Enter') unawaited(execute());
   }.toJS;
 
-  // Snapshot: capture current Python variables → Uint8List.
   snapBtn.onclick = (web.MouseEvent _) {
-    try {
-      final bytes = monty.snapshot();
-      savedSnapshot = bytes;
-      write(
-        '📸 Snapshot saved (${bytes.length} bytes). '
-        'Modify state then click ↩ to restore.',
-        className: 'system-line',
-      );
-    } on Object catch (e) {
-      write('Snapshot error: $e', className: 'error-line');
-    }
+    write(
+      'Snapshot not yet available for MontyRepl.',
+      className: 'system-line',
+    );
   }.toJS;
 
-  // Restore: reload the most recently saved snapshot.
   restoreBtn.onclick = (web.MouseEvent _) {
-    final saved = savedSnapshot;
-    if (saved == null) {
-      write('No snapshot yet — click 📸 first.', className: 'system-line');
-      return;
-    }
-    try {
-      monty.restore(saved);
-      write(
-        '✅ State restored from snapshot.',
-        className: 'system-line',
-      );
-    } on Object catch (e) {
-      write('Restore error: $e', className: 'error-line');
-    }
+    write(
+      'Restore not yet available for MontyRepl.',
+      className: 'system-line',
+    );
   }.toJS;
 }

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -8,13 +8,16 @@
 //    Worker's replHandles Map. Variables in A are invisible in B.
 //    Tip: set x = 10 in A, then evaluate x in B — B won't see it.
 //
-//  VFS / OsCall   — a MontyRepl with an in-memory virtual filesystem
-//    wired to the osHandler per feed() call. Uses MontyRepl (not Monty)
-//    so that `import pathlib` on one call persists to the next — the Rust
-//    REPL heap stays alive across feed() calls whereas MontySession only
-//    persists JSON-serializable variables (modules are not serializable).
+//  VFS / OsCall   — a Monty() session with an in-memory virtual filesystem
+//    wired to the osHandler. Python's pathlib.Path reads and writes go
+//    through the Dart handler instead of the real filesystem.
+//    MontySession replays stored import statements as a preamble on each
+//    run() call so that `import pathlib` on one call persists to the next.
+//    Also demonstrates snapshot / restore — click 📸 to capture state
+//    and ↩ to restore it.
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:typed_data';
 
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:web/web.dart' as web;
@@ -138,13 +141,7 @@ void _initReplPanel(String panelId, String label, MontyRepl repl) {
 }
 
 // ---------------------------------------------------------------------------
-// VFS panel — MontyRepl with osHandler per-call
-//
-// MontySession (Monty) persists only JSON-serializable variables. Module
-// objects (from `import pathlib`) are not JSON-serializable and are silently
-// dropped by _buildPersistCode. MontyRepl keeps the full Rust heap alive
-// across feed() calls, so `import pathlib` on one line is visible on the
-// next — exactly the interactive REPL experience users expect.
+// VFS panel — Monty() with osHandler + snapshot/restore
 // ---------------------------------------------------------------------------
 void _initVfsPanel() {
   final output = _div('output-vfs');
@@ -152,6 +149,8 @@ void _initVfsPanel() {
   final runBtn = _button('run-vfs');
   final snapBtn = _button('snap-vfs');
   final restoreBtn = _button('restore-vfs');
+
+  Uint8List? savedSnapshot;
 
   void write(String text, {String? className}) {
     final div = web.document.createElement('div') as web.HTMLDivElement
@@ -162,12 +161,13 @@ void _initVfsPanel() {
       ..scrollTop = output.scrollHeight;
   }
 
-  // MontyRepl keeps the Rust REPL alive between feed() calls.
-  // osHandler is supplied per-call so pathlib OS calls reach _vfs.
-  final repl = MontyRepl();
+  // Monty session with in-memory VFS wired to the osHandler.
+  // MontySession replays top-level import statements as a preamble on each
+  // run() call, so `import pathlib` on one call persists to the next.
+  final monty = Monty(osHandler: _osHandler);
 
   write(
-    'VFS REPL — try: import pathlib  then: '
+    'VFS session — try: import pathlib  then: '
     'pathlib.Path("/data/hello.txt").read_text()',
     className: 'system-line',
   );
@@ -175,8 +175,6 @@ void _initVfsPanel() {
 
   input.disabled = false;
   runBtn.disabled = false;
-  snapBtn.disabled = true; // snapshot not yet supported on MontyRepl
-  restoreBtn.disabled = true;
   input.placeholder = 'import pathlib';
 
   Future<void> execute() async {
@@ -188,7 +186,7 @@ void _initVfsPanel() {
     input.value = '';
     write('>>> $code', className: 'input-line');
     try {
-      final result = await repl.feed(code, osHandler: _osHandler);
+      final result = await monty.run(code);
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!, className: 'print-line');
       }
@@ -210,17 +208,36 @@ void _initVfsPanel() {
     if (e.key == 'Enter') unawaited(execute());
   }.toJS;
 
+  // Snapshot: capture current Python variables → Uint8List.
   snapBtn.onclick = (web.MouseEvent _) {
-    write(
-      'Snapshot not yet available for MontyRepl.',
-      className: 'system-line',
-    );
+    try {
+      final bytes = monty.snapshot();
+      savedSnapshot = bytes;
+      write(
+        '📸 Snapshot saved (${bytes.length} bytes). '
+        'Modify state then click ↩ to restore.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Snapshot error: $e', className: 'error-line');
+    }
   }.toJS;
 
+  // Restore: reload the most recently saved snapshot.
   restoreBtn.onclick = (web.MouseEvent _) {
-    write(
-      'Restore not yet available for MontyRepl.',
-      className: 'system-line',
-    );
+    final saved = savedSnapshot;
+    if (saved == null) {
+      write('No snapshot yet — click 📸 first.', className: 'system-line');
+      return;
+    }
+    try {
+      monty.restore(saved);
+      write(
+        '✅ State restored from snapshot.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Restore error: $e', className: 'error-line');
+    }
   }.toJS;
 }

--- a/test/integration/ffi_repl_oscall_test.dart
+++ b/test/integration/ffi_repl_oscall_test.dart
@@ -1,0 +1,197 @@
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// In-memory VFS shared across tests
+// ---------------------------------------------------------------------------
+
+Map<String, String> _makeVfs() => {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=test',
+};
+
+OsCallHandler _vfsHandler(Map<String, String> vfs) => (op, args, kwargs) async {
+  switch (op) {
+    case 'Path.read_text':
+      return vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported');
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ffi_repl_oscall', () {
+    // Regression: two separate feed() calls — import on first, read_text on
+    // second. This was broken before the REPL_PROGRESS vtable fix because
+    // readProgress() called monty_os_call_fn_name() (session API) on a
+    // MontyReplHandle*, returning null → operationName '' → default case.
+    test('pathlib.read_text works across two feed() calls', () async {
+      final vfs = _makeVfs();
+      final handler = _vfsHandler(vfs);
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      final importResult = await repl.feed(
+        'import pathlib',
+        osHandler: handler,
+      );
+      expect(
+        importResult.error,
+        isNull,
+        reason: 'import pathlib should not error',
+      );
+
+      final readResult = await repl.feed(
+        "pathlib.Path('/data/hello.txt').read_text()",
+        osHandler: handler,
+      );
+      expect(readResult.error, isNull);
+      expect(
+        readResult.value,
+        const MontyString('Hello from the virtual filesystem!'),
+      );
+    });
+
+    test('one-line import + read_text works (control case)', () async {
+      final vfs = _makeVfs();
+      final handler = _vfsHandler(vfs);
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      final result = await repl.feed(
+        "import pathlib; pathlib.Path('/data/hello.txt').read_text()",
+        osHandler: handler,
+      );
+      expect(result.error, isNull);
+      expect(
+        result.value,
+        const MontyString('Hello from the virtual filesystem!'),
+      );
+    });
+
+    test(
+      'pathlib module persists across feed() calls without osHandler on import',
+      () async {
+        final vfs = _makeVfs();
+        final handler = _vfsHandler(vfs);
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        // Import without osHandler (fast path)
+        await repl.feed('import pathlib');
+
+        // Use pathlib with osHandler
+        final result = await repl.feed(
+          "pathlib.Path('/data/hello.txt').read_text()",
+          osHandler: handler,
+        );
+        expect(result.error, isNull);
+        expect(
+          result.value,
+          const MontyString('Hello from the virtual filesystem!'),
+        );
+      },
+    );
+
+    test('VFS write then read across separate feed() calls', () async {
+      final vfs = _makeVfs();
+      final handler = _vfsHandler(vfs);
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import pathlib', osHandler: handler);
+
+      await repl.feed(
+        "pathlib.Path('/data/new.txt').write_text('written!')",
+        osHandler: handler,
+      );
+      expect(vfs['/data/new.txt'], 'written!');
+
+      final result = await repl.feed(
+        "pathlib.Path('/data/new.txt').read_text()",
+        osHandler: handler,
+      );
+      expect(result.value, const MontyString('written!'));
+    });
+
+    test('missing file returns empty string', () async {
+      final vfs = _makeVfs();
+      final handler = _vfsHandler(vfs);
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import pathlib', osHandler: handler);
+
+      final result = await repl.feed(
+        "pathlib.Path('/data/missing.txt').read_text()",
+        osHandler: handler,
+      );
+      expect(result.error, isNull);
+      expect(result.value, const MontyString(''));
+    });
+
+    test('Path.exists returns correct bool', () async {
+      final vfs = _makeVfs();
+      final handler = _vfsHandler(vfs);
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import pathlib', osHandler: handler);
+
+      final exists = await repl.feed(
+        "pathlib.Path('/data/hello.txt').exists()",
+        osHandler: handler,
+      );
+      expect(exists.value, const MontyBool(true));
+
+      final missing = await repl.feed(
+        "pathlib.Path('/data/nope.txt').exists()",
+        osHandler: handler,
+      );
+      expect(missing.value, const MontyBool(false));
+    });
+
+    test(
+      'OsCallException becomes Python RuntimeError, REPL survives',
+      () async {
+        // Handler that throws OsCallException for every op — ensures the
+        // exception-to-RuntimeError translation is exercised even for ops like
+        // read_text that we know are real OS calls.
+        Future<Object?> alwaysThrows(
+          String op,
+          List<Object?> args,
+          Map<String, Object?>? kwargs,
+        ) async => throw OsCallException('handler rejected: $op');
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        await repl.feed('import pathlib', osHandler: alwaysThrows);
+
+        // read_text is a real OS call → alwaysThrows → Python RuntimeError
+        final result = await repl.feed(
+          "try:\n  pathlib.Path('/x').read_text()\nexcept RuntimeError as e:\n  str(e)",
+          osHandler: alwaysThrows,
+        );
+        expect(result.error, isNull); // Python caught it — no Dart exception
+        // REPL survives; subsequent calls still work
+        final ok = await repl.feed('1 + 1');
+        expect(ok.value, const MontyInt(2));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **Web demo** (`index_js.html`, `index_wasm.html`, `repl_demo.dart`): Replaces the single-REPL panel with three panels: **Session A** (`MontyRepl`), **Session B** (`MontyRepl` with independent state), and **VFS / OsCall + Snapshot** (`Monty(osHandler:)` with 📸/↩ buttons).
- **Flutter demo** (`packages/dart_monty_flutter/lib/main.dart`): Same three-feature layout as a `TabBarView` — Sessions A+B for REPL isolation, VFS tab for `osHandler` + snapshot/restore.
- **Bug fix**: Previous `main.dart` incorrectly called `MontyRepl.snapshot()` / `restore()` — those methods exist only on `Monty`. Fixed by moving snapshot support exclusively to the VFS panel.
- **Lint fix**: Five `cast_nullable_to_non_nullable` infos in `_osHandler` (`args.first as String` etc.) resolved by asserting non-null before cast (`args.first! as String`).

## What each panel demonstrates

| Panel | Type | Features shown |
|---|---|---|
| Session A | `MontyRepl` | Stateful REPL; variables survive across `feed()` calls |
| Session B | `MontyRepl` | Independent Rust handle; A's variables are invisible in B |
| VFS / OsCall | `Monty(osHandler:)` | `pathlib.Path` routed to in-memory Dart map; 📸 snapshot / ↩ restore |

## Depends on

runyaga/dart_monty_core#17 (WASM multi-REPL fix + snapshot API)

## Test plan

- [x] `dart analyze --fatal-infos lib/ packages/` — no issues
- [x] `dart format` — no changes
- [ ] Manual smoke: open `index_js.html` and `index_wasm.html` in browser; verify three panels load, A/B state isolation works, VFS `read_text` returns correct content, snapshot round-trip restores Python variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)