### PR TITLE
fix(demo): use 'def broken(:' for SyntaxError example

### DIFF
--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -157,7 +157,7 @@ const _kSamples = <_Sample>[
         'starts; MontyScriptError wraps runtime exceptions with a Python '
         'traceback. Each step exercises a different subtype.',
     steps: [
-      _Step(label: 'SyntaxError', code: 'def broken('),
+      _Step(label: 'SyntaxError', code: 'def broken(:'),
       _Step(label: 'ZeroDivisionError', code: '1 / 0'),
       _Step(label: 'NameError', code: 'undefined_name'),
     ],

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -592,7 +592,7 @@ const _kSamples = <_Sample>[
         'starts; MontyScriptError wraps runtime exceptions with a Python '
         'traceback. Each snippet exercises a different subtype.',
     steps: [
-      _Step(label: 'SyntaxError', code: 'def broken('),
+      _Step(label: 'SyntaxError', code: 'def broken(:'),
       _Step(label: 'ZeroDivisionError', code: '1 / 0'),
       _Step(label: 'NameError', code: 'undefined_name'),
     ],


### PR DESCRIPTION
## Summary

- The SyntaxError demo button populated `def broken(` which is just incomplete input (unclosed paren) — the REPL treats it as a continuation, not an error
- Changed to `def broken(:` which is unambiguously invalid syntax
- Fixed in both `dart_monty_web` and `dart_monty_flutter` demos

## Test plan

- [ ] Click SyntaxError button in web demo — should show SyntaxError, not hang waiting for more input

🤖 Generated with [Claude Code](https://claude.com/claude-code)