### PR TITLE
fix(demo): await monty.restore() — restore() is now Future<void>

### DIFF
--- a/native/.dart_tool/native_assets.yaml
+++ b/native/.dart_tool/native_assets.yaml
@@ -9,9 +9,9 @@
   ],
   "native-assets": {
     "macos_arm64": {
-      "package:dart_monty/dart_monty_ffi.dart": [
+      "package:dart_monty_core/dart_monty_core_ffi.dart": [
         "absolute",
-        "/Users/runyaga/dev/dart_monty/main/native/.dart_tool/lib/libdart_monty_native.dylib"
+        "/Users/runyaga/dev/dart_monty_core--repl-snapshot/native/.dart_tool/lib/libdart_monty_native.dylib"
       ]
     }
   }

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -232,13 +232,13 @@ void _initVfsPanel() {
       write('No snapshot yet — click 📸 first.', className: 'system-line');
       return;
     }
-    try {
-      monty.restore(
-        Uint8List.fromList(saved),
-      );
-      write('✅ State restored from snapshot.', className: 'system-line');
-    } on Object catch (e) {
-      write('Restore error: $e', className: 'error-line');
-    }
+    unawaited(() async {
+      try {
+        await monty.restore(Uint8List.fromList(saved));
+        write('✅ State restored from snapshot.', className: 'system-line');
+      } on Object catch (e) {
+        write('Restore error: $e', className: 'error-line');
+      }
+    }());
   }.toJS;
 }


### PR DESCRIPTION
## Summary

- `Monty.restore()` returns `Future<void>` since PR #25, but the restore button handler in `repl_demo.dart` called it synchronously (discarding the future)
- Wraps the call in `unawaited(() async { await monty.restore(...) }())` — consistent with the snapshot button handler directly above it

## Test plan

- [ ] `dart analyze --fatal-infos` passes (was the failing check on `main`)