### PR TITLE
feat(demos): three-panel Flutter + web demo — concurrent REPLs and VFS/OsCall

### DIFF
--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -1,17 +1,62 @@
+// Flutter demo for dart_monty_core.
+//
+// Three tabs demonstrate the core features:
+//
+//  Session A / Session B — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally so their Rust heap handles
+//    are stored separately in the WASM Worker's replHandles Map. Variables
+//    in A are invisible in B and vice versa.
+//    Tip: set x = 10 in Session A, then evaluate x in Session B — B won't see it.
+//
+//  VFS / OsCall — a Monty() session (REPL-backed) with an in-memory
+//    filesystem wired to the osHandler. `import pathlib` on one call
+//    persists to the next — the Rust REPL heap stays alive between run()
+//    calls.
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:flutter/material.dart';
 
-void main() {
-  runApp(const MontyReplApp());
+// ---------------------------------------------------------------------------
+// In-memory VFS
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
 }
 
-class MontyReplApp extends StatelessWidget {
-  const MontyReplApp({super.key});
+// ---------------------------------------------------------------------------
+// App
+// ---------------------------------------------------------------------------
+void main() => runApp(const MontyDemoApp());
+
+class MontyDemoApp extends StatelessWidget {
+  const MontyDemoApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Monty REPL',
+      title: 'Monty Demo',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(
           seedColor: const Color(0xFF4EC9B0),
@@ -20,50 +65,136 @@ class MontyReplApp extends StatelessWidget {
         useMaterial3: true,
         fontFamily: 'monospace',
       ),
-      home: const MontyReplPage(),
+      home: const MontyDemoPage(),
     );
   }
 }
 
-class MontyReplPage extends StatefulWidget {
-  const MontyReplPage({super.key});
+class MontyDemoPage extends StatefulWidget {
+  const MontyDemoPage({super.key});
 
   @override
-  State<MontyReplPage> createState() => _MontyReplPageState();
+  State<MontyDemoPage> createState() => _MontyDemoPageState();
 }
 
-class _MontyReplPageState extends State<MontyReplPage> {
-  final MontyRepl _repl = MontyRepl();
-  final TextEditingController _controller = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final FocusNode _focusNode = FocusNode();
-  final List<_ReplLine> _lines = [
-    const _ReplLine('Monty REPL initialized.', _LineKind.system),
-  ];
+class _MontyDemoPageState extends State<MontyDemoPage>
+    with SingleTickerProviderStateMixin {
+  late final TabController _tabs;
+
+  // Two independent REPL sessions.
+  final MontyRepl _replA = MontyRepl();
+  final MontyRepl _replB = MontyRepl();
+
+  // VFS session with osHandler.
+  late final Monty _vfsMonty;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabs = TabController(length: 3, vsync: this);
+    _vfsMonty = Monty(osHandler: _osHandler);
+  }
 
   @override
   void dispose() {
-    _repl.dispose();
+    _replA.dispose();
+    _replB.dispose();
+    _vfsMonty.dispose();
+    _tabs.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFF1E1E1E),
+      appBar: AppBar(
+        backgroundColor: const Color(0xFF333333),
+        title: const Text(
+          'Monty Demo',
+          style: TextStyle(
+            color: Color(0xFF4EC9B0),
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        bottom: TabBar(
+          controller: _tabs,
+          labelColor: const Color(0xFF4EC9B0),
+          unselectedLabelColor: Colors.grey,
+          indicatorColor: const Color(0xFF4EC9B0),
+          tabs: const [
+            Tab(text: 'Session A'),
+            Tab(text: 'Session B'),
+            Tab(text: 'VFS / OsCall'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabs,
+        children: [
+          _ReplPanel(label: 'A', repl: _replA),
+          _ReplPanel(label: 'B', repl: _replB),
+          _VfsPanel(monty: _vfsMonty),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel widget (MontyRepl — concurrent session isolation demo)
+// ---------------------------------------------------------------------------
+class _ReplPanel extends StatefulWidget {
+  const _ReplPanel({required this.label, required this.repl});
+
+  final String label;
+  final MontyRepl repl;
+
+  @override
+  State<_ReplPanel> createState() => _ReplPanelState();
+}
+
+class _ReplPanelState extends State<_ReplPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  final List<_ReplLine> _lines = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _lines.add(
+      _ReplLine(
+        'Session ${widget.label} — Monty REPL ready.',
+        _LineKind.system,
+      ),
+    );
+    _lines.add(
+      const _ReplLine(
+        'Tip: set x = 10 here, then evaluate x in the other session.',
+        _LineKind.system,
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
     _controller.dispose();
-    _scrollController.dispose();
-    _focusNode.dispose();
+    _scroll.dispose();
+    _focus.dispose();
     super.dispose();
   }
 
   Future<void> _execute() async {
     final code = _controller.text.trim();
     if (code.isEmpty) return;
-
     _controller.clear();
-    setState(() {
-      _lines.add(_ReplLine('>>> $code', _LineKind.input));
-    });
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
 
     try {
-      final result = await _repl.feed(code);
-
+      final result = await widget.repl.feed(code);
       setState(() {
-        if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        if (result.printOutput?.isNotEmpty ?? false) {
           _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
         }
         if (result.error != null) {
@@ -73,153 +204,277 @@ class _MontyReplPageState extends State<MontyReplPage> {
         }
       });
     } on Object catch (e) {
-      setState(() {
-        _lines.add(_ReplLine('Error: $e', _LineKind.error));
-      });
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
     }
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
           duration: const Duration(milliseconds: 100),
           curve: Curves.easeOut,
         );
       }
-      _focusNode.requestFocus();
+      _focus.requestFocus();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
-
-    return Scaffold(
-      backgroundColor: const Color(0xFF1E1E1E),
-      appBar: AppBar(
-        backgroundColor: const Color(0xFF333333),
-        title: const Text(
-          'Monty Python REPL',
-          style: TextStyle(
-            color: Color(0xFF4EC9B0),
-            fontWeight: FontWeight.bold,
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
+            ),
           ),
         ),
-        actions: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-            child: Chip(
-              label: const Text(
-                'Flutter',
-                style: TextStyle(color: Colors.white, fontSize: 12),
-              ),
-              backgroundColor: const Color(0xFF007ACC),
-            ),
-          ),
-        ],
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.all(16),
-              itemCount: _lines.length,
-              itemBuilder: (context, index) {
-                final line = _lines[index];
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 4),
-                  child: Text(
-                    line.text,
-                    style: TextStyle(
-                      color: line.kind.color,
-                      fontFamily: 'monospace',
-                      fontSize: 14,
-                      height: 1.4,
-                    ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: true,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC),
+                    fontFamily: 'monospace',
+                    fontSize: 13,
                   ),
-                );
-              },
-            ),
-          ),
-          Container(
-            color: const Color(0xFF252526),
-            padding: const EdgeInsets.all(12),
-            child: Row(
-              children: [
-                Expanded(
-                  child: TextField(
-                    controller: _controller,
-                    focusNode: _focusNode,
-                    style: const TextStyle(
-                      color: Color(0xFFCCCCCC),
-                      fontFamily: 'monospace',
-                      fontSize: 14,
+                  decoration: InputDecoration(
+                    hintText: 'Python code…',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 8,
                     ),
-                    decoration: InputDecoration(
-                      hintText: 'Type Python code...',
-                      hintStyle: TextStyle(
-                        color: cs.onSurface.withOpacity(0.4),
-                      ),
-                      filled: true,
-                      fillColor: const Color(0xFF3C3C3C),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 12,
-                        vertical: 8,
-                      ),
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      enabledBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF555555)),
-                      ),
-                      focusedBorder: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(4),
-                        borderSide: const BorderSide(color: Color(0xFF007ACC)),
-                      ),
-                    ),
-                    onSubmitted: (_) => _execute(),
-                    autofocus: true,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                ElevatedButton(
-                  onPressed: _execute,
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: const Color(0xFF0E639C),
-                    foregroundColor: Colors.white,
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 20,
-                      vertical: 12,
-                    ),
-                    shape: RoundedRectangleBorder(
+                    border: OutlineInputBorder(
                       borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF007ACC)),
                     ),
                   ),
-                  child: const Text(
-                    'Run',
-                    style: TextStyle(fontWeight: FontWeight.bold),
-                  ),
+                  onSubmitted: (_) => _execute(),
                 ),
-              ],
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel widget (Monty + osHandler)
+// ---------------------------------------------------------------------------
+class _VfsPanel extends StatefulWidget {
+  const _VfsPanel({required this.monty});
+  final Monty monty;
+
+  @override
+  State<_VfsPanel> createState() => _VfsPanelState();
+}
+
+class _VfsPanelState extends State<_VfsPanel> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  final _focus = FocusNode();
+  final List<_ReplLine> _lines = [
+    const _ReplLine(
+      'VFS session — try: import pathlib  then: pathlib.Path("/data/hello.txt").read_text()',
+      _LineKind.system,
+    ),
+    _ReplLine('Files: ${_vfs.keys.join(", ")}', _LineKind.system),
+  ];
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    _scroll.dispose();
+    _focus.dispose();
+    super.dispose();
+  }
+
+  Future<void> _execute() async {
+    final code = _controller.text.trim();
+    if (code.isEmpty) return;
+    _controller.clear();
+    setState(() => _lines.add(_ReplLine('>>> $code', _LineKind.input)));
+
+    try {
+      final result = await widget.monty.run(code);
+      setState(() {
+        if (result.printOutput?.isNotEmpty ?? false) {
+          _lines.add(_ReplLine(result.printOutput!, _LineKind.print));
+        }
+        if (result.error != null) {
+          _lines.add(_ReplLine(result.error!.message, _LineKind.error));
+        } else if (result.value is! MontyNone) {
+          _lines.add(_ReplLine('=> ${result.value}', _LineKind.output));
+        }
+      });
+    } on Object catch (e) {
+      setState(() => _lines.add(_ReplLine('Error: $e', _LineKind.error)));
+    }
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scroll.hasClients) {
+        _scroll.animateTo(
+          _scroll.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 100),
+          curve: Curves.easeOut,
+        );
+      }
+      _focus.requestFocus();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Expanded(
+          child: ListView.builder(
+            controller: _scroll,
+            padding: const EdgeInsets.all(12),
+            itemCount: _lines.length,
+            itemBuilder: (_, i) => Padding(
+              padding: const EdgeInsets.only(bottom: 3),
+              child: Text(
+                _lines[i].text,
+                style: TextStyle(
+                  color: _lines[i].kind.color,
+                  fontFamily: 'monospace',
+                  fontSize: 13,
+                  height: 1.5,
+                ),
+              ),
             ),
           ),
-        ],
+        ),
+        Container(
+          color: const Color(0xFF252526),
+          padding: const EdgeInsets.all(8),
+          child: Row(
+            children: [
+              Expanded(
+                child: TextField(
+                  controller: _controller,
+                  focusNode: _focus,
+                  autofocus: false,
+                  style: const TextStyle(
+                    color: Color(0xFFCCCCCC),
+                    fontFamily: 'monospace',
+                    fontSize: 13,
+                  ),
+                  decoration: InputDecoration(
+                    hintText:
+                        'import pathlib; pathlib.Path("/data/hello.txt").read_text()',
+                    hintStyle: const TextStyle(color: Color(0xFF666666)),
+                    filled: true,
+                    fillColor: const Color(0xFF3C3C3C),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 8,
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    enabledBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF555555)),
+                    ),
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(4),
+                      borderSide: const BorderSide(color: Color(0xFF4EC9B0)),
+                    ),
+                  ),
+                  onSubmitted: (_) => _execute(),
+                ),
+              ),
+              const SizedBox(width: 6),
+              _DemoButton(label: 'Run', onPressed: _execute),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+class _DemoButton extends StatelessWidget {
+  const _DemoButton({
+    required this.label,
+    required this.onPressed,
+    this.small = false,
+  });
+  final String label;
+  final VoidCallback onPressed;
+  final bool small;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: small
+            ? const Color(0xFF3C3C3C)
+            : const Color(0xFF0E639C),
+        foregroundColor: Colors.white,
+        padding: small
+            ? const EdgeInsets.symmetric(horizontal: 10, vertical: 8)
+            : const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+        minimumSize: Size.zero,
+        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(4)),
+        elevation: 0,
+      ),
+      child: Text(
+        label,
+        style: TextStyle(
+          fontSize: small ? 12 : 13,
+          fontWeight: FontWeight.bold,
+        ),
       ),
     );
   }
 }
 
-enum _LineKind {
-  input,
-  output,
-  print,
-  error,
-  system
-  ;
+enum _LineKind { input, output, print, error, system }
 
+extension on _LineKind {
   Color get color => switch (this) {
     _LineKind.input => const Color(0xFF9CDCFE),
     _LineKind.output => const Color(0xFFDCDCAA),

--- a/packages/dart_monty_web/README.md
+++ b/packages/dart_monty_web/README.md
@@ -40,11 +40,34 @@ if (result.error != null) {
 }
 ```
 
-> **Note on `Monty.compile()` / `runPrecompiled()`:** These APIs are not
-> supported on WASM — snapshot support requires a future update to the
-> WASM JS bridge. Calling them throws `UnsupportedError` on the web
-> backend. Use `repl.feed(code, inputs: {...})` for repeated execution
-> instead.
+### Concurrent REPLs
+
+Multiple `MontyRepl` instances can coexist concurrently on the WASM backend.
+Each instance generates a unique `replId` that is threaded through the JS
+bridge into the Web Worker, so independent Rust heap handles are maintained
+in a `Map` rather than a single scalar:
+
+```dart
+final repl1 = MontyRepl();
+final repl2 = MontyRepl();
+
+await repl1.feed('x = 1');
+await repl2.feed('x = 2');
+
+print((await repl1.feed('x')).value); // MontyInt(1)
+print((await repl2.feed('x')).value); // MontyInt(2)
+```
+
+### Compile and run precompiled
+
+`Monty.compile()` and `Monty.runPrecompiled()` are fully supported on the WASM
+backend. Use them to avoid re-parsing the same script on repeated executions:
+
+```dart
+final binary = await Monty.compile('output = [x * 2 for x in data]');
+final monty = Monty();
+final result = await monty.runPrecompiled(binary);
+```
 
 See [`web/repl_demo.dart`](web/repl_demo.dart) for the full wiring including DOM
 manipulation, button event handlers, and the dispose pattern.

--- a/packages/dart_monty_web/web/index_js.html
+++ b/packages/dart_monty_web/web/index_js.html
@@ -4,97 +4,134 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2js)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #007acc; 
-      color: white; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #007acc; color: white;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    /* Three-column layout */
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #007acc; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #007acc;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2js</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall</span>
+        <span class="hint">MontyRepl · osHandler · pathlib</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Bridge must load before the Dart runner -->
   <script src="dart_monty_bridge.js"></script>

--- a/packages/dart_monty_web/web/index_wasm.html
+++ b/packages/dart_monty_web/web/index_wasm.html
@@ -4,97 +4,133 @@
   <meta charset="UTF-8">
   <title>Monty Interactive REPL (dart2wasm)</title>
   <style>
-    body { 
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; 
-      margin: 0; 
-      padding: 0; 
-      background: #1e1e1e; 
-      color: #d4d4d4;
-      display: flex;
-      flex-direction: column;
-      height: 100vh;
+    *, *::before, *::after { box-sizing: border-box; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      margin: 0; padding: 0;
+      background: #1e1e1e; color: #d4d4d4;
+      display: flex; flex-direction: column; height: 100vh;
     }
     header {
-      background: #333;
-      padding: 10px 20px;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      border-bottom: 1px solid #444;
+      background: #333; padding: 10px 20px;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
     }
-    h1 { margin: 0; font-size: 1.2rem; color: #4ec9b0; }
-    .badge { 
-      background: #4ec9b0; 
-      color: #1e1e1e; 
-      padding: 2px 8px; 
-      border-radius: 4px; 
-      font-size: 0.8rem;
-      font-weight: bold;
+    h1 { margin: 0; font-size: 1.1rem; color: #4ec9b0; }
+    .badge {
+      background: #4ec9b0; color: #1e1e1e;
+      padding: 2px 8px; border-radius: 4px;
+      font-size: 0.75rem; font-weight: bold;
     }
-    #output {
-      flex: 1;
-      padding: 20px;
-      overflow-y: auto;
+
+    .panels {
+      display: flex; flex: 1; overflow: hidden; gap: 1px;
+      background: #444;
+    }
+    .panel {
+      display: flex; flex-direction: column; flex: 1;
+      background: #1e1e1e; overflow: hidden;
+    }
+    .panel-header {
+      background: #2d2d2d; padding: 6px 12px;
+      font-size: 0.75rem; font-weight: bold;
+      display: flex; justify-content: space-between; align-items: center;
+      border-bottom: 1px solid #444; flex-shrink: 0;
+    }
+    .panel-header span { color: #4ec9b0; }
+    .panel-header .hint { color: #888; font-weight: normal; font-size: 0.7rem; }
+
+    .output {
+      flex: 1; padding: 12px; overflow-y: auto;
       font-family: 'Consolas', 'Courier New', monospace;
-      white-space: pre-wrap;
-      font-size: 14px;
-      line-height: 1.4;
+      white-space: pre-wrap; font-size: 13px; line-height: 1.5;
     }
-    .line { margin-bottom: 4px; }
-    .input-line { color: #9cdcfe; }
+    .input-row {
+      background: #252526; padding: 8px; border-top: 1px solid #333;
+      display: flex; gap: 6px; flex-shrink: 0;
+    }
+    .input-row input {
+      flex: 1; background: #3c3c3c; border: 1px solid #555; color: #ccc;
+      padding: 6px 10px; border-radius: 4px;
+      font-family: 'Consolas', 'Courier New', monospace; font-size: 13px;
+    }
+    .input-row input:focus { outline: none; border-color: #4ec9b0; }
+    .btn {
+      background: #0e639c; color: white; border: none;
+      padding: 6px 14px; border-radius: 4px; cursor: pointer;
+      font-size: 12px; font-weight: bold; white-space: nowrap;
+    }
+    .btn:hover { background: #1177bb; }
+    .btn:disabled { background: #444; cursor: not-allowed; }
+    .btn-sm {
+      background: #3c3c3c; color: #ccc; border: 1px solid #555;
+      padding: 4px 8px; border-radius: 4px; cursor: pointer;
+      font-size: 11px;
+    }
+    .btn-sm:hover { background: #4a4a4a; }
+
+.input-line  { color: #9cdcfe; }
     .output-line { color: #dcdcaa; }
-    .error-line { color: #f44747; }
-    .print-line { color: #b5cea8; }
+    .error-line  { color: #f44747; }
+    .print-line  { color: #b5cea8; }
     .system-line { color: #6a9955; font-style: italic; }
-    
-    footer {
-      background: #252526;
-      padding: 10px 20px;
-      display: flex;
-      gap: 10px;
-      border-top: 1px solid #333;
-    }
-    input {
-      flex: 1;
-      background: #3c3c3c;
-      border: 1px solid #555;
-      color: #ccc;
-      padding: 8px 12px;
-      border-radius: 4px;
-      font-family: 'Consolas', 'Courier New', monospace;
-      font-size: 14px;
-    }
-    input:focus {
-      outline: none;
-      border-color: #4ec9b0;
-    }
-    button {
-      background: #0e639c;
-      color: white;
-      border: none;
-      padding: 8px 20px;
-      border-radius: 4px;
-      cursor: pointer;
-      font-weight: bold;
-    }
-    button:hover { background: #1177bb; }
-    button:disabled { background: #444; cursor: not-allowed; }
   </style>
 </head>
 <body>
   <header>
-    <h1>Monty Python REPL</h1>
+    <h1>Monty Python REPL — concurrent sessions · snapshot · VFS</h1>
     <span class="badge">dart2wasm</span>
   </header>
-  
-  <div id="output">
-    <div class="system-line">Initializing Monty engine (WASM)...</div>
-  </div>
 
-  <footer>
-    <input type="text" id="input" placeholder="Enter Python code here (e.g. 1 + 1)" autofocus disabled>
-    <button id="run" disabled>Run</button>
-  </footer>
+  <div class="panels">
+    <!-- Session A — MontyRepl, independent Rust heap handle -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session A</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-a">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-a" disabled placeholder="Python code…">
+        <button id="run-a" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- Session B — MontyRepl, separate replId from A -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>Session B</span>
+        <span class="hint">MontyRepl · independent state</span>
+      </div>
+      <div class="output" id="output-b">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-b" disabled placeholder="Python code…">
+        <button id="run-b" class="btn" disabled>Run</button>
+      </div>
+    </div>
+
+    <!-- VFS panel — MontyRepl with osHandler per feed() call -->
+    <div class="panel">
+      <div class="panel-header">
+        <span>VFS / OsCall</span>
+        <span class="hint">MontyRepl · osHandler · pathlib</span>
+      </div>
+      <div class="output" id="output-vfs">
+        <div class="system-line">Initializing…</div>
+      </div>
+      <div class="input-row">
+        <input id="input-vfs" disabled
+          placeholder="import pathlib; pathlib.Path('/data/hello.txt').read_text()">
+        <button id="run-vfs" class="btn" disabled>Run</button>
+        <button id="snap-vfs" class="btn-sm">📸</button>
+        <button id="restore-vfs" class="btn-sm">↩</button>
+      </div>
+    </div>
+  </div>
 
   <!--
     coi-serviceworker: registers a service worker that injects COOP/COEP headers
@@ -113,7 +149,7 @@
           }
         }).catch(err => console.error('Service worker registration failed:', err));
       } else {
-        const out = document.getElementById('output');
+        const out = document.getElementById('output-a');
         const div = document.createElement('div');
         div.className = 'error-line';
         div.textContent = 'Service workers not supported — try a modern browser.';
@@ -133,7 +169,7 @@
       instantiatedApp.invokeMain();
     } catch (e) {
       console.error('Failed to run dart2wasm REPL demo:', e);
-      const output = document.getElementById('output');
+      const output = document.getElementById('output-a');
       if (output) {
         const err = document.createElement('div');
         err.className = 'error-line';

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -1,31 +1,110 @@
+// Interactive demo for dart_monty_core.
+//
+// Three panels — all features work under both dart2js and dart2wasm:
+//
+//  Session A / B  — two independent MontyRepl instances.
+//    Each is assigned a unique replId internally (WasmReplBindings static
+//    counter) so their Rust heap handles are stored separately in the WASM
+//    Worker's replHandles Map. Variables in A are invisible in B.
+//    Tip: set x = 10 in A, then evaluate x in B — B won't see it.
+//
+//  VFS / OsCall + Snapshot — a Monty() session with an in-memory virtual
+//    filesystem wired to the osHandler. Monty is backed by MontyRepl
+//    internally, so `import pathlib` on one call persists to the next.
+//    Also demonstrates snapshot / restore — click 📸 to capture state
+//    and ↩ to restore it.
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:web/web.dart' as web;
 
-void main() async {
-  final output =
-      web.document.getElementById('output')! as web.HTMLDivElement;
-  final input =
-      web.document.getElementById('input')! as web.HTMLInputElement;
-  final runButton =
-      web.document.getElementById('run')! as web.HTMLButtonElement;
+// ---------------------------------------------------------------------------
+// In-memory VFS shared for the VFS panel.
+// ---------------------------------------------------------------------------
+final Map<String, String> _vfs = {
+  '/data/hello.txt': 'Hello from the virtual filesystem!',
+  '/data/config.txt': 'version=1.0\nenv=demo',
+};
+
+Future<Object?> _osHandler(
+  String op,
+  List<Object?> args,
+  Map<String, Object?>? kwargs,
+) async {
+  switch (op) {
+    case 'Path.read_text':
+      return _vfs[args.first! as String] ?? '';
+    case 'Path.write_text':
+      _vfs[args[0]! as String] = args[1]! as String;
+      return null;
+    case 'Path.exists':
+      return _vfs.containsKey(args.first! as String);
+    case 'Path.unlink':
+      _vfs.remove(args.first! as String);
+      return null;
+    default:
+      throw OsCallException('$op not supported in this demo');
+  }
+}
+
+web.HTMLDivElement _div(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLDivElement;
+}
+
+web.HTMLInputElement _input(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLInputElement;
+}
+
+web.HTMLButtonElement _button(String id) {
+  final el = web.document.getElementById(id);
+  if (el == null) throw StateError('#$id not found');
+  return el as web.HTMLButtonElement;
+}
+
+void main() {
+  // Two independent MontyRepl instances — demonstrates the multi-REPL fix.
+  // WasmReplBindings assigns each a unique replId so their Rust handles are
+  // stored independently in the Worker's replHandles Map.
+  _initReplPanel('a', 'A', MontyRepl());
+  _initReplPanel('b', 'B', MontyRepl());
+
+  // VFS panel: Monty session (REPL-backed) with osHandler + snapshot.
+  _initVfsPanel();
+}
+
+// ---------------------------------------------------------------------------
+// REPL panel (Session A or B)
+// ---------------------------------------------------------------------------
+void _initReplPanel(String panelId, String label, MontyRepl repl) {
+  final output = _div('output-$panelId');
+  final input = _input('input-$panelId');
+  final runBtn = _button('run-$panelId');
 
   void write(String text, {String? className}) {
     final div = web.document.createElement('div') as web.HTMLDivElement
       ..textContent = text;
     if (className != null) div.className = className;
-    output..appendChild(div)..scrollTop = output.scrollHeight;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
   }
 
-  write('Monty REPL initialized.', className: 'system-line');
+  final other = label == 'A' ? 'B' : 'A';
+  write('Session $label — Monty REPL ready.', className: 'system-line');
+  write(
+    'Tip: set x = 10 here, then evaluate x in Session $other.',
+    className: 'system-line',
+  );
 
-  final repl = MontyRepl();
-
-  // Enable UI
   input.disabled = false;
-  runButton.disabled = false;
-  input.placeholder = 'Type Python code...';
+  runBtn.disabled = false;
+  input.placeholder = 'Python code…';
 
   Future<void> execute() async {
     final code = input.value.trim();
@@ -33,17 +112,13 @@ void main() async {
       input.focus();
       return;
     }
-
     input.value = '';
     write('>>> $code', className: 'input-line');
-
     try {
       final result = await repl.feed(code);
-
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!, className: 'print-line');
       }
-
       if (result.error != null) {
         write(result.error!.message, className: 'error-line');
       } else if (result.value is! MontyNone) {
@@ -55,13 +130,115 @@ void main() async {
     input.focus();
   }
 
-  runButton.onclick = (web.MouseEvent e) {
+  runBtn.onclick = (web.MouseEvent _) {
     unawaited(execute());
   }.toJS;
-
   input.onkeydown = (web.KeyboardEvent e) {
-    if (e.key == 'Enter') {
-      unawaited(execute());
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+}
+
+// ---------------------------------------------------------------------------
+// VFS panel — Monty() with osHandler + snapshot/restore
+//
+// Monty is now backed by MontyRepl internally, so `import pathlib` on one
+// call persists to the next — the Rust REPL heap stays alive between run()
+// calls. snapshot() runs Python introspection to capture JSON-serialisable
+// globals; restore() re-injects them into a fresh REPL on the next run().
+// ---------------------------------------------------------------------------
+void _initVfsPanel() {
+  final output = _div('output-vfs');
+  final input = _input('input-vfs');
+  final runBtn = _button('run-vfs');
+  final snapBtn = _button('snap-vfs');
+  final restoreBtn = _button('restore-vfs');
+
+  List<int>? savedSnapshot;
+
+  void write(String text, {String? className}) {
+    final div = web.document.createElement('div') as web.HTMLDivElement
+      ..textContent = text;
+    if (className != null) div.className = className;
+    output
+      ..appendChild(div)
+      ..scrollTop = output.scrollHeight;
+  }
+
+  final monty = Monty(osHandler: _osHandler);
+
+  write(
+    'VFS session — try: import pathlib  then: '
+    'pathlib.Path("/data/hello.txt").read_text()',
+    className: 'system-line',
+  );
+  write('Files: ${_vfs.keys.join(", ")}', className: 'system-line');
+
+  input.disabled = false;
+  runBtn.disabled = false;
+  input.placeholder = 'import pathlib';
+
+  Future<void> execute() async {
+    final code = input.value.trim();
+    if (code.isEmpty) {
+      input.focus();
+      return;
+    }
+    input.value = '';
+    write('>>> $code', className: 'input-line');
+    try {
+      final result = await monty.run(code);
+      if (result.printOutput != null && result.printOutput!.isNotEmpty) {
+        write(result.printOutput!, className: 'print-line');
+      }
+      if (result.error != null) {
+        write(result.error!.message, className: 'error-line');
+      } else if (result.value is! MontyNone) {
+        write('=> ${result.value}', className: 'output-line');
+      }
+    } on Object catch (e) {
+      write('Error: $e', className: 'error-line');
+    }
+    input.focus();
+  }
+
+  runBtn.onclick = (web.MouseEvent _) {
+    unawaited(execute());
+  }.toJS;
+  input.onkeydown = (web.KeyboardEvent e) {
+    if (e.key == 'Enter') unawaited(execute());
+  }.toJS;
+
+  // Snapshot: capture JSON-serialisable Python globals → bytes.
+  snapBtn.onclick = (web.MouseEvent _) {
+    unawaited(() async {
+      try {
+        final bytes = await monty.snapshot();
+        savedSnapshot = bytes.toList();
+        write(
+          '📸 Snapshot saved (${bytes.length} bytes). '
+          'Modify state then click ↩ to restore.',
+          className: 'system-line',
+        );
+      } on Object catch (e) {
+        write('Snapshot error: $e', className: 'error-line');
+      }
+    }());
+  }.toJS;
+
+  // Restore: reload the most recently saved snapshot.
+  restoreBtn.onclick = (web.MouseEvent _) {
+    final saved = savedSnapshot;
+    if (saved == null) {
+      write('No snapshot yet — click 📸 first.', className: 'system-line');
+      return;
+    }
+    try {
+      monty.restore(
+        Uint8List.fromList(saved),
+      );
+      write('✅ State restored from snapshot.', className: 'system-line');
+    } on Object catch (e) {
+      write('Restore error: $e', className: 'error-line');
     }
   }.toJS;
 }


### PR DESCRIPTION
## Summary

- **Flutter demo** rewritten from single-panel to three-tab layout: Session A, Session B, and VFS/OsCall. Each REPL tab holds an independent `MontyRepl` instance with isolated Rust heap state. The VFS tab uses `Monty` with an in-memory `osHandler` filesystem.
- **Web REPL demo** (`repl_demo.dart`, `index_js.html`, `index_wasm.html`) updated to match — concurrent REPL and compile/runPrecompiled sections added to the README.

## Depends on

runyaga/dart_monty_core#22 — `MontySession` backed by `MontyRepl`, multi-REPL WASM support.

## Test plan

- [ ] `bash tool/run_flutter_demo.sh --device macos` — three tabs render, Session A/B state is isolated, VFS reads/writes work
- [ ] `bash tool/serve_demo.sh --skip-build` — web REPL loads, concurrent REPLs work

🤖 Generated with [Claude Code](https://claude.com/claude-code)