### PR TITLE
fix(wasm): typed vtables in readProgress prevent MontyHandle/MontyReplHandle mixup

### DIFF
--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -88,18 +88,71 @@ function excTypeFromMsg(msg) {
 }
 
 // ---------------------------------------------------------------------------
+// Progress API vtables — typed accessors per handle kind
+// ---------------------------------------------------------------------------
+// MontyHandle* (session) and MontyReplHandle* (REPL) are distinct Rust types
+// with parallel but separate C exports. Passing the wrong handle type to a C
+// function is undefined behaviour — the struct layout differs. These vtables
+// make readProgress() handle-type-aware: non-REPL handlers pass
+// SESSION_PROGRESS, REPL handlers pass REPL_PROGRESS. Adding a new progress
+// tag requires only one change inside readProgress().
+//
+// The closures capture the module-level `wasm` variable by reference so they
+// always use the post-init value; they are safe to define before initWasm().
+
+const SESSION_PROGRESS = {
+  completeIsError:      (h) => wasm.monty_complete_is_error(h),
+  completeResultJson:   (h) => wasm.monty_complete_result_json(h),
+  pendingFnName:        (h) => wasm.monty_pending_fn_name(h),
+  pendingFnArgsJson:    (h) => wasm.monty_pending_fn_args_json(h),
+  pendingFnKwargsJson:  (h) => wasm.monty_pending_fn_kwargs_json(h),
+  pendingCallId:        (h) => wasm.monty_pending_call_id(h),
+  pendingMethodCall:    (h) => wasm.monty_pending_method_call(h),
+  pendingFutureCallIds: (h) => wasm.monty_pending_future_call_ids(h),
+  osCallFnName:         (h) => wasm.monty_os_call_fn_name(h),
+  osCallArgsJson:       (h) => wasm.monty_os_call_args_json(h),
+  osCallKwargsJson:     (h) => wasm.monty_os_call_kwargs_json(h),
+  osCallId:             (h) => wasm.monty_os_call_id(h),
+  nameLookupName:       (h) => wasm.monty_name_lookup_name(h),
+};
+
+const REPL_PROGRESS = {
+  completeIsError:      (h) => wasm.monty_repl_complete_is_error(h),
+  completeResultJson:   (h) => wasm.monty_repl_complete_result_json(h),
+  pendingFnName:        (h) => wasm.monty_repl_pending_fn_name(h),
+  pendingFnArgsJson:    (h) => wasm.monty_repl_pending_fn_args_json(h),
+  pendingFnKwargsJson:  (h) => wasm.monty_repl_pending_fn_kwargs_json(h),
+  pendingCallId:        (h) => wasm.monty_repl_pending_call_id(h),
+  pendingMethodCall:    (h) => wasm.monty_repl_pending_method_call(h),
+  pendingFutureCallIds: (h) => wasm.monty_repl_pending_future_call_ids(h),
+  osCallFnName:         (h) => wasm.monty_repl_os_call_fn_name(h),
+  osCallArgsJson:       (h) => wasm.monty_repl_os_call_args_json(h),
+  osCallKwargsJson:     (h) => wasm.monty_repl_os_call_kwargs_json(h),
+  osCallId:             (h) => wasm.monty_repl_os_call_id(h),
+  // REPL auto-resolves NameLookup internally (process_repl_progress loop);
+  // PROGRESS_NAME_LOOKUP never surfaces to JS for REPL handles.
+  nameLookupName:       null,
+};
+
+// ---------------------------------------------------------------------------
 // Progress reading (shared by start, resume, resumeAsFuture, resumeFutures)
 // ---------------------------------------------------------------------------
 
 /**
  * Read progress state from a handle after a C-ABI progress call.
+ *
+ * @param {number}  id      - Dart request ID to echo back.
+ * @param {number}  handle  - C handle pointer (MontyHandle* or MontyReplHandle*).
+ * @param {number}  tag     - PROGRESS_* constant returned by the C call.
+ * @param {string}  errMsg  - Error string from the out-error pointer, if any.
+ * @param {object}  api     - SESSION_PROGRESS or REPL_PROGRESS vtable.
  * @returns {Object} message payload to send back to main thread.
  */
-function readProgress(id, handle, tag, errMsg) {
+function readProgress(id, handle, tag, errMsg, api) {
   switch (tag) {
     case PROGRESS_COMPLETE: {
-      const isErr = wasm.monty_complete_is_error(handle);
-      const ptr = wasm.monty_complete_result_json(handle);
+      const isErr = api.completeIsError(handle);
+      const ptr = api.completeResultJson(handle);
       const json = readAndFreeCString(ptr);
       if (json) {
         const adapted = adaptResultForDart(json, isErr === 1);
@@ -116,17 +169,14 @@ function readProgress(id, handle, tag, errMsg) {
     }
 
     case PROGRESS_PENDING: {
-      const fnName = readAndFreeCString(wasm.monty_pending_fn_name(handle));
-      const argsJson = readAndFreeCString(wasm.monty_pending_fn_args_json(handle));
-      const kwargsJson = readAndFreeCString(wasm.monty_pending_fn_kwargs_json(handle));
-      const callId = wasm.monty_pending_call_id(handle);
-      const methodCall = wasm.monty_pending_method_call(handle);
+      const fnName = readAndFreeCString(api.pendingFnName(handle));
+      const argsJson = readAndFreeCString(api.pendingFnArgsJson(handle));
+      const kwargsJson = readAndFreeCString(api.pendingFnKwargsJson(handle));
+      const callId = api.pendingCallId(handle);
+      const methodCall = api.pendingMethodCall(handle);
 
       return {
-        type: 'result',
-        id,
-        ok: true,
-        state: 'pending',
+        type: 'result', id, ok: true, state: 'pending',
         functionName: fnName,
         args: argsJson ? JSON.parse(argsJson) : [],
         kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
@@ -136,27 +186,21 @@ function readProgress(id, handle, tag, errMsg) {
     }
 
     case PROGRESS_RESOLVE_FUTURES: {
-      const idsPtr = wasm.monty_pending_future_call_ids(handle);
+      const idsPtr = api.pendingFutureCallIds(handle);
       const idsJson = readAndFreeCString(idsPtr);
       return {
-        type: 'result',
-        id,
-        ok: true,
-        state: 'resolve_futures',
+        type: 'result', id, ok: true, state: 'resolve_futures',
         pendingCallIds: idsJson ? JSON.parse(idsJson) : [],
       };
     }
 
     case PROGRESS_OS_CALL: {
-      const fnName = readAndFreeCString(wasm.monty_os_call_fn_name(handle));
-      const argsJson = readAndFreeCString(wasm.monty_os_call_args_json(handle));
-      const kwargsJson = readAndFreeCString(wasm.monty_os_call_kwargs_json(handle));
-      const callId = wasm.monty_os_call_id(handle);
+      const fnName = readAndFreeCString(api.osCallFnName(handle));
+      const argsJson = readAndFreeCString(api.osCallArgsJson(handle));
+      const kwargsJson = readAndFreeCString(api.osCallKwargsJson(handle));
+      const callId = api.osCallId(handle);
       return {
-        type: 'result',
-        id,
-        ok: true,
-        state: 'os_call',
+        type: 'result', id, ok: true, state: 'os_call',
         functionName: fnName,
         args: argsJson ? JSON.parse(argsJson) : [],
         kwargs: kwargsJson ? JSON.parse(kwargsJson) : {},
@@ -165,13 +209,18 @@ function readProgress(id, handle, tag, errMsg) {
     }
 
     case PROGRESS_NAME_LOOKUP: {
-      const namePtr = wasm.monty_name_lookup_name(handle);
+      if (!api.nameLookupName) {
+        // REPL auto-resolves NameLookup internally — this tag should never reach JS.
+        return {
+          type: 'result', id, ok: false,
+          error: 'Unexpected PROGRESS_NAME_LOOKUP for REPL handle',
+          errorType: 'InternalError',
+        };
+      }
+      const namePtr = api.nameLookupName(handle);
       const variableName = readAndFreeCString(namePtr);
       return {
-        type: 'result',
-        id,
-        ok: true,
-        state: 'name_lookup',
+        type: 'result', id, ok: true, state: 'name_lookup',
         variableName,
       };
     }
@@ -180,8 +229,8 @@ function readProgress(id, handle, tag, errMsg) {
       // Python runtime exceptions: handle_exception() sets state to Complete
       // (is_error=true) before returning PROGRESS_ERROR. Read the full result
       // JSON so exc_type, traceback, etc. are available to Dart.
-      const isErrState = wasm.monty_complete_is_error(handle);
-      const errPtr2 = wasm.monty_complete_result_json(handle);
+      const isErrState = api.completeIsError(handle);
+      const errPtr2 = api.completeResultJson(handle);
       const errJson = readAndFreeCString(errPtr2);
       if (errJson && isErrState === 1) {
         const adapted = adaptResultForDart(errJson, true);
@@ -189,9 +238,7 @@ function readProgress(id, handle, tag, errMsg) {
       }
       // Fallback for internal Rust errors (no complete JSON available).
       return {
-        type: 'result',
-        id,
-        ok: false,
+        type: 'result', id, ok: false,
         error: errMsg || 'Unknown error',
         errorType: 'MontyException',
         excType: excTypeFromMsg(errMsg),
@@ -200,9 +247,7 @@ function readProgress(id, handle, tag, errMsg) {
 
     default:
       return {
-        type: 'result',
-        id,
-        ok: false,
+        type: 'result', id, ok: false,
         error: `Unknown progress tag: ${tag}`,
         errorType: 'InternalError',
       };
@@ -379,7 +424,7 @@ function handleStart(id, code, extFns, limits, scriptName) {
 
   let msg;
   try {
-    msg = readProgress(id, handle, tag, errMsg);
+    msg = readProgress(id, handle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     activeHandle = null;
     wasm.monty_free(handle);
@@ -430,7 +475,7 @@ function handleResume(id, value) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -481,7 +526,7 @@ function handleResumeWithError(id, errorMessage) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -536,7 +581,7 @@ function handleResumeWithException(id, excType, errorMessage) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -581,7 +626,7 @@ function handleResumeAsFuture(id) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -636,7 +681,7 @@ function handleResolveFutures(id, resultsJson, errorsJson) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -1016,7 +1061,7 @@ function handleStartPrecompiled(id, dataBase64, limits, scriptName) {
 
   let msg;
   try {
-    msg = readProgress(id, handle, tag, errMsg);
+    msg = readProgress(id, handle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     activeHandle = null;
     wasm.monty_free(handle);
@@ -1067,7 +1112,7 @@ function handleResumeNameLookupValue(id, valueJson) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -1112,7 +1157,7 @@ function handleResumeNameLookupUndefined(id) {
 
   let msg;
   try {
-    msg = readProgress(id, activeHandle, tag, errMsg);
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
   } catch (e) {
     wasm.monty_free(activeHandle);
     activeHandle = null;
@@ -1232,7 +1277,7 @@ function handleReplFeedStart(id, replId, code) {
     const tag = wasm.monty_repl_feed_start(handle, cCode.ptr, outError.ptr);
     const errPtr = outError.read();
     const errMsg = readAndFreeCString(errPtr);
-    self.postMessage(readProgress(id, handle, tag, errMsg));
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
   } finally {
     if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
     if (outError) outError.free();
@@ -1271,7 +1316,7 @@ function handleReplResume(id, replId, value) {
     const tag = wasm.monty_repl_resume(handle, cVal.ptr, outError.ptr);
     const errPtr = outError.read();
     const errMsg = readAndFreeCString(errPtr);
-    self.postMessage(readProgress(id, handle, tag, errMsg));
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
   } finally {
     if (cVal) wasm.monty_dealloc(cVal.ptr, cVal.size);
     if (outError) outError.free();
@@ -1293,7 +1338,7 @@ function handleReplResumeWithError(id, replId, errorMessage) {
     const tag = wasm.monty_repl_resume_with_error(handle, cErr.ptr, outError.ptr);
     const errPtr = outError.read();
     const errMsg = readAndFreeCString(errPtr);
-    self.postMessage(readProgress(id, handle, tag, errMsg));
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
   } finally {
     if (cErr) wasm.monty_dealloc(cErr.ptr, cErr.size);
     if (outError) outError.free();

--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -1,17 +1,63 @@
+// Flutter demo for dart_monty_core.
+//
+// Three tabs demonstrate the core features:
+//
+//  Session A / Session B — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally so their Rust heap handles
+//    are stored separately in the WASM Worker's replHandles Map. Variables
+//    in A are invisible in B and vice versa.
+//    Tip: set x = 10 in Session A, then evaluate x in Session B — B won't see it.
+//
+//  VFS / OsCall — a Monty() session with an in-memory filesystem wired
+//    to the osHandler. Python's pathlib.Path reads and writes go through
+//    the Dart handler instead of the real filesystem.
+//    Also demonstrates snapshot / restore (📸 / ↩).
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(const MontyReplApp());
+// ---------------------------------------------------------------------------
+// In-memory VFS
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
 }
 
-class MontyReplApp extends StatelessWidget {
-  const MontyReplApp({super.key});
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+void main() => runApp(const MontyDemoApp());
+
+class MontyDemoApp extends StatelessWidget {
+  const MontyDemoApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Monty REPL',
+      title: 'Monty Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: const Color(0xFF4EC9B0),
@@ -20,50 +66,129 @@ class MontyReplApp extends StatelessWidget {
         useMaterial3: true,
         fontFamily: 'monospace',
       ),
-      home: const MontyReplPage(),
+      home: const MontyDemoPage(),
     );
   }
 }
 
-class MontyReplPage extends StatefulWidget {
-  const MontyReplPage({super.key});
+class MontyDemoPage extends StatefulWidget {
+  const MontyDemoPage({super.key});
 
   @override
-  State<MontyReplPage> createState() => _MontyReplPageState();
+  State<MontyDemoPage> createState() => _MontyDemoPageState();
 }
 
-class _MontyReplPageState extends State<MontyReplPage> {
-  final MontyRepl _repl = MontyRepl();
-  final TextEditingController _controller = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final FocusNode _focusNode = FocusNode();
-  final List<_ReplLine> _lines = [
-    const _ReplLine('Monty REPL initialized.', _LineKind.system),
-  ];
+class _MontyDemoPageState extends State<MontyDemoPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabs;
+
+  // Two independent REPL sessions.
+  final MontyRepl _replA = MontyRepl();
+  final MontyRepl _replB = MontyRepl();
+
+  // VFS session with osHandler.
+  late final Monty _vfsMonty;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: 3, vsync: this);
+    _vfsMonty = Monty(osHandler: _osHandler);
+  }
 
   @override
   void dispose() {
-    _repl.dispose();
+    _replA.dispose();
+    _replB.dispose();
+    _vfsMonty.dispose();
+    _tabs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1E1E1E),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF333333),
+        title: const Text(
+          'Monty Demo',
+          style: TextStyle(color: Color(0xFF4EC9B0), fontWeight: FontWeight.bold),
+        ),
+        bottom: TabBar(
+          controller: _tabs,
+          labelColor: const Color(0xFF4EC9B0),
+          unselectedLabelColor: Colors.grey,
+          indicatorColor: const Color(0xFF4EC9B0),
+          tabs: const [
+            Tab(text: 'Session A'),
+            Tab(text: 'Session B'),
+            Tab(text: 'VFS / OsCall'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabs,
+        children: [
+          _ReplPanel(label: 'A', repl: _replA),
+          _ReplPanel(label: 'B', repl: _replB),
+          _VfsPanel(monty: _vfsMonty),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel widget (MontyRepl — concurrent session isolation demo)
+// ---------------------------------------------------------------------------
+class _ReplPanel extends StatefulWidget {
+  const _ReplPanel({required this.label, required this.repl});
+
+  final String label;
+  final MontyRepl repl;
+
+  @override
+  State<_ReplPanel> createState() => _ReplPanelState();
+}
+
+class _ReplPanelState extends State<_ReplPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  final List<_ReplLine> _lines = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _lines.add(_ReplLine(
+      'Session ${widget.label} — Monty REPL ready.',
+      _LineKind.system,
+    ));
+    _lines.add(const _ReplLine(
+      'Tip: set x = 10 here, then evaluate x in the other session.',
+      _LineKind.system,
+    ));
+  }
+
+  @override
+  void dispose() {
     _controller.dispose();
-    _scrollController.dispose();
-    _focusNode.dispose();
+    _scroll.dispose();
+    _focus.dispose();
     super.dispose();
   }
 
   Future<void> _execute() async {
     final code = _controller.text.trim();
     if (code.isEmpty) return;
-
     _controller.clear();
-    setState(() {
-      _lines.add(_ReplLine('>>> $code', _LineKind.input));
-    });
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
 
     try {
-      final result = await _repl.feed(code);
-
+      final result = await widget.repl.feed(code);
       setState(() {
-        if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        if (result.printOutput?.isNotEmpty ?? false) {
           _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
         }
         if (result.error != null) {
@@ -73,158 +198,310 @@ class _MontyReplPageState extends State<MontyReplPage> {
         }
       });
     } on Object catch (e) {
-      setState(() {
-        _lines.add(_ReplLine('Error: $e', _LineKind.error));
-      });
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
           duration: const Duration(milliseconds: 100),
           curve: Curves.easeOut,
         );
       }
-      _focusNode.requestFocus();
+      _focus.requestFocus();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return Scaffold(
-      backgroundColor: const Color(0xFF1E1E1E),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF333333),
-        title: const Text(
-          'Monty Python REPL',
-          style: TextStyle(
-            color: Color(0xFF4EC9B0),
-            fontWeight: FontWeight.bold,
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
+            ),
           ),
         ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: Chip(
-              label: const Text(
-                'Flutter',
-                style: TextStyle(color: Colors.white, fontSize: 12),
-              ),
-              backgroundColor: const Color(0xFF007ACC),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.all(16),
-              itemCount: _lines.length,
-              itemBuilder: (context, index) {
-                final line = _lines[index];
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    line.text,
-                    style: TextStyle(
-                      color: line.kind.color,
-                      fontFamily: 'monospace',
-                      fontSize: 14,
-                      height: 1.4,
-                    ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: true,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC), fontFamily: 'monospace', fontSize: 13,
                   ),
-                );
-              },
-            ),
-          ),
-          Container(
-            color: const Color(0xFF252526),
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    style: const TextStyle(
-                      color: Color(0xFFCCCCCC),
-                      fontFamily: 'monospace',
-                      fontSize: 14,
-                    ),
-                    decoration: InputDecoration(
-                      hintText: 'Type Python code...',
-                      hintStyle: TextStyle(
-                        color: cs.onSurface.withOpacity(0.4),
-                      ),
-                      filled: true,
-                      fillColor: const Color(0xFF3C3C3C),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF007ACC)),
-                      ),
-                    ),
-                    onSubmitted: (_) => _execute(),
-                    autofocus: true,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                ElevatedButton(
-                  onPressed: _execute,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF0E639C),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                    shape: RoundedRectangleBorder(
+                  decoration: InputDecoration(
+                    hintText: 'Python code…',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF007ACC)),
                     ),
                   ),
-                  child: const Text(
-                    'Run',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
+                  onSubmitted: (_) => _execute(),
                 ),
-              ],
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel widget (Monty + osHandler + snapshot/restore)
+// ---------------------------------------------------------------------------
+class _VfsPanel extends StatefulWidget {
+  const _VfsPanel({required this.monty});
+  final Monty monty;
+
+  @override
+  State<_VfsPanel> createState() => _VfsPanelState();
+}
+
+class _VfsPanelState extends State<_VfsPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  Uint8List? _savedSnapshot;
+  final List<_ReplLine> _lines = [
+    const _ReplLine(
+      'VFS session — try: import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+      _LineKind.system,
+    ),
+    _ReplLine('Files: ${_vfs.keys.join(", ")}', _LineKind.system),
+  ];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scroll.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  Future<void> _execute() async {
+    final code = _controller.text.trim();
+    if (code.isEmpty) return;
+    _controller.clear();
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
+
+    try {
+      final result = await widget.monty.run(code);
+      setState(() {
+        if (result.printOutput?.isNotEmpty ?? false) {
+          _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
+        }
+        if (result.error != null) {
+          _lines.add(_ReplLine(result.error!.message, _LineKind.error));
+        } else if (result.value is! MontyNone) {
+          _lines.add(_ReplLine('=> ${result.value}', _LineKind.output));
+        }
+      });
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+        );
+      }
+      _focus.requestFocus();
+    });
+  }
+
+  void _snapshot() {
+    try {
+      final bytes = widget.monty.snapshot();
+      setState(() {
+        _savedSnapshot = bytes;
+        _lines.add(_ReplLine(
+          '📸 Snapshot saved (${bytes.length} bytes). Modify state then tap ↩.',
+          _LineKind.system,
+        ));
+      });
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Snapshot error: $e', _LineKind.error)));
+    }
+  }
+
+  void _restore() {
+    final saved = _savedSnapshot;
+    if (saved == null) {
+      setState(() => _lines.add(
+        const _ReplLine('No snapshot — tap 📸 first.', _LineKind.system),
+      ));
+      return;
+    }
+    try {
+      widget.monty.restore(saved);
+      setState(() => _lines.add(
+        const _ReplLine('✅ State restored from snapshot.', _LineKind.system),
+      ));
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Restore error: $e', _LineKind.error)));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
             ),
           ),
-        ],
+        ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: false,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC), fontFamily: 'monospace', fontSize: 13,
+                  ),
+                  decoration: InputDecoration(
+                    hintText:
+                        'import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding:
+                        const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF4EC9B0)),
+                    ),
+                  ),
+                  onSubmitted: (_) => _execute(),
+                ),
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+              const SizedBox(width: 4),
+              _DemoButton(label: '📸', onPressed: _snapshot, small: true),
+              const SizedBox(width: 4),
+              _DemoButton(label: '↩', onPressed: _restore, small: true),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+class _DemoButton extends StatelessWidget {
+  const _DemoButton({
+    required this.label,
+    required this.onPressed,
+    this.small = false,
+  });
+  final String label;
+  final VoidCallback onPressed;
+  final bool small;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: small ? const Color(0xFF3C3C3C) : const Color(0xFF0E639C),
+        foregroundColor: Colors.white,
+        padding: small
+            ? const EdgeInsets.symmetric(horizontal: 10, vertical: 8)
+            : const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+        elevation: 0,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: small ? 12 : 13,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
   }
 }
 
-enum _LineKind {
-  input,
-  output,
-  print,
-  error,
-  system
-  ;
+enum _LineKind { input, output, print, error, system }
 
+extension on _LineKind {
   Color get color => switch (this) {
-    _LineKind.input => const Color(0xFF9CDCFE),
+    _LineKind.input  => const Color(0xFF9CDCFE),
     _LineKind.output => const Color(0xFFDCDCAA),
-    _LineKind.print => const Color(0xFFB5CEA8),
-    _LineKind.error => const Color(0xFFF44747),
+    _LineKind.print  => const Color(0xFFB5CEA8),
+    _LineKind.error  => const Color(0xFFF44747),
     _LineKind.system => const Color(0xFF6A9955),
   };
 }

--- a/packages/dart_monty_web/web/index_js.html
+++ b/packages/dart_monty_web/web/index_js.html
@@ -4,97 +4,134 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2js)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #007acc; 
-      color: white; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #007acc; color: white;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    /* Three-column layout */
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #007acc; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #007acc;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2js</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Bridge must load before the Dart runner -->
   <script src="dart_monty_bridge.js"></script>

--- a/packages/dart_monty_web/web/index_wasm.html
+++ b/packages/dart_monty_web/web/index_wasm.html
@@ -4,97 +4,133 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2wasm)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #4ec9b0; 
-      color: #1e1e1e; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #4ec9b0; color: #1e1e1e;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #4ec9b0; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #4ec9b0;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2wasm</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine (WASM)...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — Monty() with osHandler + snapshot/restore -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall + Snapshot</span>
+        <span class="hint">Monty · osHandler · snapshot</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!--
     coi-serviceworker: registers a service worker that injects COOP/COEP headers
@@ -113,7 +149,7 @@
           }
         }).catch(err => console.error('Service worker registration failed:', err));
       } else {
-        const out = document.getElementById('output');
+        const out = document.getElementById('output-a');
         const div = document.createElement('div');
         div.className = 'error-line';
         div.textContent = 'Service workers not supported — try a modern browser.';
@@ -133,7 +169,7 @@
       instantiatedApp.invokeMain();
     } catch (e) {
       console.error('Failed to run dart2wasm REPL demo:', e);
-      const output = document.getElementById('output');
+      const output = document.getElementById('output-a');
       if (output) {
         const err = document.createElement('div');
         err.className = 'error-line';

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -1,31 +1,110 @@
+// Interactive demo for dart_monty_core.
+//
+// Three panels — all features work under both dart2js and dart2wasm:
+//
+//  Session A / B  — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally (WasmReplBindings static
+//    counter) so their Rust heap handles are stored separately in the WASM
+//    Worker's replHandles Map. Variables in A are invisible in B.
+//    Tip: set x = 10 in A, then evaluate x in B — B won't see it.
+//
+//  VFS / OsCall   — a Monty() session with an in-memory virtual filesystem
+//    wired to the osHandler. Python's pathlib.Path reads and writes go
+//    through the Dart handler instead of the real filesystem.
+//    Also demonstrates snapshot / restore — click 📸 to capture state
+//    and ↩ to restore it.
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:web/web.dart' as web;
 
-void main() async {
-  final output =
-      web.document.getElementById('output')! as web.HTMLDivElement;
-  final input =
-      web.document.getElementById('input')! as web.HTMLInputElement;
-  final runButton =
-      web.document.getElementById('run')! as web.HTMLButtonElement;
+// ---------------------------------------------------------------------------
+// In-memory VFS shared for the VFS panel.
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
+}
+
+web.HTMLDivElement _div(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLDivElement;
+}
+
+web.HTMLInputElement _input(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLInputElement;
+}
+
+web.HTMLButtonElement _button(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLButtonElement;
+}
+
+void main() {
+  // Two independent MontyRepl instances — demonstrates the multi-REPL fix.
+  // WasmReplBindings assigns each a unique replId so their Rust handles are
+  // stored independently in the Worker's replHandles Map.
+  _initReplPanel('a', 'A', MontyRepl());
+  _initReplPanel('b', 'B', MontyRepl());
+
+  // VFS panel: Monty session with osHandler + snapshot capability.
+  _initVfsPanel();
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel (Session A or B)
+// ---------------------------------------------------------------------------
+void _initReplPanel(String panelId, String label, MontyRepl repl) {
+  final output = _div('output-$panelId');
+  final input = _input('input-$panelId');
+  final runBtn = _button('run-$panelId');
 
   void write(String text, {String? className}) {
     final div = web.document.createElement('div') as web.HTMLDivElement
       ..textContent = text;
     if (className != null) div.className = className;
-    output..appendChild(div)..scrollTop = output.scrollHeight;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
   }
 
-  write('Monty REPL initialized.', className: 'system-line');
+  final other = label == 'A' ? 'B' : 'A';
+  write('Session $label — Monty REPL ready.', className: 'system-line');
+  write(
+    'Tip: set x = 10 here, then evaluate x in Session $other.',
+    className: 'system-line',
+  );
 
-  final repl = MontyRepl();
-
-  // Enable UI
   input.disabled = false;
-  runButton.disabled = false;
-  input.placeholder = 'Type Python code...';
+  runBtn.disabled = false;
+  input.placeholder = 'Python code…';
 
   Future<void> execute() async {
     final code = input.value.trim();
@@ -33,17 +112,13 @@ void main() async {
       input.focus();
       return;
     }
-
     input.value = '';
     write('>>> $code', className: 'input-line');
-
     try {
       final result = await repl.feed(code);
-
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!, className: 'print-line');
       }
-
       if (result.error != null) {
         write(result.error!.message, className: 'error-line');
       } else if (result.value is! MontyNone) {
@@ -55,13 +130,110 @@ void main() async {
     input.focus();
   }
 
-  runButton.onclick = (web.MouseEvent e) {
+  runBtn.onclick = (web.MouseEvent _) {
     unawaited(execute());
   }.toJS;
-
   input.onkeydown = (web.KeyboardEvent e) {
-    if (e.key == 'Enter') {
-      unawaited(execute());
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel — Monty() with osHandler + snapshot/restore
+// ---------------------------------------------------------------------------
+void _initVfsPanel() {
+  final output = _div('output-vfs');
+  final input = _input('input-vfs');
+  final runBtn = _button('run-vfs');
+  final snapBtn = _button('snap-vfs');
+  final restoreBtn = _button('restore-vfs');
+
+  Uint8List? savedSnapshot;
+
+  void write(String text, {String? className}) {
+    final div = web.document.createElement('div') as web.HTMLDivElement
+      ..textContent = text;
+    if (className != null) div.className = className;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
+  }
+
+  // Monty session with in-memory VFS wired to the osHandler.
+  final monty = Monty(osHandler: _osHandler);
+
+  write(
+    'VFS session — try: import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+    className: 'system-line',
+  );
+  write('Files: ${_vfs.keys.join(", ")}', className: 'system-line');
+
+  input.disabled = false;
+  runBtn.disabled = false;
+  input.placeholder =
+      'import pathlib; pathlib.Path("/data/hello.txt").read_text()';
+
+  Future<void> execute() async {
+    final code = input.value.trim();
+    if (code.isEmpty) {
+      input.focus();
+      return;
+    }
+    input.value = '';
+    write('>>> $code', className: 'input-line');
+    try {
+      final result = await monty.run(code);
+      if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        write(result.printOutput!, className: 'print-line');
+      }
+      if (result.error != null) {
+        write(result.error!.message, className: 'error-line');
+      } else if (result.value is! MontyNone) {
+        write('=> ${result.value}', className: 'output-line');
+      }
+    } on Object catch (e) {
+      write('Error: $e', className: 'error-line');
+    }
+    input.focus();
+  }
+
+  runBtn.onclick = (web.MouseEvent _) {
+    unawaited(execute());
+  }.toJS;
+  input.onkeydown = (web.KeyboardEvent e) {
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+
+  // Snapshot: capture current Python variables → Uint8List.
+  snapBtn.onclick = (web.MouseEvent _) {
+    try {
+      final bytes = monty.snapshot();
+      savedSnapshot = bytes;
+      write(
+        '📸 Snapshot saved (${bytes.length} bytes). '
+        'Modify state then click ↩ to restore.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Snapshot error: $e', className: 'error-line');
+    }
+  }.toJS;
+
+  // Restore: reload the most recently saved snapshot.
+  restoreBtn.onclick = (web.MouseEvent _) {
+    final saved = savedSnapshot;
+    if (saved == null) {
+      write('No snapshot yet — click 📸 first.', className: 'system-line');
+      return;
+    }
+    try {
+      monty.restore(saved);
+      write(
+        '✅ State restored from snapshot.',
+        className: 'system-line',
+      );
+    } on Object catch (e) {
+      write('Restore error: $e', className: 'error-line');
     }
   }.toJS;
 }


### PR DESCRIPTION
## Summary

- `readProgress()` was calling `monty_os_call_fn_name()` (session C API) on `MontyReplHandle*` pointers, which returns null — the two Rust types have **separate C exports** and mixing them is UB
- Root symptom: `pathlib.Path(...).read_text()` always hit the `default` case in `_osHandler` because `operationName` was always `''`
- Fix: add `SESSION_PROGRESS` / `REPL_PROGRESS` vtables and thread an `api` parameter through `readProgress()` so every call site names the correct C function set explicitly

## What changed

`SESSION_PROGRESS` wraps `monty_*` (for `MontyHandle*`); `REPL_PROGRESS` wraps `monty_repl_*` (for `MontyReplHandle*`). All 9 non-REPL call sites pass `SESSION_PROGRESS`. The 3 REPL call sites (`handleReplFeedStart`, `handleReplResume`, `handleReplResumeWithError`) now pass `REPL_PROGRESS`. Adding a new progress tag requires one change inside `readProgress()` only — the vtables make wrong-type usage a visible mistake at the call site.

## Test plan

- [ ] Open demo at `localhost:8098/index_js.html`
- [ ] VFS panel: `import pathlib` → `pathlib.Path("/data/hello.txt").read_text()` → returns `Hello from the virtual filesystem!`
- [ ] Session A/B isolation still works (set `x=10` in A, verify `x` is undefined in B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)