### PR TITLE
fix(ci): kill Chrome after FIXTURE_DONE instead of burning 300s timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -413,8 +413,12 @@ jobs:
             local label=$2
             local log=$(mktemp)
             echo "--- Running $label test ---"
-            
-            timeout 300 "$CHROME" \
+
+            # Run Chrome in the background and stream stderr to the log file.
+            # Poll the log for FIXTURE_DONE instead of waiting for Chrome to
+            # exit — headless Chrome never exits on its own, so without this
+            # we burn the full 300s timeout on every run.
+            "$CHROME" \
               --headless \
               --disable-gpu \
               --no-sandbox \
@@ -422,18 +426,30 @@ jobs:
               --enable-logging=stderr \
               --v=0 \
               "$url" \
-              2>"$log" || true
+              2>"$log" &
+            local chrome_pid=$!
+
+            local elapsed=0
+            while [ $elapsed -lt 300 ]; do
+              if grep -q 'FIXTURE_DONE:' "$log" 2>/dev/null; then
+                break
+              fi
+              sleep 1
+              elapsed=$((elapsed + 1))
+            done
+            kill "$chrome_pid" 2>/dev/null || true
+            wait "$chrome_pid" 2>/dev/null || true
 
             DONE_LINE=$(grep -o 'FIXTURE_DONE:{[^}]*}' "$log" || true)
             if [ -z "$DONE_LINE" ]; then
-              echo "ERROR ($label): No FIXTURE_DONE line captured. Chrome output:"
+              echo "ERROR ($label): No FIXTURE_DONE line captured after ${elapsed}s. Chrome output:"
               grep -i "CONSOLE\|FIXTURE\|ERROR" "$log" | head -60 || true
               rm -f "$log"
               TOTAL_FAILURES=$((TOTAL_FAILURES + 1))
               return
             fi
 
-            echo "$label: $DONE_LINE"
+            echo "$label: $DONE_LINE (${elapsed}s)"
             FAILURES=$(grep -o 'FIXTURE_RESULT:{[^}]*}' "$log" | grep '"ok":false' | wc -l || echo 0)
             if [ "$FAILURES" -gt 0 ]; then
               echo "ERROR ($label): $FAILURES fixtures failed"

--- a/test/integration/ffi_repl_oscall_test.dart
+++ b/test/integration/ffi_repl_oscall_test.dart
@@ -166,32 +166,29 @@ void main() {
       expect(missing.value, const MontyBool(false));
     });
 
-    test(
-      'OsCallException becomes Python RuntimeError, REPL survives',
-      () async {
-        // Handler that throws OsCallException for every op — ensures the
-        // exception-to-RuntimeError translation is exercised even for ops like
-        // read_text that we know are real OS calls.
-        Future<Object?> alwaysThrows(
-          String op,
-          List<Object?> args,
-          Map<String, Object?>? kwargs,
-        ) async => throw OsCallException('handler rejected: $op');
-        final repl = MontyRepl();
-        addTearDown(repl.dispose);
+    test('OsCallException → Python RuntimeError, REPL survives', () async {
+      // Handler that throws OsCallException for every op — ensures the
+      // exception-to-RuntimeError translation is exercised even for ops like
+      // read_text that we know are real OS calls.
+      Future<Object?> alwaysThrows(
+        String op,
+        List<Object?> args,
+        Map<String, Object?>? kwargs,
+      ) async => throw OsCallException('handler rejected: $op');
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
 
-        await repl.feed('import pathlib', osHandler: alwaysThrows);
+      await repl.feed('import pathlib', osHandler: alwaysThrows);
 
-        // read_text is a real OS call → alwaysThrows → Python RuntimeError
-        final result = await repl.feed(
-          "try:\n  pathlib.Path('/x').read_text()\nexcept RuntimeError as e:\n  str(e)",
-          osHandler: alwaysThrows,
-        );
-        expect(result.error, isNull); // Python caught it — no Dart exception
-        // REPL survives; subsequent calls still work
-        final ok = await repl.feed('1 + 1');
-        expect(ok.value, const MontyInt(2));
-      },
-    );
+      // read_text is a real OS call → alwaysThrows → Python RuntimeError
+      final result = await repl.feed(
+        "try:\n  pathlib.Path('/x').read_text()\nexcept RuntimeError as e:\n  str(e)",
+        osHandler: alwaysThrows,
+      );
+      expect(result.error, isNull); // Python caught it — no Dart exception
+      // REPL survives; subsequent calls still work
+      final ok = await repl.feed('1 + 1');
+      expect(ok.value, const MontyInt(2));
+    });
   });
 }


### PR DESCRIPTION
## Summary

- Headless Chrome never exits after the test page finishes, so each WASM integration test burned the full 300s timeout (~10 min total for dart2js + dart2wasm)
- Now runs Chrome in background, polls the log for `FIXTURE_DONE`, and kills Chrome immediately once found
- Prints elapsed time alongside results for visibility
- Also fixes a pre-existing line-length lint in `ffi_repl_oscall_test.dart`

## Test plan

- [ ] CI WASM/JS integration tests job completes in seconds instead of ~10 minutes
- [ ] Both dart2js and dart2wasm fixture results still captured correctly
- [ ] Timeout still triggers if Chrome genuinely hangs (300s fallback preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)