### PR TITLE
feat(snapshot): implement REPL-path snapshot/restore

### DIFF
--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -636,6 +636,40 @@ async function replDispose(replId) {
   return JSON.stringify(result);
 }
 
+/**
+ * Snapshot a REPL handle's heap to postcard bytes.
+ *
+ * @param {string} replId Unique identifier for the REPL handle.
+ * @returns {Promise<Object>} Raw JS object with snapshotBuffer ArrayBuffer.
+ */
+async function replSnapshot(replId) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) {
+    return { ok: false, error: 'Not initialized' };
+  }
+  const session = sessions.get(sid);
+  const result = await callWorker(sid, { type: 'replSnapshot', replId }, session.timeoutMs);
+  // Return raw JS object — snapshotBuffer is an ArrayBuffer, not JSON-safe.
+  return result;
+}
+
+/**
+ * Restore a REPL handle from base64-encoded postcard bytes.
+ *
+ * @param {string} replId   Unique identifier for the REPL handle.
+ * @param {string} dataBase64 Base64-encoded snapshot data.
+ * @returns {Promise<string>} JSON result.
+ */
+async function replRestore(replId, dataBase64) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid, { type: 'replRestore', replId, dataBase64 }, session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
 // Expose bridge on window for Dart JS interop
 window.DartMontyBridge = {
   init,
@@ -669,6 +703,8 @@ window.DartMontyBridge = {
   replResumeWithError,
   replDetectContinuation,
   replDispose,
+  replSnapshot,
+  replRestore,
 };
 
 console.log('[DartMontyBridge] Registered on window (Worker pool architecture)');

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -1368,6 +1368,112 @@ function handleReplDispose(id, replId) {
   self.postMessage({ type: 'result', id, ok: true });
 }
 
+function handleReplSnapshot(id, replId) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`,
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const outLen = allocOutPtr();
+  let ptr;
+  try {
+    ptr = wasm.monty_repl_snapshot(handle, outLen.ptr);
+  } catch (e) {
+    outLen.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+
+  if (ptr === 0) {
+    outLen.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'monty_repl_snapshot returned null — REPL may be mid-execution',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  const len = outLen.read();
+  outLen.free();
+
+  const wasmBytes = new Uint8Array(wasm.memory.buffer, ptr, len);
+  let copy;
+  try {
+    copy = wasmBytes.slice();
+  } finally {
+    wasm.monty_bytes_free(ptr, len);
+  }
+
+  self.postMessage(
+    { type: 'result', id, ok: true, snapshotBuffer: copy.buffer },
+    [copy.buffer],
+  );
+}
+
+function handleReplRestore(id, replId, dataBase64) {
+  // Free existing handle for this replId, if any.
+  const existing = replHandles.get(replId);
+  if (existing) {
+    wasm.monty_repl_free(existing);
+    replHandles.delete(replId);
+  }
+
+  // Decode base64 to Uint8Array.
+  const binary = atob(dataBase64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  const outError = allocOutPtr();
+  const ptr = wasm.monty_alloc(bytes.length);
+  if (ptr === 0) {
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: `monty_alloc(${bytes.length}) returned null — OOM`,
+      errorType: 'MemoryError',
+    });
+    return;
+  }
+  new Uint8Array(wasm.memory.buffer).set(bytes, ptr);
+
+  let handle;
+  try {
+    handle = wasm.monty_repl_restore(ptr, bytes.length, outError.ptr);
+  } catch (e) {
+    outError.free();
+    throw e;
+  } finally {
+    wasm.monty_dealloc(ptr, bytes.length);
+  }
+
+  if (handle === 0) {
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    outError.free();
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_repl_restore failed',
+      errorType: 'RestoreError',
+    });
+    return;
+  }
+  outError.free();
+  replHandles.set(replId, handle);
+  self.postMessage({ type: 'result', id, ok: true });
+}
+
 // ---------------------------------------------------------------------------
 // Message dispatch
 // ---------------------------------------------------------------------------
@@ -1446,6 +1552,12 @@ self.onmessage = (e) => {
         break;
       case 'replDispose':
         handleReplDispose(id, replId);
+        break;
+      case 'replSnapshot':
+        handleReplSnapshot(id, replId);
+        break;
+      case 'replRestore':
+        handleReplRestore(id, replId, dataBase64);
         break;
       default:
         self.postMessage({

--- a/lib/src/ffi/generated/dart_monty_bindings.dart
+++ b/lib/src/ffi/generated/dart_monty_bindings.dart
@@ -769,6 +769,41 @@ external ffi.Pointer<ffi.Char> monty_repl_pending_future_call_ids(
   ffi.Pointer<MontyReplHandle> handle,
 );
 
+/// Serialise a REPL handle's heap to postcard bytes.
+///
+/// @param handle   Non-null REPL handle in Idle or Complete state.
+/// @param out_len  Receives the byte count on success.
+/// @return         Heap-allocated bytes (free with monty_bytes_free()), or NULL on error.
+@ffi.Native<
+  ffi.Pointer<ffi.Uint8> Function(
+    ffi.Pointer<MontyReplHandle>,
+    ffi.Pointer<ffi.Size>,
+  )
+>()
+external ffi.Pointer<ffi.Uint8> monty_repl_snapshot(
+  ffi.Pointer<MontyReplHandle> handle,
+  ffi.Pointer<ffi.Size> out_len,
+);
+
+/// Restore a REPL handle from postcard bytes produced by monty_repl_snapshot().
+///
+/// @param data       Pointer to snapshot bytes (not consumed by this call).
+/// @param len        Byte count.
+/// @param out_error  On failure, receives error string (free with monty_string_free()).
+/// @return           New REPL handle (free with monty_repl_free()), or NULL on error.
+@ffi.Native<
+  ffi.Pointer<MontyReplHandle> Function(
+    ffi.Pointer<ffi.Uint8>,
+    ffi.Size,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+  )
+>()
+external ffi.Pointer<MontyReplHandle> monty_repl_restore(
+  ffi.Pointer<ffi.Uint8> data,
+  int len,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+);
+
 /// Free a string returned by any monty_* function. Safe with NULL.
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Char>)>()
 external void monty_string_free(

--- a/lib/src/ffi/native_bindings.dart
+++ b/lib/src/ffi/native_bindings.dart
@@ -200,4 +200,15 @@ abstract class NativeBindings {
     String resultsJson,
     String errorsJson,
   );
+
+  /// Serialises a REPL handle's heap to postcard bytes.
+  ///
+  /// Throws [StateError] if the REPL is mid-execution.
+  Uint8List replSnapshot(int handle);
+
+  /// Restores a REPL handle from postcard bytes produced by [replSnapshot].
+  ///
+  /// Returns the new handle address. The caller must free the old handle
+  /// via [replFree] before calling this.
+  int replRestore(Uint8List data);
 }

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -470,6 +470,53 @@ class NativeBindingsFfi extends NativeBindings {
     }
   }
 
+  @override
+  Uint8List replSnapshot(int handle) {
+    final ptr = Pointer<ffi_native.MontyReplHandle>.fromAddress(handle);
+    final outLen = calloc<Size>();
+
+    try {
+      final buf = ffi_native.monty_repl_snapshot(ptr, outLen);
+      if (buf == nullptr) {
+        throw StateError(
+          'monty_repl_snapshot returned null — REPL may be mid-execution',
+        );
+      }
+      final len = outLen.value;
+      final bytes = Uint8List.fromList(buf.cast<Uint8>().asTypedList(len));
+      ffi_native.monty_bytes_free(buf, len);
+
+      return bytes;
+    } finally {
+      calloc.free(outLen);
+    }
+  }
+
+  @override
+  int replRestore(Uint8List data) {
+    final cData = calloc<Uint8>(data.length);
+    final outError = calloc<Pointer<Char>>();
+
+    try {
+      cData.asTypedList(data.length).setAll(0, data);
+      final handle = ffi_native.monty_repl_restore(
+        cData,
+        data.length,
+        outError,
+      );
+      if (handle == nullptr) {
+        final errorMsg = _readAndFreeString(outError.value);
+        throw StateError(errorMsg ?? 'monty_repl_restore returned null');
+      }
+
+      return handle.address;
+    } finally {
+      calloc
+        ..free(cData)
+        ..free(outError);
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // Helpers
   // ---------------------------------------------------------------------------

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -70,11 +70,17 @@ class Monty {
     inputs: inputs,
   );
 
-  /// Not yet implemented — see issue #23.
+  /// Serialises the interpreter state to postcard bytes.
+  ///
+  /// Pass the result to [restore] to rehydrate an identical interpreter.
+  /// Throws [StateError] if the interpreter is mid-execution.
   Future<Uint8List> snapshot() => _session.snapshot();
 
-  /// Not yet implemented — see issue #23.
-  void restore(Uint8List bytes) => _session.restore(bytes);
+  /// Restores this interpreter's state from bytes produced by [snapshot].
+  ///
+  /// The current REPL handle is freed and replaced. Await this before
+  /// issuing further [run] calls.
+  Future<void> restore(Uint8List bytes) => _session.restore(bytes);
 
   /// Clears all persisted state.
   ///

--- a/lib/src/monty_session.dart
+++ b/lib/src/monty_session.dart
@@ -125,24 +125,26 @@ class MontySession {
     return _repl.resumeWithError(errorMessage);
   }
 
-  /// Not yet implemented — see issue #23.
+  /// Serialises the REPL heap to postcard bytes.
   ///
-  /// Snapshot/restore requires exposing `replSnapshot`/`replRestore` on the
-  /// REPL path (JS bridge + `ReplBindings`) so the full Rust heap can be
-  /// serialised, rather than relying on Python introspection or Dart-side
-  /// variable tracking.
-  Future<Uint8List> snapshot() => Future.error(
-    UnsupportedError(
-      'MontySession.snapshot() is not yet implemented. '
-      'Track progress at https://github.com/runyaga/dart_monty_core/issues/23',
-    ),
-  );
+  /// The bytes can be passed to [restore] to rehydrate an identical session.
+  /// Throws [StateError] if the session is disposed or the REPL is
+  /// mid-execution.
+  Future<Uint8List> snapshot() {
+    _checkNotDisposed();
 
-  /// Not yet implemented — see issue #23.
-  void restore(Uint8List bytes) => throw UnsupportedError(
-    'MontySession.restore() is not yet implemented. '
-    'Track progress at https://github.com/runyaga/dart_monty_core/issues/23',
-  );
+    return _repl.snapshot();
+  }
+
+  /// Restores this session's REPL from bytes produced by [snapshot].
+  ///
+  /// The current REPL handle is freed and replaced with a new one restored
+  /// from [bytes]. Any in-flight [run] calls must complete before calling this.
+  Future<void> restore(Uint8List bytes) {
+    _checkNotDisposed();
+
+    return _repl.restore(bytes);
+  }
 
   /// Clears all persisted state. The next [run] starts with empty globals.
   void clearState() {

--- a/lib/src/repl/ffi_repl_bindings.dart
+++ b/lib/src/repl/ffi_repl_bindings.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:ffi' as ffi;
+import 'dart:typed_data';
 
 import 'package:dart_monty_core/src/ffi/generated/dart_monty_bindings.dart'
     as ffi_native;
@@ -138,6 +139,48 @@ class FfiReplBindings implements ReplBindings {
     throw UnimplementedError(
       'resumeNameLookupUndefined is not supported by the FFI REPL backend',
     );
+  }
+
+  @override
+  Future<Uint8List> snapshot() async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+
+    return _bindings.replSnapshot(handle);
+  }
+
+  @override
+  Future<void> restore(Uint8List bytes) async {
+    // Detach old finalizer to prevent double-free.
+    final token = _detachToken;
+    if (_guard != null && token != null) {
+      _replHandleFinalizer.detach(token);
+    }
+    // Free old handle explicitly.
+    final oldHandle = _replHandle;
+    if (oldHandle != null) {
+      _bindings.replFree(oldHandle);
+    }
+    _replHandle = null;
+    _guard = null;
+    _detachToken = null;
+
+    // Restore new handle from bytes.
+    final newHandle = _bindings.replRestore(bytes);
+    _replHandle = newHandle;
+
+    // Attach new finalizer.
+    final guard = _ReplHandleGuard(newHandle);
+    final token2 = Object();
+    _replHandleFinalizer.attach(
+      guard,
+      ffi.Pointer.fromAddress(newHandle),
+      detach: token2,
+    );
+    _guard = guard;
+    _detachToken = token2;
   }
 
   // -----------------------------------------------------------------------

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dart_monty_core/src/externals.dart';
 import 'package:dart_monty_core/src/platform/core_bindings.dart';
@@ -241,6 +242,31 @@ class MontyRepl {
       2 => ReplContinuationMode.incompleteBlock,
       _ => ReplContinuationMode.complete,
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Snapshot / restore
+  // ---------------------------------------------------------------------------
+
+  /// Serialises the REPL heap to postcard bytes.
+  ///
+  /// The bytes can be passed to [restore] to rehydrate an identical REPL.
+  /// The REPL must not be mid-execution (no pending [feedStart]/[resume]
+  /// loop in progress). Throws [StateError] if mid-execution.
+  Future<Uint8List> snapshot() {
+    _checkNotDisposed();
+
+    return _bindings.snapshot();
+  }
+
+  /// Restores the REPL from bytes produced by [snapshot].
+  ///
+  /// The current REPL handle is freed and replaced with a new one restored
+  /// from [bytes]. Any in-flight operations must complete before calling this.
+  Future<void> restore(Uint8List bytes) {
+    _checkNotDisposed();
+
+    return _bindings.restore(bytes);
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/repl/repl_bindings.dart
+++ b/lib/src/repl/repl_bindings.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dart_monty_core/src/platform/core_bindings.dart';
 
 /// Internal bindings interface for REPL operations.
@@ -34,6 +36,17 @@ abstract class ReplBindings {
   ///
   /// The engine raises NameError.
   Future<CoreProgressResult> resumeNameLookupUndefined();
+
+  /// Serialises the REPL heap to postcard bytes.
+  ///
+  /// Throws [StateError] if the REPL is mid-execution.
+  Future<Uint8List> snapshot();
+
+  /// Restores the REPL from postcard bytes produced by [snapshot].
+  ///
+  /// The old native handle is freed and replaced with a new one
+  /// restored from [bytes].
+  Future<void> restore(Uint8List bytes);
 
   /// Disposes the REPL session.
   Future<void> dispose();

--- a/lib/src/repl/wasm_repl_bindings.dart
+++ b/lib/src/repl/wasm_repl_bindings.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:dart_monty_core/src/platform/core_bindings.dart';
 import 'package:dart_monty_core/src/platform/monty_resource_usage.dart';
@@ -101,6 +102,23 @@ class WasmReplBindings implements ReplBindings {
     return _translateWasmProgressResult(
       await _bindings.resumeNameLookupUndefined(),
     );
+  }
+
+  @override
+  Future<Uint8List> snapshot() {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+
+    return _bindings.replSnapshot(replId: _replId);
+  }
+
+  @override
+  Future<void> restore(Uint8List bytes) async {
+    // replRestore in the Worker frees the old handle and stores the new one
+    // under the same replId — no explicit free needed here.
+    await _bindings.replRestore(replId: _replId, data: bytes);
+    _created = true;
   }
 
   @override

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -425,4 +425,19 @@ abstract class WasmBindings {
   /// The engine raises NameError. When [sessionId] is non-null, routes to
   /// that specific session instead of the default.
   Future<WasmProgressResult> resumeNameLookupUndefined({int? sessionId});
+
+  /// Serialises a REPL handle's heap to postcard bytes.
+  ///
+  /// [replId] must match the value passed to [replCreate].
+  /// Throws [StateError] if the REPL is mid-execution.
+  Future<Uint8List> replSnapshot({required String replId, int? sessionId});
+
+  /// Restores a REPL handle from postcard bytes produced by [replSnapshot].
+  ///
+  /// The old Worker-side handle for [replId] is freed and replaced.
+  Future<void> replRestore({
+    required String replId,
+    required Uint8List data,
+    int? sessionId,
+  });
 }

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -181,6 +181,19 @@ external JSPromise<JSString> _jsResumeNameLookupUndefined([
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.replSnapshot')
+external JSPromise<JSAny> _jsReplSnapshot(
+  JSString replId, [
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.replRestore')
+external JSPromise<JSString> _jsReplRestore(
+  JSString replId,
+  JSString dataBase64, [
+  JSNumber? sessionId,
+]);
+
 /// Concrete [WasmBindings] implementation using `dart:js_interop`.
 ///
 /// Calls static methods on `window.DartMontyBridge`, which manages a
@@ -608,6 +621,41 @@ class WasmBindingsJs extends WasmBindings {
     ).toDart;
 
     return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<Uint8List> replSnapshot({
+    required String replId,
+    int? sessionId,
+  }) async {
+    final jsAny = await _jsReplSnapshot(
+      replId.toJS,
+      sessionId?.toJS,
+    ).toDart;
+    final result = jsAny as _SnapshotResult;
+    if (!result.ok.toDart) {
+      throw StateError(result.error?.toDart ?? 'replSnapshot failed');
+    }
+
+    return result.snapshotBuffer!.toDart.asUint8List();
+  }
+
+  @override
+  Future<void> replRestore({
+    required String replId,
+    required Uint8List data,
+    int? sessionId,
+  }) async {
+    final dataBase64 = base64Encode(data);
+    final resultJson = await _jsReplRestore(
+      replId.toJS,
+      dataBase64.toJS,
+      sessionId?.toJS,
+    ).toDart;
+    final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
+    if (map['ok'] != true) {
+      throw StateError(map['error'] as String? ?? 'replRestore failed');
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -168,4 +168,17 @@ class WasmBindingsJs extends WasmBindings {
   @override
   Future<WasmProgressResult> resumeNameLookupUndefined({int? sessionId}) =>
       throw UnimplementedError();
+
+  @override
+  Future<Uint8List> replSnapshot({
+    required String replId,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<void> replRestore({
+    required String replId,
+    required Uint8List data,
+    int? sessionId,
+  }) => throw UnimplementedError();
 }

--- a/native/include/dart_monty.h
+++ b/native/include/dart_monty.h
@@ -451,6 +451,29 @@ int monty_repl_complete_is_error(const MontyReplHandle *handle);
 char *monty_repl_pending_future_call_ids(const MontyReplHandle *handle);
 
 /* ------------------------------------------------------------------ */
+/* REPL snapshots                                                     */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Serialise a REPL handle's heap to postcard bytes.
+ *
+ * @param handle   Non-null REPL handle in Idle or Complete state.
+ * @param out_len  Receives the byte count on success.
+ * @return         Heap-allocated bytes (free with monty_bytes_free()), or NULL on error.
+ */
+uint8_t *monty_repl_snapshot(const MontyReplHandle *handle, size_t *out_len);
+
+/**
+ * Restore a REPL handle from postcard bytes produced by monty_repl_snapshot().
+ *
+ * @param data       Pointer to snapshot bytes (not consumed by this call).
+ * @param len        Byte count.
+ * @param out_error  On failure, receives error string (free with monty_string_free()).
+ * @return           New REPL handle (free with monty_repl_free()), or NULL on error.
+ */
+MontyReplHandle *monty_repl_restore(const uint8_t *data, size_t len, char **out_error);
+
+/* ------------------------------------------------------------------ */
 /* Memory management                                                  */
 /* ------------------------------------------------------------------ */
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1237,6 +1237,89 @@ pub unsafe extern "C" fn monty_repl_pending_future_call_ids(
 }
 
 // ---------------------------------------------------------------------------
+// REPL snapshots
+// ---------------------------------------------------------------------------
+
+/// Serialise a REPL handle's heap to postcard bytes.
+///
+/// - `handle`: non-null pointer to a `MontyReplHandle` in Idle or Complete state.
+/// - `out_len`: receives the byte count on success.
+///
+/// Returns a heap-allocated byte buffer (free with `monty_bytes_free`),
+/// or NULL if the handle is mid-execution or `handle`/`out_len` is NULL.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monty_repl_snapshot(
+    handle: *const MontyReplHandle,
+    out_len: *mut usize,
+) -> *mut u8 {
+    if handle.is_null() || out_len.is_null() {
+        return ptr::null_mut();
+    }
+    // SAFETY: handle is non-null (just checked), created by monty_repl_create via Box::into_raw
+    let h = unsafe { &*handle };
+    match catch_ffi_panic(|| h.snapshot()) {
+        Ok(Ok(bytes)) => {
+            let len = bytes.len();
+            let boxed = bytes.into_boxed_slice();
+            let ptr = Box::into_raw(boxed).cast::<u8>();
+            // SAFETY: out_len is non-null (just checked), writing the byte count
+            unsafe { *out_len = len };
+            ptr
+        }
+        Ok(Err(_)) | Err(_) => ptr::null_mut(),
+    }
+}
+
+/// Restore a `MontyReplHandle` from postcard bytes produced by `monty_repl_snapshot`.
+///
+/// - `data`: pointer to the byte buffer (caller owns; not consumed).
+/// - `len`: byte count.
+/// - `out_error`: on failure, receives a heap-allocated error string
+///   (free with `monty_string_free`). May be NULL.
+///
+/// Returns a heap-allocated handle (free with `monty_repl_free`), or NULL on error.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monty_repl_restore(
+    data: *const u8,
+    len: usize,
+    out_error: *mut *mut c_char,
+) -> *mut MontyReplHandle {
+    if data.is_null() {
+        if !out_error.is_null() {
+            // SAFETY: out_error is non-null (just checked), writing error message
+            unsafe { *out_error = to_c_string("data is NULL") };
+        }
+        return ptr::null_mut();
+    }
+    // SAFETY: data is non-null (just checked) and len matches the snapshot buffer
+    let bytes = unsafe { std::slice::from_raw_parts(data, len) };
+    match catch_ffi_panic(|| MontyReplHandle::restore(bytes)) {
+        Ok(Ok(handle)) => {
+            let ptr = Box::into_raw(Box::new(handle));
+            LIVE_REPL_HANDLES
+                .write()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .insert(ptr as usize);
+            ptr
+        }
+        Ok(Err(msg)) => {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing restore error message
+                unsafe { *out_error = to_c_string(&msg) };
+            }
+            ptr::null_mut()
+        }
+        Err(panic_msg) => {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing panic message
+                unsafe { *out_error = to_c_string(&panic_msg) };
+            }
+            ptr::null_mut()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Memory management
 // ---------------------------------------------------------------------------
 

--- a/native/src/repl_handle.rs
+++ b/native/src/repl_handle.rs
@@ -110,6 +110,36 @@ impl MontyReplHandle {
         }
     }
 
+    /// Serialises the REPL heap to postcard bytes.
+    ///
+    /// Only valid in `Idle` or `Complete` states (when the `MontyRepl` is
+    /// accessible). Returns `Err` if the REPL is mid-execution (`Paused`,
+    /// `OsCall`, `Futures`).
+    pub fn snapshot(&self) -> Result<Vec<u8>, String> {
+        match &self.state {
+            ReplHandleState::Idle(repl) => repl
+                .dump()
+                .map_err(|e| format!("repl snapshot failed: {e}")),
+            ReplHandleState::Complete { repl, .. } => repl
+                .dump()
+                .map_err(|e| format!("repl snapshot failed: {e}")),
+            _ => Err("can only snapshot an idle or complete REPL (not mid-execution)".into()),
+        }
+    }
+
+    /// Restores a `MontyReplHandle` from postcard bytes produced by `snapshot`.
+    ///
+    /// On success, the returned handle is in `Idle` state with the restored
+    /// interpreter state. `ext_fn_names` and `print_output` are reset to defaults.
+    pub fn restore(bytes: &[u8]) -> Result<Self, String> {
+        let repl = MontyRepl::load(bytes).map_err(|e| format!("repl restore failed: {e}"))?;
+        Ok(Self {
+            state: ReplHandleState::Idle(repl),
+            ext_fn_names: HashSet::new(),
+            print_output: String::new(),
+        })
+    }
+
     /// Registers external function names for `feed_start()` name resolution.
     pub fn set_ext_fns(&mut self, names: Vec<String>) {
         self.ext_fn_names = names.into_iter().collect();
@@ -939,6 +969,55 @@ mod tests {
     // -----------------------------------------------------------------------
     // Debug fmt
     // -----------------------------------------------------------------------
+
+    // -----------------------------------------------------------------------
+    // Snapshot / restore
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn snapshot_restore_preserves_state() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, _, _) = repl.feed_run("x = 42");
+        assert_eq!(tag, MontyResultTag::Ok);
+
+        let bytes = repl
+            .snapshot()
+            .expect("snapshot should succeed in Idle state");
+        assert!(!bytes.is_empty());
+
+        let mut restored = MontyReplHandle::restore(&bytes).expect("restore should succeed");
+        let (tag, json, _) = restored.feed_run("x");
+        assert_eq!(tag, MontyResultTag::Ok);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["value"], 42);
+    }
+
+    #[test]
+    fn snapshot_mid_execution_returns_err() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["f".into()]);
+        repl.feed_start("f()");
+        // Handle is now Paused — snapshot must fail
+        assert!(repl.snapshot().is_err());
+    }
+
+    #[test]
+    fn restore_isolates_from_original() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.feed_run("x = 1");
+
+        let bytes = repl.snapshot().unwrap();
+        let mut restored = MontyReplHandle::restore(&bytes).unwrap();
+
+        // Modify original
+        repl.feed_run("x = 99");
+
+        // Restored session should still have x == 1
+        let (tag, json, _) = restored.feed_run("x");
+        assert_eq!(tag, MontyResultTag::Ok);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["value"], 1);
+    }
 
     #[test]
     fn debug_fmt_does_not_panic() {


### PR DESCRIPTION
## Summary

- Implements `MontyRepl.snapshot()` / `restore()` backed by `monty::MontyRepl::dump()` / `load()` (postcard binary serialisation) — closes #23
- Threads through all layers: Rust C ABI → FFI Dart → JS Worker/Bridge → WASM Dart → `ReplBindings` → `MontyRepl` → `MontySession` → `Monty`
- Replaces the `UnsupportedError` stubs added in `refactor/session-repl-backed`
- **Breaking change**: `Monty.restore()` / `MontySession.restore()` return type changed `void` → `Future<void>` (stubs were never callable so no real consumers exist)

## Layers changed

| Layer | What changed |
|---|---|
| `native/src/repl_handle.rs` | `MontyReplHandle::snapshot/restore` + 3 unit tests |
| `native/src/lib.rs` | `monty_repl_snapshot` / `monty_repl_restore` C ABI (reuses `monty_bytes_free`) |
| `native/include/dart_monty.h` | Two declarations |
| Generated FFI | Regenerated from header |
| `NativeBindings` / `NativeBindingsFfi` | `replSnapshot` / `replRestore` |
| `ReplBindings` | Abstract `snapshot()` / `restore()` |
| `FfiReplBindings` | Impl with `NativeFinalizer` detach/reattach on restore |
| `js/src/worker_src.js` | `handleReplSnapshot` / `handleReplRestore` + dispatch cases |
| `js/src/bridge.js` | `replSnapshot` / `replRestore` on `window.DartMontyBridge` |
| `WasmBindings` / `WasmBindingsJs` | Abstract + `@JS` interop (reuses `_SnapshotResult` / base64 pattern) + VM stubs |
| `WasmReplBindings` | Delegates to bindings |
| `MontyRepl` | `snapshot()` / `restore()` |
| `MontySession` / `Monty` | Real implementations, `restore()` → `Future<void>` |

## Test plan

- [x] Rust unit tests: 182/182 (includes 3 new snapshot-specific tests)
- [x] Dart unit tests: 67/67
- [x] FFI oracle tests: 464/464
- [x] FFI multi-repl + oscall integration: 10/10
- [x] `dart format`, `dart analyze --fatal-infos`, `dcm analyze`, `cargo fmt`, `cargo clippy -D warnings` — all clean
- [ ] WASM smoke tests (`snapshot_wasm_test.dart`) — to be added in a follow-up per the plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)