### PR TITLE
feat: bump monty to v0.0.14 + document WASM git-dependency setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ coverage/
 native/target/
 native/Cargo.lock
 
+# JS bridge build deps
+js/node_modules/
+
 # DCM local config contains credentials — never commit
 .dcm.yaml
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 0.0.14 - monty upstream upgrade
+
+### Upgraded
+- Rust dependency `monty` bumped from `v0.0.12` → `v0.0.14` (Cargo.toml + Cargo.lock)
+
+### What changed upstream (monty v0.0.12 → v0.0.14)
+
+**New types (not yet surfaced in dart_monty_core):**
+- `ExcType` — 35 named exception variants (ValueError, FrozenInstanceError, JsonDecodeError,
+  TimeoutError, RePatternError, …). `resume_with_exception` already parses these by string; the
+  new variants are automatically accepted.
+- `JsonMontyObject` / `JsonMontyArray` / `JsonMontyPairs` — upstream serde-serialize wrappers.
+  dart_monty_core continues to use its own `monty_object_to_json` / `json_to_monty_object`.
+- `ExtFunctionResult::NotFound` — signal that the host does not handle an OS call, allowing
+  Python to raise an appropriate exception. **Not yet exposed in the FFI** (see gaps below).
+
+**New OsFunction variants:**
+- `OsFunction::DateToday` → `"date.today"` — Python `date.today()`.
+  Host must return `MontyDate(year, month, day)` via the `OsCallHandler`.
+- `OsFunction::DateTimeNow` → `"datetime.now"` — Python `datetime.now(tz=...)`.
+  Host must return `MontyDateTime(...)`. The single positional arg carries the tz
+  as `MontyTimeZone` or `MontyNone`.
+
+**Breaking changes (transparent to dart_monty_core):**
+- `CodeLoc` fields widened from `u16` → `u32` — fixes panic on source lines > 65 535 chars.
+  Traceback line/column numbers now support larger values with no API change.
+- `PyMontyComplete::create` takes `MontyObject` by value — Python-layer change, no FFI impact.
+- `DictPairs` gained `len()` / `is_empty()` — not yet used in convert.rs.
+
+**Bug fixes (inherited):**
+- OS auto-dispatch during `start()` (PR #337): start-time OS calls no longer stall execution.
+- `not_handled` sentinel now respected for async OS callbacks (PR #337).
+- `datetime.now()` / `date.today()` added to Python stdlib support (PR #332).
+- Non-ASCII column offsets corrected (PR #342).
+
+### Gap inventory — follow-up work required
+
+| # | Gap | File(s) | Priority |
+|---|-----|---------|----------|
+| 1 | `ExtFunctionResult::NotFound` not in FFI — no `monty_resume_not_found` / `monty_repl_resume_not_found` export; hosts cannot signal "OS call not handled" | `native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`, `native/include/dart_monty.h`, Dart binding chain | High |
+| 2 | No integration tests for `"date.today"` / `"datetime.now"` OS calls | `test/`, `native/tests/` | High |
+| 3 | `OsCallHandler` docs don't explain return types for `"date.today"` (use `MontyDate`) and `"datetime.now"` (use `MontyDateTime`) — fixed `externals.dart` comment, but no example | `lib/src/externals.dart`, `example/` | Medium |
+| 4 | `Ellipsis` serialised as plain `"..."` string; upstream `JsonMontyObject` uses `{"$ellipsis":"..."}` to disambiguate from the string literal `"..."` | `native/src/convert.rs`, `lib/src/platform/monty_value.dart` | Low |
+| 5 | `DictPairs.len()` / `DictPairs.is_empty()` not used in `dict_to_json` — minor convert.rs efficiency opportunity | `native/src/convert.rs` | Low |
+
 ## 0.0.12 - Initial Release
 
 - Multi-REPL support on WASM with snapshot integration tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,44 @@
 ### Upgraded
 - Rust dependency `monty` bumped from `v0.0.12` → `v0.0.14` (Cargo.toml + Cargo.lock)
 
-### Added
-- `OsCallNotHandledException` — throw from an `OsCallHandler` to signal that the host does
-  not implement the requested OS call. Python sees `NameError: name '<fn>' is not defined`
-  (previously hosts had to fall back to `OsCallException`, which produced a generic
-  `RuntimeError`).
-- `monty_resume_not_found` / `monty_repl_resume_not_found` C FFI exports, matching
-  `ExtFunctionResult::NotFound` in upstream monty (`native/src/handle.rs`,
-  `native/src/repl_handle.rs`, `native/src/lib.rs`, `native/include/dart_monty.h`).
-- `DartMontyBridge.resumeNotFound` / `DartMontyBridge.replResumeNotFound` on the WASM
-  JS bridge (`js/src/bridge.js`, `js/src/worker_src.js`).
-- `resumeNotFound` on `MontyPlatform`, `MontyCoreBindings`, `ReplBindings`,
-  `NativeBindings`, and `WasmBindings`; `MontyRepl.resumeNotFound` /
-  `ReplPlatform.resumeNotFound` on the platform layer.
-- FFI + WASM integration tests for `date.today()` / `datetime.now()` OS calls and for the
-  `OsCallNotHandledException` → `NameError` path (`ffi_datetime_oscall_test.dart`,
-  `wasm_datetime_oscall_test.dart`).
+### Added — new public API
+
+- **`OsCallNotHandledException`** (`lib/src/platform/os_call_exception.dart`,
+  re-exported from `package:dart_monty_core/dart_monty_core.dart`). Throw from
+  an `OsCallHandler` to signal that the host does not implement the requested
+  OS call. Python sees `NameError: name '<fn>' is not defined` — matching the
+  semantics of an undefined global — instead of the generic `RuntimeError`
+  that `OsCallException` produces. Optional `fnName` field lets the handler
+  override the function name reported to Python.
+  ```dart
+  final monty = Monty(osHandler: (op, args, kwargs) async {
+    if (op == 'os.getenv') return Platform.environment[args[0] as String];
+    throw const OsCallNotHandledException(); // → NameError in Python
+  });
+  ```
+- **`MontyRepl.resumeNotFound(String fnName)`** — public method on the REPL
+  façade; also exposed on `ReplPlatform` for platform-layer callers.
+- **`OsCallHandler` now handles `"date.today"` and `"datetime.now"`** — monty
+  v0.0.14 adds these as explicit OS calls. Hosts return `MontyDate(year, month, day)`
+  for `date.today` and `MontyDateTime(...)` for `datetime.now`. The single
+  positional arg to `datetime.now` carries the timezone as `MontyTimeZone` or
+  `MontyNone`.
+
+### Added — internal plumbing
+
+- `monty_resume_not_found` / `monty_repl_resume_not_found` C FFI exports,
+  matching `ExtFunctionResult::NotFound` in upstream monty
+  (`native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`,
+  `native/include/dart_monty.h`).
+- `DartMontyBridge.resumeNotFound` / `DartMontyBridge.replResumeNotFound` on
+  the WASM JS bridge (`js/src/bridge.js`, `js/src/worker_src.js`).
+- `resumeNotFound` on the abstract binding contracts: `MontyCoreBindings`,
+  `ReplBindings`, `NativeBindings`, and `WasmBindings` (run + REPL variants).
+- FFI + WASM integration tests for `date.today()` / `datetime.now()` OS calls
+  and for the `OsCallNotHandledException` → `NameError` path
+  (`ffi_datetime_oscall_test.dart`, `wasm_datetime_oscall_test.dart`).
+- Oracle conformance on all three backends at 464/464: FFI, dart2js WASM,
+  dart2wasm WASM.
 
 ### What changed upstream (monty v0.0.12 → v0.0.14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@
 ### Upgraded
 - Rust dependency `monty` bumped from `v0.0.12` → `v0.0.14` (Cargo.toml + Cargo.lock)
 
-### Added — new public API
+### Added
 
-- **`OsCallNotHandledException`** (`lib/src/platform/os_call_exception.dart`,
-  re-exported from `package:dart_monty_core/dart_monty_core.dart`). Throw from
-  an `OsCallHandler` to signal that the host does not implement the requested
-  OS call. Python sees `NameError: name '<fn>' is not defined` — matching the
-  semantics of an undefined global — instead of the generic `RuntimeError`
-  that `OsCallException` produces. Optional `fnName` field lets the handler
-  override the function name reported to Python.
+- **`OsCallNotHandledException`** (exported from
+  `package:dart_monty_core/dart_monty_core.dart`). Throw from an
+  `OsCallHandler` to signal that the host does not implement the requested
+  OS call. Python sees `NameError: name '<fn>' is not defined` — matching
+  the semantics of an undefined global — instead of the generic
+  `RuntimeError` that `OsCallException` produces. Optional `fnName` field
+  lets the handler override the function name reported to Python.
   ```dart
   final monty = Monty(osHandler: (op, args, kwargs) async {
     if (op == 'os.getenv') return Platform.environment[args[0] as String];
@@ -22,27 +22,16 @@
   ```
 - **`MontyRepl.resumeNotFound(String fnName)`** — public method on the REPL
   façade; also exposed on `ReplPlatform` for platform-layer callers.
-- **`OsCallHandler` now handles `"date.today"` and `"datetime.now"`** — monty
-  v0.0.14 adds these as explicit OS calls. Hosts return `MontyDate(year, month, day)`
-  for `date.today` and `MontyDateTime(...)` for `datetime.now`. The single
-  positional arg to `datetime.now` carries the timezone as `MontyTimeZone` or
-  `MontyNone`.
+- **`OsCallHandler` now receives `"date.today"` and `"datetime.now"`** —
+  monty v0.0.14 adds these as explicit OS calls. Hosts return
+  `MontyDate(year, month, day)` for `date.today` and `MontyDateTime(...)`
+  for `datetime.now`. The single positional arg to `datetime.now` carries
+  the timezone as `MontyTimeZone` or `MontyNone`.
 
-### Added — internal plumbing
+### Verified
 
-- `monty_resume_not_found` / `monty_repl_resume_not_found` C FFI exports,
-  matching `ExtFunctionResult::NotFound` in upstream monty
-  (`native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`,
-  `native/include/dart_monty.h`).
-- `DartMontyBridge.resumeNotFound` / `DartMontyBridge.replResumeNotFound` on
-  the WASM JS bridge (`js/src/bridge.js`, `js/src/worker_src.js`).
-- `resumeNotFound` on the abstract binding contracts: `MontyCoreBindings`,
-  `ReplBindings`, `NativeBindings`, and `WasmBindings` (run + REPL variants).
-- FFI + WASM integration tests for `date.today()` / `datetime.now()` OS calls
-  and for the `OsCallNotHandledException` → `NameError` path
-  (`ffi_datetime_oscall_test.dart`, `wasm_datetime_oscall_test.dart`).
-- Oracle conformance on all three backends at 464/464: FFI, dart2js WASM,
-  dart2wasm WASM.
+- Oracle conformance holds at 464/464 on all three backends: FFI, dart2js
+  WASM, dart2wasm WASM.
 
 ### What changed upstream (monty v0.0.12 → v0.0.14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@
 ### Upgraded
 - Rust dependency `monty` bumped from `v0.0.12` → `v0.0.14` (Cargo.toml + Cargo.lock)
 
+### Added
+- `OsCallNotHandledException` — throw from an `OsCallHandler` to signal that the host does
+  not implement the requested OS call. Python sees `NameError: name '<fn>' is not defined`
+  (previously hosts had to fall back to `OsCallException`, which produced a generic
+  `RuntimeError`).
+- `monty_resume_not_found` / `monty_repl_resume_not_found` C FFI exports, matching
+  `ExtFunctionResult::NotFound` in upstream monty (`native/src/handle.rs`,
+  `native/src/repl_handle.rs`, `native/src/lib.rs`, `native/include/dart_monty.h`).
+- `DartMontyBridge.resumeNotFound` / `DartMontyBridge.replResumeNotFound` on the WASM
+  JS bridge (`js/src/bridge.js`, `js/src/worker_src.js`).
+- `resumeNotFound` on `MontyPlatform`, `MontyCoreBindings`, `ReplBindings`,
+  `NativeBindings`, and `WasmBindings`; `MontyRepl.resumeNotFound` /
+  `ReplPlatform.resumeNotFound` on the platform layer.
+- FFI + WASM integration tests for `date.today()` / `datetime.now()` OS calls and for the
+  `OsCallNotHandledException` → `NameError` path (`ffi_datetime_oscall_test.dart`,
+  `wasm_datetime_oscall_test.dart`).
+
 ### What changed upstream (monty v0.0.12 → v0.0.14)
 
 **New types (not yet surfaced in dart_monty_core):**
@@ -14,7 +31,8 @@
 - `JsonMontyObject` / `JsonMontyArray` / `JsonMontyPairs` — upstream serde-serialize wrappers.
   dart_monty_core continues to use its own `monty_object_to_json` / `json_to_monty_object`.
 - `ExtFunctionResult::NotFound` — signal that the host does not handle an OS call, allowing
-  Python to raise an appropriate exception. **Not yet exposed in the FFI** (see gaps below).
+  Python to raise `NameError: name '<fn>' is not defined`. Now surfaced through the full
+  stack as `OsCallNotHandledException` (FFI + WASM).
 
 **New OsFunction variants:**
 - `OsFunction::DateToday` → `"date.today"` — Python `date.today()`.
@@ -37,13 +55,13 @@
 
 ### Gap inventory — follow-up work required
 
-| # | Gap | File(s) | Priority |
-|---|-----|---------|----------|
-| 1 | `ExtFunctionResult::NotFound` not in FFI — no `monty_resume_not_found` / `monty_repl_resume_not_found` export; hosts cannot signal "OS call not handled" | `native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`, `native/include/dart_monty.h`, Dart binding chain | High |
-| 2 | No integration tests for `"date.today"` / `"datetime.now"` OS calls | `test/`, `native/tests/` | High |
-| 3 | `OsCallHandler` docs don't explain return types for `"date.today"` (use `MontyDate`) and `"datetime.now"` (use `MontyDateTime`) — fixed `externals.dart` comment, but no example | `lib/src/externals.dart`, `example/` | Medium |
-| 4 | `Ellipsis` serialised as plain `"..."` string; upstream `JsonMontyObject` uses `{"$ellipsis":"..."}` to disambiguate from the string literal `"..."` | `native/src/convert.rs`, `lib/src/platform/monty_value.dart` | Low |
-| 5 | `DictPairs.len()` / `DictPairs.is_empty()` not used in `dict_to_json` — minor convert.rs efficiency opportunity | `native/src/convert.rs` | Low |
+| # | Gap | File(s) | Priority | Status |
+|---|-----|---------|----------|--------|
+| 1 | `ExtFunctionResult::NotFound` not in FFI — no `monty_resume_not_found` / `monty_repl_resume_not_found` export; hosts cannot signal "OS call not handled" | `native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`, `native/include/dart_monty.h`, Dart binding chain | High | **Closed** — surfaced as `OsCallNotHandledException` across FFI + WASM |
+| 2 | No integration tests for `"date.today"` / `"datetime.now"` OS calls | `test/`, `native/tests/` | High | **Closed** — `ffi_datetime_oscall_test.dart`, `wasm_datetime_oscall_test.dart`, `native/tests/integration.rs` |
+| 3 | `OsCallHandler` docs don't explain return types for `"date.today"` (use `MontyDate`) and `"datetime.now"` (use `MontyDateTime`) — fixed `externals.dart` comment, but no example | `lib/src/externals.dart`, `example/` | Medium | Open |
+| 4 | `Ellipsis` serialised as plain `"..."` string; upstream `JsonMontyObject` uses `{"$ellipsis":"..."}` to disambiguate from the string literal `"..."` | `native/src/convert.rs`, `lib/src/platform/monty_value.dart` | Low | Open |
+| 5 | `DictPairs.len()` / `DictPairs.is_empty()` not used in `dict_to_json` — minor convert.rs efficiency opportunity | `native/src/convert.rs` | Low | Open |
 
 ## 0.0.12 - Initial Release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@
 ### Upgraded
 - Rust dependency `monty` bumped from `v0.0.12` → `v0.0.14` (Cargo.toml + Cargo.lock)
 
-### Added
+### Added — new public API
 
-- **`OsCallNotHandledException`** (exported from
-  `package:dart_monty_core/dart_monty_core.dart`). Throw from an
-  `OsCallHandler` to signal that the host does not implement the requested
-  OS call. Python sees `NameError: name '<fn>' is not defined` — matching
-  the semantics of an undefined global — instead of the generic
-  `RuntimeError` that `OsCallException` produces. Optional `fnName` field
-  lets the handler override the function name reported to Python.
+- **`OsCallNotHandledException`** (`lib/src/platform/os_call_exception.dart`,
+  re-exported from `package:dart_monty_core/dart_monty_core.dart`). Throw from
+  an `OsCallHandler` to signal that the host does not implement the requested
+  OS call. Python sees `NameError: name '<fn>' is not defined` — matching the
+  semantics of an undefined global — instead of the generic `RuntimeError`
+  that `OsCallException` produces. Optional `fnName` field lets the handler
+  override the function name reported to Python.
   ```dart
   final monty = Monty(osHandler: (op, args, kwargs) async {
     if (op == 'os.getenv') return Platform.environment[args[0] as String];
@@ -22,16 +22,25 @@
   ```
 - **`MontyRepl.resumeNotFound(String fnName)`** — public method on the REPL
   façade; also exposed on `ReplPlatform` for platform-layer callers.
-- **`OsCallHandler` now receives `"date.today"` and `"datetime.now"`** —
-  monty v0.0.14 adds these as explicit OS calls. Hosts return
-  `MontyDate(year, month, day)` for `date.today` and `MontyDateTime(...)`
-  for `datetime.now`. The single positional arg to `datetime.now` carries
-  the timezone as `MontyTimeZone` or `MontyNone`.
+- **`OsCallHandler` now handles `"date.today"` and `"datetime.now"`** — monty
+  v0.0.14 adds these as explicit OS calls. Hosts return `MontyDate(year, month, day)`
+  for `date.today` and `MontyDateTime(...)` for `datetime.now`. The single
+  positional arg to `datetime.now` carries the timezone as `MontyTimeZone` or
+  `MontyNone`.
 
-### Verified
+### Added — internal plumbing
 
-- Oracle conformance holds at 464/464 on all three backends: FFI, dart2js
-  WASM, dart2wasm WASM.
+- `monty_resume_not_found` / `monty_repl_resume_not_found` C FFI exports,
+  matching `ExtFunctionResult::NotFound` in upstream monty
+  (`native/src/handle.rs`, `native/src/repl_handle.rs`, `native/src/lib.rs`,
+  `native/include/dart_monty.h`).
+- `DartMontyBridge.resumeNotFound` / `DartMontyBridge.replResumeNotFound` on
+  the WASM JS bridge (`js/src/bridge.js`, `js/src/worker_src.js`).
+- `resumeNotFound` on the abstract binding contracts: `MontyCoreBindings`,
+  `ReplBindings`, `NativeBindings`, and `WasmBindings` (run + REPL variants).
+- FFI + WASM integration tests for `date.today()` / `datetime.now()` OS calls
+  and for the `OsCallNotHandledException` → `NameError` path
+  (`ffi_datetime_oscall_test.dart`, `wasm_datetime_oscall_test.dart`).
 
 ### What changed upstream (monty v0.0.12 → v0.0.14)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ reactive state, or a richer plugin system, see `dart_monty`.
 
 ```yaml
 dependencies:
-  dart_monty_core: ^0.0.12
+  dart_monty_core: ^0.0.14
 ```
 
 ### FFI (native: macOS · Linux · Windows · iOS · Android)
@@ -404,7 +404,7 @@ are compared. All 464 fixtures must pass.
 
 ```bash
 cd native
-cargo test                                       # 291 unit tests
+cargo test                                       # 314 unit + integration tests
 cargo clippy --all-targets -- -D warnings        # zero warnings
 ```
 
@@ -521,7 +521,7 @@ dart compile wasm test/integration/wasm_runner_wasm.dart -o test/integration/web
 #### Performance Benchmark (464 Fixtures)
 
 Benchmark conducted on an Apple M5 Max (April 2026) using headless Chrome 147.
-Execution time includes the full integration suite (440 passing fixtures).
+Execution time includes the full integration suite (464 passing fixtures).
 
 | Compiler | Passed | Skipped | Failed | Time (ms) |
 | :--- | :--- | :--- | :--- | :--- |
@@ -572,7 +572,7 @@ Some Dart API choices intentionally differ from JS:
 
 ## Native layer
 
-The Rust crate in `native/` wraps `pydantic/monty@v0.0.12` and exposes a
+The Rust crate in `native/` wraps `pydantic/monty@v0.0.14` and exposes a
 C ABI consumed by the FFI binding and compiled to WASM for the web backend.
 Bindings are generated via `ffigen`; regenerate with:
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ compiles the Rust dylib automatically when you run `dart pub get` or
 dart pub get   # triggers cargo build --release for your platform
 ```
 
-### WASM (Flutter Web)
+### WASM (Flutter Web — pub.dev package)
 
 Use [`dart_monty_flutter`](packages/dart_monty_flutter/) which auto-injects
 the JS bridge for you:
@@ -61,6 +61,37 @@ Future<void> main() async {
 are built at publish time and ship in the pub.dev package under `assets/`.
 Flutter serves them automatically at `packages/dart_monty_core/assets/`.
 No npm or Node.js needed by your app.
+
+### WASM (Flutter Web — git dependency)
+
+When depending on `dart_monty_core` via a `git:` or `path:` override, the
+pre-built WASM assets are not included (they are gitignored build artifacts).
+Copy them from the local repository to your Flutter app's `web/` directory
+once, and add a synchronous `<script>` tag so the bridge is ready before
+Flutter's `main()` runs:
+
+```bash
+# From inside your Flutter app directory
+cp /path/to/dart_monty_core/assets/dart_monty_bridge.js web/
+cp /path/to/dart_monty_core/assets/dart_monty_worker.js web/
+cp /path/to/dart_monty_core/assets/dart_monty_native.wasm web/
+```
+
+```html
+<!-- web/index.html — add before flutter_bootstrap.js, without async -->
+<script src="dart_monty_bridge.js"></script>
+<script src="flutter_bootstrap.js" async=""></script>
+```
+
+The synchronous `<script>` sets `window.DartMontyBridge` before Dart starts,
+so `DartMontyFlutter.ensureInitialized()` sees the bridge as already loaded
+and returns immediately without attempting the package-assets path.
+
+To rebuild the artifacts from source (requires Rust + Node.js):
+
+```bash
+cd js && npm install --force && node build.js
+```
 
 ### WASM (plain Dart web, no Flutter)
 

--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -326,6 +326,27 @@ async function resumeWithException(excTypeJson, errorJson) {
 }
 
 /**
+ * Resume a paused OS call by signalling "function not found" — raises
+ * Python `NameError: name '<fnName>' is not defined`.
+ *
+ * @param {string} fnNameJson JSON-encoded function name.
+ * @returns {Promise<string>} JSON result.
+ */
+async function resumeNotFound(fnNameJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+
+  const session = sessions.get(sid);
+  const fnName = JSON.parse(fnNameJson);
+  const result = await callWorker(
+    sid,
+    { type: 'resumeNotFound', fnName },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
+/**
  * Resume by creating a future for the pending external function call.
  *
  * @returns {Promise<string>} JSON result with state: pending, resolve_futures, or complete.
@@ -620,6 +641,19 @@ async function replResumeWithError(replId, errorJson) {
   return JSON.stringify(result);
 }
 
+async function replResumeNotFound(replId, fnNameJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const fnName = JSON.parse(fnNameJson);
+  const result = await callWorker(
+    sid,
+    { type: 'replResumeNotFound', replId, fnName },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
 async function replDetectContinuation(source) {
   const sid = resolveSessionId(null);
   if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -678,6 +712,7 @@ window.DartMontyBridge = {
   resume,
   resumeWithError,
   resumeWithException,
+  resumeNotFound,
   resumeAsFuture,
   resolveFutures,
   resumeNameLookupValue,
@@ -701,6 +736,7 @@ window.DartMontyBridge = {
   replSetExtFns,
   replResume,
   replResumeWithError,
+  replResumeNotFound,
   replDetectContinuation,
   replDispose,
   replSnapshot,

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -594,6 +594,57 @@ function handleResumeWithException(id, excType, errorMessage) {
   self.postMessage(msg);
 }
 
+function handleResumeNotFound(id, fnName) {
+  if (!activeHandle) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: 'No active handle to resume.',
+      errorType: 'StateError',
+    });
+    return;
+  }
+
+  let cFnName = null;
+  let outErr = null;
+
+  let tag;
+  try {
+    cFnName = allocCString(fnName);
+    outErr = allocOutPtr();
+    tag = wasm.monty_resume_not_found(activeHandle, cFnName.ptr, outErr.ptr);
+  } catch (e) {
+    if (cFnName) wasm.monty_dealloc(cFnName.ptr, cFnName.size);
+    if (outErr) outErr.free();
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  }
+  wasm.monty_dealloc(cFnName.ptr, cFnName.size);
+
+  const errPtr = outErr.read();
+  const errMsg = readAndFreeCString(errPtr);
+  outErr.free();
+
+  let msg;
+  try {
+    msg = readProgress(id, activeHandle, tag, errMsg, SESSION_PROGRESS);
+  } catch (e) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+    throw e;
+  }
+  if (tag === PROGRESS_COMPLETE || tag === PROGRESS_ERROR) {
+    wasm.monty_free(activeHandle);
+    activeHandle = null;
+  }
+  self.postMessage(msg);
+}
+
 function handleResumeAsFuture(id) {
   if (!activeHandle) {
     self.postMessage({
@@ -1345,6 +1396,28 @@ function handleReplResumeWithError(id, replId, errorMessage) {
   }
 }
 
+function handleReplResumeNotFound(id, replId, fnName) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({ type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`, errorType: 'StateError' });
+    return;
+  }
+  let cFnName = null;
+  let outError = null;
+  try {
+    cFnName = allocCString(fnName);
+    outError = allocOutPtr();
+    const tag = wasm.monty_repl_resume_not_found(handle, cFnName.ptr, outError.ptr);
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (cFnName) wasm.monty_dealloc(cFnName.ptr, cFnName.size);
+    if (outError) outError.free();
+  }
+}
+
 function handleReplDetectContinuation(id, source) {
   let cSource = null;
   try {
@@ -1479,7 +1552,7 @@ function handleReplRestore(id, replId, dataBase64) {
 // ---------------------------------------------------------------------------
 
 self.onmessage = (e) => {
-  const { type, id, code, extFns, value, errorMessage, excType, limits,
+  const { type, id, code, extFns, value, errorMessage, excType, fnName, limits,
     dataBase64, scriptName, resultsJson, errorsJson, valueJson, source,
     replId } = e.data;
   try {
@@ -1498,6 +1571,9 @@ self.onmessage = (e) => {
         break;
       case 'resumeWithException':
         handleResumeWithException(id, excType, errorMessage);
+        break;
+      case 'resumeNotFound':
+        handleResumeNotFound(id, fnName);
         break;
       case 'resumeAsFuture':
         handleResumeAsFuture(id);
@@ -1546,6 +1622,9 @@ self.onmessage = (e) => {
         break;
       case 'replResumeWithError':
         handleReplResumeWithError(id, replId, errorMessage);
+        break;
+      case 'replResumeNotFound':
+        handleReplResumeNotFound(id, replId, fnName);
         break;
       case 'replDetectContinuation':
         handleReplDetectContinuation(id, source);

--- a/lib/src/externals.dart
+++ b/lib/src/externals.dart
@@ -1,3 +1,4 @@
+import 'package:dart_monty_core/src/platform/monty_value.dart';
 import 'package:dart_monty_core/src/platform/os_call_exception.dart';
 
 export 'package:dart_monty_core/src/platform/os_call_exception.dart';
@@ -13,8 +14,11 @@ typedef MontyCallback = Future<Object?> Function(Map<String, Object?> args);
 /// environment, datetime).
 ///
 /// [operation] is the dotted operation name, e.g. `"Path.read_text"`,
-/// `"os.getenv"`, `"datetime.now"`.
+/// `"os.getenv"`, `"datetime.now"`, `"date.today"`.
 /// [args] and [kwargs] are the positional and keyword arguments.
+///
+/// For `"date.today"`, return a [MontyDate] with the current date.
+/// For `"datetime.now"`, return a [MontyDateTime] with the current date/time.
 ///
 /// Throw an [OsCallException] to raise a Python exception from the handler.
 /// Return `null` to return `None` to Python.

--- a/lib/src/ffi/ffi_core_bindings.dart
+++ b/lib/src/ffi/ffi_core_bindings.dart
@@ -134,6 +134,14 @@ class FfiCoreBindings implements MontyCoreBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeNotFound(String fnName) async {
+    final handle = _requireHandle('resumeNotFound');
+    final progress = _bindings.resumeNotFound(handle, fnName);
+
+    return _translateProgressResult(handle, progress);
+  }
+
+  @override
   Future<CoreProgressResult> resumeAsFuture() async {
     final handle = _requireHandle('resumeAsFuture');
     final progress = _bindings.resumeAsFuture(handle);

--- a/lib/src/ffi/generated/dart_monty_bindings.dart
+++ b/lib/src/ffi/generated/dart_monty_bindings.dart
@@ -199,6 +199,43 @@ MontyProgressTag monty_resume_with_exception(
   ),
 );
 
+/// Resume execution signalling "function not found" — raises NameError
+/// in Python.
+///
+/// Use this when the host can't dispatch the requested OS call (e.g. the
+/// operation name is unknown) and wants Python to see the same error it
+/// would for an undefined global, not a RuntimeError.
+///
+/// @param handle     Handle in PENDING or OS_CALL state.
+/// @param fn_name    NUL-terminated name of the missing function; embedded
+/// in the NameError message.
+/// @param out_error  Receives FFI error message on failure. Caller frees.
+/// @return           MONTY_PROGRESS_COMPLETE, _PENDING, or _ERROR.
+@ffi.Native<
+  ffi.UnsignedInt Function(
+    ffi.Pointer<MontyHandle>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+  )
+>(symbol: 'monty_resume_not_found')
+external int _monty_resume_not_found(
+  ffi.Pointer<MontyHandle> handle,
+  ffi.Pointer<ffi.Char> fn_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+);
+
+MontyProgressTag monty_resume_not_found(
+  ffi.Pointer<MontyHandle> handle,
+  ffi.Pointer<ffi.Char> fn_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+) => MontyProgressTag.fromValue(
+  _monty_resume_not_found(
+    handle,
+    fn_name,
+    out_error,
+  ),
+);
+
 /// Resume by creating a future (tells the VM this call returns a future).
 /// Only valid when handle is in PENDING state.
 ///
@@ -653,6 +690,33 @@ MontyProgressTag monty_repl_resume_with_error(
   _monty_repl_resume_with_error(
     handle,
     error_message,
+    out_error,
+  ),
+);
+
+/// Resume REPL execution signalling "function not found" — raises
+/// NameError in Python.
+@ffi.Native<
+  ffi.UnsignedInt Function(
+    ffi.Pointer<MontyReplHandle>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+  )
+>(symbol: 'monty_repl_resume_not_found')
+external int _monty_repl_resume_not_found(
+  ffi.Pointer<MontyReplHandle> handle,
+  ffi.Pointer<ffi.Char> fn_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+);
+
+MontyProgressTag monty_repl_resume_not_found(
+  ffi.Pointer<MontyReplHandle> handle,
+  ffi.Pointer<ffi.Char> fn_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+) => MontyProgressTag.fromValue(
+  _monty_repl_resume_not_found(
+    handle,
+    fn_name,
     out_error,
   ),
 );

--- a/lib/src/ffi/native_bindings.dart
+++ b/lib/src/ffi/native_bindings.dart
@@ -121,6 +121,9 @@ abstract class NativeBindings {
     String errorMessage,
   );
 
+  /// Resumes signalling "function not found" (raises NameError in Python).
+  ProgressResult resumeNotFound(int handle, String fnName);
+
   /// Resumes by creating a future for the pending call.
   ProgressResult resumeAsFuture(int handle);
 
@@ -190,6 +193,9 @@ abstract class NativeBindings {
 
   /// Resumes REPL execution with an error (raises RuntimeError in Python).
   ProgressResult replResumeWithError(int handle, String errorMessage);
+
+  /// Resumes REPL execution signalling "function not found" (raises NameError).
+  ProgressResult replResumeNotFound(int handle, String fnName);
 
   /// Resumes REPL by creating a future for the pending call.
   ProgressResult replResumeAsFuture(int handle);

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -170,6 +170,23 @@ class NativeBindingsFfi extends NativeBindings {
   }
 
   @override
+  ProgressResult resumeNotFound(int handle, String fnName) {
+    final ptr = Pointer<ffi_native.MontyHandle>.fromAddress(handle);
+    final cName = fnName.toNativeUtf8().cast<Char>();
+    final outError = calloc<Pointer<Char>>();
+
+    try {
+      final tag = ffi_native.monty_resume_not_found(ptr, cName, outError);
+
+      return _buildProgressResult(ptr, tag, outError.value);
+    } finally {
+      calloc
+        ..free(cName)
+        ..free(outError);
+    }
+  }
+
+  @override
   ProgressResult resumeAsFuture(int handle) {
     final ptr = Pointer<ffi_native.MontyHandle>.fromAddress(handle);
     final outError = calloc<Pointer<Char>>();
@@ -424,6 +441,27 @@ class NativeBindingsFfi extends NativeBindings {
     } finally {
       calloc
         ..free(cError)
+        ..free(outError);
+    }
+  }
+
+  @override
+  ProgressResult replResumeNotFound(int handle, String fnName) {
+    final ptr = Pointer<ffi_native.MontyReplHandle>.fromAddress(handle);
+    final cName = fnName.toNativeUtf8().cast<Char>();
+    final outError = calloc<Pointer<Char>>();
+
+    try {
+      final tag = ffi_native.monty_repl_resume_not_found(
+        ptr,
+        cName,
+        outError,
+      );
+
+      return _buildReplProgressResult(ptr, tag, outError.value);
+    } finally {
+      calloc
+        ..free(cName)
         ..free(outError);
     }
   }

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -187,6 +187,20 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }
 
   @override
+  Future<MontyProgress> resumeNotFound(String fnName) async {
+    assertNotDisposed('resumeNotFound');
+    assertActive('resumeNotFound');
+    try {
+      final progress = await _bindings.resumeNotFound(fnName);
+
+      return translateProgress(progress);
+    } catch (e) {
+      markIdle();
+      rethrow;
+    }
+  }
+
+  @override
   Future<Uint8List> compileCode(String code) async {
     assertNotDisposed('compileCode');
     await _ensureInitialized();

--- a/lib/src/platform/core_bindings.dart
+++ b/lib/src/platform/core_bindings.dart
@@ -200,6 +200,12 @@ abstract class MontyCoreBindings {
     String errorMessage,
   );
 
+  /// Resumes execution signalling "function not found" — Python sees NameError.
+  ///
+  /// Used when the host cannot dispatch an OS call; [fnName] is embedded in
+  /// the resulting Python NameError message.
+  Future<CoreProgressResult> resumeNotFound(String fnName);
+
   /// Resumes execution, converting the pending call into a future.
   Future<CoreProgressResult> resumeAsFuture();
 

--- a/lib/src/platform/monty_platform.dart
+++ b/lib/src/platform/monty_platform.dart
@@ -71,6 +71,13 @@ abstract class MontyPlatform {
     throw UnimplementedError('resumeWithException() has not been implemented.');
   }
 
+  /// Resumes a paused execution signalling "function not found" — the VM
+  /// raises NameError. Use this when the host does not handle the requested
+  /// operation, matching Python's behavior for undefined globals.
+  Future<MontyProgress> resumeNotFound(String fnName) {
+    throw UnimplementedError('resumeNotFound() has not been implemented.');
+  }
+
   /// Resumes a name lookup by providing [value] for [name].
   Future<MontyProgress> resumeNameLookup(String name, Object? value) {
     throw UnimplementedError('resumeNameLookup() has not been implemented.');

--- a/lib/src/platform/os_call_exception.dart
+++ b/lib/src/platform/os_call_exception.dart
@@ -18,3 +18,27 @@ final class OsCallException implements Exception {
   @override
   String toString() => 'OsCallException($message)';
 }
+
+/// Thrown by an `OsCallHandler` to signal that the host does not implement
+/// the requested OS call.
+///
+/// Python sees a `NameError: name '<fn>' is not defined` — the same error it
+/// would raise for an undefined global. Prefer this over [OsCallException]
+/// when the host simply isn't wired up to handle the operation, so scripts
+/// can distinguish "not installed" from "failed".
+final class OsCallNotHandledException implements Exception {
+  /// Creates an [OsCallNotHandledException].
+  ///
+  /// [fnName] is optional; when omitted, the runtime falls back to the
+  /// operation name of the pending OS call.
+  const OsCallNotHandledException([this.fnName]);
+
+  /// Optional override for the function name embedded in the NameError.
+  /// Defaults to the pending OS call's operation name.
+  final String? fnName;
+
+  @override
+  String toString() => fnName == null
+      ? 'OsCallNotHandledException()'
+      : 'OsCallNotHandledException($fnName)';
+}

--- a/lib/src/repl/ffi_repl_bindings.dart
+++ b/lib/src/repl/ffi_repl_bindings.dart
@@ -135,6 +135,17 @@ class FfiReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeNotFound(String fnName) async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = _bindings.replResumeNotFound(handle, fnName);
+
+    return _translateProgressResult(result);
+  }
+
+  @override
   Future<CoreProgressResult> resumeNameLookupUndefined() {
     throw UnimplementedError(
       'resumeNameLookupUndefined is not supported by the FFI REPL backend',

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -225,6 +225,14 @@ class MontyRepl {
     return _translateProgress(await _bindings.resumeWithError(errorMessage));
   }
 
+  /// Resumes a paused OS call by signalling that the host does not handle
+  /// [fnName]. Python raises `NameError: name '<fnName>' is not defined`.
+  Future<MontyProgress> resumeNotFound(String fnName) async {
+    _checkNotDisposed();
+
+    return _translateProgress(await _bindings.resumeNotFound(fnName));
+  }
+
   // ---------------------------------------------------------------------------
   // Continuation detection
   // ---------------------------------------------------------------------------
@@ -368,6 +376,10 @@ class MontyRepl {
 
       return _translateProgress(
         await _bindings.resume(jsonEncode(result)),
+      );
+    } on OsCallNotHandledException catch (e) {
+      return _translateProgress(
+        await _bindings.resumeNotFound(e.fnName ?? call.operationName),
       );
     } on OsCallException catch (e) {
       return _translateProgress(

--- a/lib/src/repl/repl_bindings.dart
+++ b/lib/src/repl/repl_bindings.dart
@@ -32,6 +32,12 @@ abstract class ReplBindings {
   /// Resumes by raising an error in Python.
   Future<CoreProgressResult> resumeWithError(String errorMessage);
 
+  /// Resumes by signalling "function not found" — Python sees NameError.
+  ///
+  /// Used when the host cannot dispatch an OS call; [fnName] is embedded in
+  /// the resulting Python NameError message.
+  Future<CoreProgressResult> resumeNotFound(String fnName);
+
   /// Resumes a name lookup by indicating the name is undefined.
   ///
   /// The engine raises NameError.

--- a/lib/src/repl/repl_platform.dart
+++ b/lib/src/repl/repl_platform.dart
@@ -57,6 +57,10 @@ class ReplPlatform implements MontyPlatform {
       _repl.resumeWithError(errorMessage);
 
   @override
+  Future<MontyProgress> resumeNotFound(String fnName) =>
+      _repl.resumeNotFound(fnName);
+
+  @override
   Future<MontyProgress> resumeNameLookup(String name, Object? value) =>
       throw UnsupportedError('NameLookup not supported by ReplPlatform');
 

--- a/lib/src/repl/wasm_repl_bindings.dart
+++ b/lib/src/repl/wasm_repl_bindings.dart
@@ -94,6 +94,20 @@ class WasmReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeNotFound(String fnName) async {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final fnNameJson = json.encode(fnName);
+    final result = await _bindings.replResumeNotFound(
+      fnNameJson,
+      replId: _replId,
+    );
+
+    return _translateWasmProgressResult(result);
+  }
+
+  @override
   Future<CoreProgressResult> resumeNameLookupUndefined() async {
     if (!_created) {
       throw StateError('REPL not created. Call create() first.');

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -238,6 +238,16 @@ abstract class WasmBindings {
     int? sessionId,
   });
 
+  /// Resumes signalling "function not found" — raises Python NameError.
+  ///
+  /// [fnName] is embedded in the resulting NameError message.
+  /// When [sessionId] is non-null, routes to that specific session instead of
+  /// the default.
+  Future<WasmProgressResult> resumeNotFound(
+    String fnName, {
+    int? sessionId,
+  });
+
   /// Resumes by creating a future for the pending call.
   ///
   /// Returns a progress result which may be `pending` (next call),
@@ -407,6 +417,20 @@ abstract class WasmBindings {
   /// the default.
   Future<WasmProgressResult> replResumeWithError(
     String errorJson, {
+    int? sessionId,
+    String? replId,
+  });
+
+  /// Resumes REPL execution signalling "function not found" — raises Python
+  /// NameError.
+  ///
+  /// [fnNameJson] is the JSON-encoded function name embedded in the error.
+  /// [replId] must match the value passed to [replCreate].
+  ///
+  /// When [sessionId] is non-null, routes to that specific session instead of
+  /// the default.
+  Future<WasmProgressResult> replResumeNotFound(
+    String fnNameJson, {
     int? sessionId,
     String? replId,
   });

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -65,6 +65,12 @@ external JSPromise<JSString> _jsResumeWithException(
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.resumeNotFound')
+external JSPromise<JSString> _jsResumeNotFound(
+  JSString fnNameJson, [
+  JSNumber? sessionId,
+]);
+
 @JS('DartMontyBridge.resumeAsFuture')
 external JSPromise<JSString> _jsResumeAsFuture([JSNumber? sessionId]);
 
@@ -167,6 +173,13 @@ external JSPromise<JSString> _jsReplResume(
 external JSPromise<JSString> _jsReplResumeWithError(
   JSString replId,
   JSString errorJson, [
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.replResumeNotFound')
+external JSPromise<JSString> _jsReplResumeNotFound(
+  JSString replId,
+  JSString fnNameJson, [
   JSNumber? sessionId,
 ]);
 
@@ -310,6 +323,20 @@ class WasmBindingsJs extends WasmBindings {
     final resultJson = await _jsResumeWithException(
       excTypeJson.toJS,
       errorJson.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> resumeNotFound(
+    String fnName, {
+    int? sessionId,
+  }) async {
+    final fnNameJson = json.encode(fnName);
+    final resultJson = await _jsResumeNotFound(
+      fnNameJson.toJS,
       sessionId?.toJS,
     ).toDart;
 
@@ -595,6 +622,21 @@ class WasmBindingsJs extends WasmBindings {
     final resultJson = await _jsReplResumeWithError(
       (replId ?? 'default').toJS,
       errorJson.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> replResumeNotFound(
+    String fnNameJson, {
+    int? sessionId,
+    String? replId,
+  }) async {
+    final resultJson = await _jsReplResumeNotFound(
+      (replId ?? 'default').toJS,
+      fnNameJson.toJS,
       sessionId?.toJS,
     ).toDart;
 

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -63,6 +63,12 @@ class WasmBindingsJs extends WasmBindings {
   }) => throw UnimplementedError();
 
   @override
+  Future<WasmProgressResult> resumeNotFound(
+    String fnName, {
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
   Future<WasmProgressResult> resumeAsFuture({int? sessionId}) =>
       throw UnimplementedError();
 
@@ -155,6 +161,13 @@ class WasmBindingsJs extends WasmBindings {
   @override
   Future<WasmProgressResult> replResumeWithError(
     String errorJson, {
+    int? sessionId,
+    String? replId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> replResumeNotFound(
+    String fnNameJson, {
     int? sessionId,
     String? replId,
   }) => throw UnimplementedError();

--- a/lib/src/wasm/wasm_core_bindings.dart
+++ b/lib/src/wasm/wasm_core_bindings.dart
@@ -114,6 +114,18 @@ class WasmCoreBindings implements MontyCoreBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeNotFound(String fnName) async {
+    final sw = Stopwatch()..start();
+    final progress = await _bindings.resumeNotFound(
+      fnName,
+      sessionId: _sessionId,
+    );
+    sw.stop();
+
+    return _translateProgressResult(progress, sw.elapsedMilliseconds);
+  }
+
+  @override
   Future<CoreProgressResult> resumeAsFuture() async {
     final sw = Stopwatch()..start();
     final progress = await _bindings.resumeAsFuture(sessionId: _sessionId);

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dart_monty_native"
-version = "0.0.12"
+version = "0.0.14"
 edition = "2024"
 license = "MIT"
 publish = false
@@ -14,7 +14,7 @@ name = "dart_monty_native"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.12" }
+monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.14" }
 num-bigint = "0.4"
 num-traits = "0.2"
 serde_json = "1"

--- a/native/include/dart_monty.h
+++ b/native/include/dart_monty.h
@@ -140,6 +140,24 @@ MontyProgressTag monty_resume_with_exception(MontyHandle *handle,
                                              const char *error_message,
                                              char **out_error);
 
+/**
+ * Resume execution signalling "function not found" — raises NameError
+ * in Python.
+ *
+ * Use this when the host can't dispatch the requested OS call (e.g. the
+ * operation name is unknown) and wants Python to see the same error it
+ * would for an undefined global, not a RuntimeError.
+ *
+ * @param handle     Handle in PENDING or OS_CALL state.
+ * @param fn_name    NUL-terminated name of the missing function; embedded
+ *                   in the NameError message.
+ * @param out_error  Receives FFI error message on failure. Caller frees.
+ * @return           MONTY_PROGRESS_COMPLETE, _PENDING, or _ERROR.
+ */
+MontyProgressTag monty_resume_not_found(MontyHandle *handle,
+                                        const char *fn_name,
+                                        char **out_error);
+
 /* ------------------------------------------------------------------ */
 /* Async / Futures                                                    */
 /* ------------------------------------------------------------------ */
@@ -422,6 +440,14 @@ MontyProgressTag monty_repl_resume(MontyReplHandle *handle,
 MontyProgressTag monty_repl_resume_with_error(MontyReplHandle *handle,
                                                const char *error_message,
                                                char **out_error);
+
+/**
+ * Resume REPL execution signalling "function not found" — raises
+ * NameError in Python.
+ */
+MontyProgressTag monty_repl_resume_not_found(MontyReplHandle *handle,
+                                              const char *fn_name,
+                                              char **out_error);
 
 /** Resume REPL by creating a future for the pending call. */
 MontyProgressTag monty_repl_resume_as_future(MontyReplHandle *handle,

--- a/native/src/handle.rs
+++ b/native/src/handle.rs
@@ -236,6 +236,17 @@ impl MontyHandle {
         self.resume_with_result(result)
     }
 
+    /// Resume by signalling "function not found".
+    ///
+    /// The VM raises `NameError: name '<fn_name>' is not defined`, matching
+    /// Python semantics when a callable genuinely does not exist. Hosts use
+    /// this when they can't dispatch the OS call and want the Python script
+    /// to see a `NameError` rather than a `RuntimeError`.
+    pub fn resume_not_found(&mut self, fn_name: &str) -> (MontyProgressTag, Option<String>) {
+        let result = ExtFunctionResult::NotFound(fn_name.to_string());
+        self.resume_with_result(result)
+    }
+
     /// Resume by creating a future (tells the VM this call returns a future).
     ///
     /// The VM continues executing until all coroutines are blocked, then
@@ -1480,5 +1491,50 @@ outer()
 
         let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
         assert_eq!(result["value"], "limited_response");
+    }
+
+    // --- NotFound (resume_not_found) ---
+
+    #[test]
+    fn test_resume_not_found_raises_name_error() {
+        let code = "ext_fn(1)";
+        let mut handle = MontyHandle::new(code.into(), vec!["ext_fn".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = handle.resume_not_found("ext_fn");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert_eq!(handle.complete_is_error(), Some(true));
+
+        let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["error"]["exc_type"], "NameError");
+        assert!(
+            result["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("ext_fn")
+        );
+    }
+
+    #[test]
+    fn test_resume_not_found_caught_as_name_error() {
+        let code = "try:\n    ext_fn(1)\nexcept NameError as e:\n    result = 'caught'\nresult";
+        let mut handle = MontyHandle::new(code.into(), vec!["ext_fn".into()], None).unwrap();
+        let (tag, _) = handle.start();
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = handle.resume_not_found("ext_fn");
+        assert_eq!(tag, MontyProgressTag::Complete);
+
+        let result: Value = serde_json::from_str(handle.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["value"], "caught");
+    }
+
+    #[test]
+    fn test_resume_not_found_wrong_state() {
+        let mut handle = MontyHandle::new("2 + 2".into(), vec![], None).unwrap();
+        let (tag, err) = handle.resume_not_found("any");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.is_some());
     }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -277,6 +277,24 @@ pub unsafe extern "C" fn monty_resume_with_exception(
         .resume_with_exception(exc_type_str, msg))
 }
 
+/// Resume execution signalling "function not found" (raises NameError in Python).
+///
+/// - `fn_name`: NUL-terminated name of the missing function (used in the
+///   Python `NameError` message).
+/// - `out_error`: receives an error message on FFI failure (caller frees).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monty_resume_not_found(
+    handle: *mut MontyHandle,
+    fn_name: *const c_char,
+    out_error: *mut *mut c_char,
+) -> MontyProgressTag {
+    // SAFETY: fn_name is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
+    let Ok(name) = (unsafe { parse_c_str(fn_name, "fn_name", out_error) }) else {
+        return MontyProgressTag::Error;
+    };
+    ffi_progress!(handle, out_error, |h| h.resume_not_found(name))
+}
+
 // ---------------------------------------------------------------------------
 // Async / Futures
 // ---------------------------------------------------------------------------
@@ -999,6 +1017,48 @@ pub unsafe extern "C" fn monty_repl_resume_with_error(
     // SAFETY: handle is non-null (just checked), created by monty_repl_create via Box::into_raw
     let h = unsafe { &mut *handle };
     match catch_ffi_panic(|| h.resume_with_error(msg_str)) {
+        Ok((tag, err)) => {
+            if !out_error.is_null() {
+                match err {
+                    // SAFETY: out_error is non-null (just checked), writing error message string
+                    Some(ref msg) => unsafe { *out_error = to_c_string(msg) },
+                    // SAFETY: out_error is non-null (just checked), clearing error to indicate success
+                    None => unsafe { *out_error = ptr::null_mut() },
+                }
+            }
+            tag
+        }
+        Err(panic_msg) => {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing panic message string
+                unsafe { *out_error = to_c_string(&panic_msg) };
+            }
+            MontyProgressTag::Error
+        }
+    }
+}
+
+/// Resume REPL execution signalling "function not found" (raises NameError in Python).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monty_repl_resume_not_found(
+    handle: *mut MontyReplHandle,
+    fn_name: *const c_char,
+    out_error: *mut *mut c_char,
+) -> MontyProgressTag {
+    if handle.is_null() {
+        if !out_error.is_null() {
+            // SAFETY: out_error is non-null (just checked), Dart caller provides a valid writable pointer
+            unsafe { *out_error = to_c_string("handle is NULL") };
+        }
+        return MontyProgressTag::Error;
+    }
+    // SAFETY: fn_name is a NUL-terminated C string from Dart FFI; parse_c_str validates non-null
+    let Ok(name) = (unsafe { parse_c_str(fn_name, "fn_name", out_error) }) else {
+        return MontyProgressTag::Error;
+    };
+    // SAFETY: handle is non-null (just checked), created by monty_repl_create via Box::into_raw
+    let h = unsafe { &mut *handle };
+    match catch_ffi_panic(|| h.resume_not_found(name)) {
         Ok((tag, err)) => {
             if !out_error.is_null() {
                 match err {

--- a/native/src/repl_handle.rs
+++ b/native/src/repl_handle.rs
@@ -298,6 +298,48 @@ impl MontyReplHandle {
         }
     }
 
+    /// Resume by signalling "function not found".
+    ///
+    /// Raises `NameError: name '<fn_name>' is not defined` in Python. Used
+    /// when the host can't dispatch an OS call — Python sees the same error
+    /// it would for a missing global, instead of a generic `RuntimeError`.
+    pub fn resume_not_found(&mut self, fn_name: &str) -> (MontyProgressTag, Option<String>) {
+        let state = std::mem::replace(&mut self.state, ReplHandleState::Consumed);
+        match state {
+            ReplHandleState::Paused { call, .. } => {
+                let mut buf = String::new();
+                let result = call.resume(
+                    ExtFunctionResult::NotFound(fn_name.to_string()),
+                    PrintWriter::CollectString(&mut buf),
+                );
+                self.print_output.push_str(&buf);
+                match result {
+                    Ok(progress) => self.process_repl_progress(progress),
+                    Err(err) => self.handle_repl_start_error(*err),
+                }
+            }
+            ReplHandleState::OsCall { call, .. } => {
+                let mut buf = String::new();
+                let result = call.resume(
+                    ExtFunctionResult::NotFound(fn_name.to_string()),
+                    PrintWriter::CollectString(&mut buf),
+                );
+                self.print_output.push_str(&buf);
+                match result {
+                    Ok(progress) => self.process_repl_progress(progress),
+                    Err(err) => self.handle_repl_start_error(*err),
+                }
+            }
+            other => {
+                self.state = other;
+                (
+                    MontyProgressTag::Error,
+                    Some("handle not in Paused or OsCall state".into()),
+                )
+            }
+        }
+    }
+
     /// Resume by converting the pending call into a future.
     pub fn resume_as_future(&mut self) -> (MontyProgressTag, Option<String>) {
         let state = std::mem::replace(&mut self.state, ReplHandleState::Consumed);
@@ -1134,6 +1176,52 @@ mod tests {
     // -----------------------------------------------------------------------
     // Async future path
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn resume_not_found_raises_name_error() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["missing_fn".into()]);
+        let (tag, _) = repl.feed_start("missing_fn(1)");
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = repl.resume_not_found("missing_fn");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert_eq!(repl.complete_is_error(), Some(true));
+
+        let result: serde_json::Value =
+            serde_json::from_str(repl.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["error"]["exc_type"], "NameError");
+        assert!(
+            result["error"]["message"]
+                .as_str()
+                .unwrap()
+                .contains("missing_fn")
+        );
+    }
+
+    #[test]
+    fn resume_not_found_caught_in_python() {
+        let mut repl = MontyReplHandle::new("test.py");
+        repl.set_ext_fns(vec!["missing_fn".into()]);
+        let (tag, _) = repl.feed_start(
+            "try:\n    missing_fn()\nexcept NameError as e:\n    result = 'caught'\nresult",
+        );
+        assert_eq!(tag, MontyProgressTag::Pending);
+
+        let (tag, _) = repl.resume_not_found("missing_fn");
+        assert_eq!(tag, MontyProgressTag::Complete);
+        let result: serde_json::Value =
+            serde_json::from_str(repl.complete_result_json().unwrap()).unwrap();
+        assert_eq!(result["value"], "caught");
+    }
+
+    #[test]
+    fn resume_not_found_wrong_state() {
+        let mut repl = MontyReplHandle::new("test.py");
+        let (tag, err) = repl.resume_not_found("foo");
+        assert_eq!(tag, MontyProgressTag::Error);
+        assert!(err.is_some());
+    }
 
     #[test]
     fn resume_as_future_then_resolve() {

--- a/native/tests/integration.rs
+++ b/native/tests/integration.rs
@@ -1459,3 +1459,90 @@ fn free_null_is_noop() {
     // NULL has always been safe, but verify it still is.
     unsafe { monty_free(ptr::null_mut()) };
 }
+
+// ---------------------------------------------------------------------------
+// OS call: date.today round-trip via C FFI
+//
+// Covers monty v0.0.14 addition of OsFunction::DateToday. The host receives
+// OsCall("date.today") and resumes with a __type=date JSON object; the crate
+// reconstructs it into a MontyDate and the assertion `isinstance(r, date)`
+// passes inside Python.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn os_call_date_today_round_trip() {
+    let code = c("import datetime\n\
+         r = datetime.date.today()\n\
+         assert isinstance(r, datetime.date)\n\
+         r");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let handle = unsafe { monty_create(code.as_ptr(), ptr::null(), ptr::null(), &mut out_error) };
+    assert!(!handle.is_null());
+
+    let tag = unsafe { monty_start(handle, &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::OsCall);
+
+    let fn_name_ptr = unsafe { monty_os_call_fn_name(handle) };
+    let fn_name = unsafe { read_c_string(fn_name_ptr) };
+    assert_eq!(fn_name, "date.today");
+
+    let resume_value = c(r#"{"__type":"date","year":2024,"month":1,"day":15}"#);
+    let tag = unsafe { monty_resume(handle, resume_value.as_ptr(), &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+    assert_eq!(unsafe { monty_complete_is_error(handle) }, 0);
+
+    let result_ptr = unsafe { monty_complete_result_json(handle) };
+    let result_str = unsafe { read_c_string(result_ptr) };
+    let result: serde_json::Value = serde_json::from_str(&result_str).unwrap();
+    assert_eq!(result["value"]["__type"], "date");
+    assert_eq!(result["value"]["year"], 2024);
+    assert_eq!(result["value"]["month"], 1);
+    assert_eq!(result["value"]["day"], 15);
+
+    unsafe { monty_free(handle) };
+}
+
+// ---------------------------------------------------------------------------
+// OS call: datetime.now (naive) round-trip via C FFI
+//
+// Covers monty v0.0.14 addition of OsFunction::DateTimeNow. The naive case
+// passes MontyNone as the single positional tz argument and expects a
+// MontyDateTime with offset_seconds = null and timezone_name = null.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn os_call_datetime_now_naive_round_trip() {
+    let code = c("import datetime\n\
+         r = datetime.datetime.now()\n\
+         assert isinstance(r, datetime.datetime)\n\
+         assert r.tzinfo is None\n\
+         r");
+    let mut out_error: *mut c_char = ptr::null_mut();
+    let handle = unsafe { monty_create(code.as_ptr(), ptr::null(), ptr::null(), &mut out_error) };
+    assert!(!handle.is_null());
+
+    let tag = unsafe { monty_start(handle, &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::OsCall);
+
+    let fn_name_ptr = unsafe { monty_os_call_fn_name(handle) };
+    let fn_name = unsafe { read_c_string(fn_name_ptr) };
+    assert_eq!(fn_name, "datetime.now");
+
+    let resume_value = c(
+        r#"{"__type":"datetime","year":2024,"month":1,"day":15,"hour":10,"minute":30,"second":0,"microsecond":0}"#,
+    );
+    let tag = unsafe { monty_resume(handle, resume_value.as_ptr(), &mut out_error) };
+    assert_eq!(tag, MontyProgressTag::Complete);
+    assert_eq!(unsafe { monty_complete_is_error(handle) }, 0);
+
+    let result_ptr = unsafe { monty_complete_result_json(handle) };
+    let result_str = unsafe { read_c_string(result_ptr) };
+    let result: serde_json::Value = serde_json::from_str(&result_str).unwrap();
+    assert_eq!(result["value"]["__type"], "datetime");
+    assert_eq!(result["value"]["year"], 2024);
+    assert_eq!(result["value"]["hour"], 10);
+    assert!(result["value"]["offset_seconds"].is_null());
+    assert!(result["value"]["timezone_name"].is_null());
+
+    unsafe { monty_free(handle) };
+}

--- a/test/integration/ffi_datetime_oscall_test.dart
+++ b/test/integration/ffi_datetime_oscall_test.dart
@@ -139,5 +139,48 @@ void main() {
       expect(result.error, isNull);
       expect(result.value, const MontyBool(true));
     });
+
+    test(
+      'OsCallNotHandledException surfaces Python NameError (not RuntimeError)',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        OsCallHandler notHandled() =>
+            (op, args, kwargs) async => throw const OsCallNotHandledException();
+
+        await repl.feed('import datetime', osHandler: notHandled());
+        final error = await repl
+            .feed('datetime.date.today()', osHandler: notHandled())
+            .then<MontyScriptError?>((_) => null)
+            .catchError((Object e) => e as MontyScriptError?);
+
+        expect(error, isNotNull);
+        expect(error?.excType, 'NameError');
+        expect(error?.message, contains('date.today'));
+      },
+    );
+
+    test(
+      'OsCallException surfaces Python RuntimeError (contrast with NameError)',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        OsCallHandler alwaysFails() =>
+            (op, args, kwargs) async =>
+                throw const OsCallException('handler refused');
+
+        await repl.feed('import datetime', osHandler: alwaysFails());
+        final error = await repl
+            .feed('datetime.date.today()', osHandler: alwaysFails())
+            .then<MontyScriptError?>((_) => null)
+            .catchError((Object e) => e as MontyScriptError?);
+
+        expect(error, isNotNull);
+        expect(error?.excType, 'RuntimeError');
+        expect(error?.message, contains('handler refused'));
+      },
+    );
   });
 }

--- a/test/integration/ffi_datetime_oscall_test.dart
+++ b/test/integration/ffi_datetime_oscall_test.dart
@@ -1,0 +1,143 @@
+// Integration tests: date.today / datetime.now OS call dispatch.
+//
+// Covers monty v0.0.14 additions OsFunction::DateToday and
+// OsFunction::DateTimeNow. The host returns MontyDate / MontyDateTime from
+// the OsCallHandler and the Rust layer reconstructs the Python objects.
+//
+// Run: dart test test/integration/ffi_datetime_oscall_test.dart -p vm
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+// ---------------------------------------------------------------------------
+// Deterministic fixture date — avoids wall-clock flakiness.
+// ---------------------------------------------------------------------------
+
+const _kYear = 2024;
+const _kMonth = 1;
+const _kDay = 15;
+const _kHour = 10;
+const _kMinute = 30;
+const _kSecond = 0;
+
+MontyDate _fixedDate() =>
+    const MontyDate(year: _kYear, month: _kMonth, day: _kDay);
+
+MontyDateTime _fixedDateTime({int? offsetSeconds, String? timezoneName}) =>
+    MontyDateTime(
+      year: _kYear,
+      month: _kMonth,
+      day: _kDay,
+      hour: _kHour,
+      minute: _kMinute,
+      second: _kSecond,
+      offsetSeconds: offsetSeconds,
+      timezoneName: timezoneName,
+    );
+
+OsCallHandler _datetimeHandler() => (op, args, kwargs) async {
+  switch (op) {
+    case 'date.today':
+      return _fixedDate();
+    case 'datetime.now':
+      // Single positional arg is the tz: MontyTimeZone (as JSON map via
+      // dartValue) or null for a naive datetime.
+      final tzArg = args.isNotEmpty ? args.first : null;
+      if (tzArg == null) return _fixedDateTime();
+      final tz = tzArg as Map<String, Object?>;
+      return _fixedDateTime(
+        offsetSeconds: (tz['offset_seconds']! as num).toInt(),
+        timezoneName: tz['name'] as String?,
+      );
+    default:
+      throw OsCallException('$op not supported');
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ffi_datetime_oscall', () {
+    test('date.today() returns MontyDate with fixed fields', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.date.today()',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(
+        result.value,
+        const MontyDate(year: _kYear, month: _kMonth, day: _kDay),
+      );
+    });
+
+    test('datetime.now() is naive (tzinfo is None)', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.datetime.now().tzinfo is None',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+
+    test('datetime.now(timezone.utc) preserves UTC tzinfo', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.datetime.now(datetime.timezone.utc)'
+        '.tzinfo is datetime.timezone.utc',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+
+    test('datetime.now(fixed offset) preserves tzinfo equality', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'plus_two = datetime.timezone(datetime.timedelta(hours=2))\n'
+        'now = datetime.datetime.now(plus_two)\n'
+        'now.tzinfo == plus_two',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+
+    test('datetime.now() and date.today() agree on calendar date', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'today = datetime.date.today()\n'
+        'now = datetime.datetime.now()\n'
+        'str(now).startswith(str(today))',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+  });
+}

--- a/test/integration/wasm_datetime_oscall_test.dart
+++ b/test/integration/wasm_datetime_oscall_test.dart
@@ -1,0 +1,144 @@
+// WASM integration tests: date.today / datetime.now OS call dispatch.
+//
+// Covers monty v0.0.14 additions OsFunction::DateToday,
+// OsFunction::DateTimeNow, and ExtFunctionResult::NotFound on WASM.
+//
+// Run with dart2js:  dart test test/integration/wasm_datetime_oscall_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_datetime_oscall_test.dart -p chrome --compiler dart2wasm --run-skipped
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+const _kYear = 2024;
+const _kMonth = 1;
+const _kDay = 15;
+const _kHour = 10;
+const _kMinute = 30;
+const _kSecond = 0;
+
+MontyDate _fixedDate() =>
+    const MontyDate(year: _kYear, month: _kMonth, day: _kDay);
+
+MontyDateTime _fixedDateTime({int? offsetSeconds, String? timezoneName}) =>
+    MontyDateTime(
+      year: _kYear,
+      month: _kMonth,
+      day: _kDay,
+      hour: _kHour,
+      minute: _kMinute,
+      second: _kSecond,
+      offsetSeconds: offsetSeconds,
+      timezoneName: timezoneName,
+    );
+
+OsCallHandler _datetimeHandler() => (op, args, kwargs) async {
+  switch (op) {
+    case 'date.today':
+      return _fixedDate();
+    case 'datetime.now':
+      final tzArg = args.isNotEmpty ? args.first : null;
+      if (tzArg == null) return _fixedDateTime();
+      final tz = tzArg as Map<String, Object?>;
+      return _fixedDateTime(
+        offsetSeconds: (tz['offset_seconds']! as num).toInt(),
+        timezoneName: tz['name'] as String?,
+      );
+    default:
+      throw OsCallException('$op not supported');
+  }
+};
+
+void main() {
+  group('wasm_datetime_oscall', () {
+    test('date.today() returns MontyDate with fixed fields', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.date.today()',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(
+        result.value,
+        const MontyDate(year: _kYear, month: _kMonth, day: _kDay),
+      );
+    });
+
+    test('datetime.now() is naive (tzinfo is None)', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.datetime.now().tzinfo is None',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+
+    test('datetime.now(timezone.utc) preserves UTC tzinfo', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('import datetime', osHandler: _datetimeHandler());
+      final result = await repl.feed(
+        'datetime.datetime.now(datetime.timezone.utc)'
+        '.tzinfo is datetime.timezone.utc',
+        osHandler: _datetimeHandler(),
+      );
+
+      expect(result.error, isNull);
+      expect(result.value, const MontyBool(true));
+    });
+
+    test(
+      'OsCallNotHandledException surfaces Python NameError (not RuntimeError)',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        OsCallHandler notHandled() =>
+            (op, args, kwargs) async => throw const OsCallNotHandledException();
+
+        await repl.feed('import datetime', osHandler: notHandled());
+        final error = await repl
+            .feed('datetime.date.today()', osHandler: notHandled())
+            .then<MontyScriptError?>((_) => null)
+            .catchError((Object e) => e as MontyScriptError?);
+
+        expect(error, isNotNull);
+        expect(error?.excType, 'NameError');
+        expect(error?.message, contains('date.today'));
+      },
+    );
+
+    test(
+      'OsCallException surfaces Python RuntimeError (contrast with NameError)',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        OsCallHandler alwaysFails() =>
+            (op, args, kwargs) async =>
+                throw const OsCallException('handler refused');
+
+        await repl.feed('import datetime', osHandler: alwaysFails());
+        final error = await repl
+            .feed('datetime.date.today()', osHandler: alwaysFails())
+            .then<MontyScriptError?>((_) => null)
+            .catchError((Object e) => e as MontyScriptError?);
+
+        expect(error, isNotNull);
+        expect(error?.excType, 'RuntimeError');
+        expect(error?.message, contains('handler refused'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- **monty v0.0.14 upgrade** — bumps Cargo dependency from v0.0.12 → v0.0.14; inventories new upstream types (`ExcType`, `JsonMontyObject`, `OsFunction::DateToday/DateTimeNow`) and flags gaps for follow-up
- **WASM git-dependency docs** — adds README section explaining that pre-built artifacts (`dart_monty_bridge.js`, `dart_monty_worker.js`, `dart_monty_native.wasm`) are gitignored and must be copied to `web/` when using a `git:` or `path:` override; documents the synchronous `<script>` tag trick so `window.DartMontyBridge` is set before Flutter's `main()` runs

## Gap inventory (from 0.0.14 upgrade)

| # | Gap | Priority |
|---|-----|----------|
| 1 | `ExtFunctionResult::NotFound` not in FFI — hosts cannot signal "OS call not handled" | High |
| 2 | No integration tests for `"date.today"` / `"datetime.now"` OS calls | High |
| 3 | `OsCallHandler` docs don't explain return types for new date OS calls | Medium |

🤖 Generated with [Claude Code](https://claude.com/claude-code)