### PR TITLE
fix(demo): show Python exception type instead of Dart class name

### DIFF
--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -157,7 +157,7 @@ const _kSamples = <_Sample>[
         'starts; MontyScriptError wraps runtime exceptions with a Python '
         'traceback. Each step exercises a different subtype.',
     steps: [
-      _Step(label: 'SyntaxError', code: 'def broken('),
+      _Step(label: 'SyntaxError', code: 'def broken(:'),
       _Step(label: 'ZeroDivisionError', code: '1 / 0'),
       _Step(label: 'NameError', code: 'undefined_name'),
     ],

--- a/packages/dart_monty_flutter/lib/main.dart
+++ b/packages/dart_monty_flutter/lib/main.dart
@@ -537,8 +537,10 @@ class _ExecPanelState extends State<_ExecPanel> {
       }
     } on MontyResourceError catch (e) {
       _write('ResourceError: ${e.message}', _LineStyle.error);
+    } on MontyScriptError catch (e) {
+      _write('${e.excType}: ${e.message}', _LineStyle.error);
     } on MontyError catch (e) {
-      _write('Error: $e', _LineStyle.error);
+      _write('${e.runtimeType}: ${e.message}', _LineStyle.error);
     }
   }
 
@@ -658,8 +660,10 @@ class _ReplPanelState extends State<_ReplPanel> {
       } else if (result.value is! MontyNone) {
         _write('=> ${_fmtValue(result.value)}', _LineStyle.output);
       }
+    } on MontyScriptError catch (e) {
+      _write('${e.excType}: ${e.message}', _LineStyle.error);
     } on MontyError catch (e) {
-      _write('Error: $e', _LineStyle.error);
+      _write('${e.runtimeType}: ${e.message}', _LineStyle.error);
     }
   }
 
@@ -852,8 +856,10 @@ class _ExternalsPanelState extends State<_ExternalsPanel> {
       } else if (result.value is! MontyNone) {
         _write('=> ${_fmtValue(result.value)}', _LineStyle.output);
       }
+    } on MontyScriptError catch (e) {
+      _write('${e.excType}: ${e.message}', _LineStyle.error);
     } on MontyError catch (e) {
-      _write('Error: $e', _LineStyle.error);
+      _write('${e.runtimeType}: ${e.message}', _LineStyle.error);
     }
   }
 
@@ -957,8 +963,10 @@ class _VfsPanelState extends State<_VfsPanel> {
       } else if (result.value is! MontyNone) {
         _write('=> ${_fmtValue(result.value)}', _LineStyle.output);
       }
+    } on MontyScriptError catch (e) {
+      _write('${e.excType}: ${e.message}', _LineStyle.error);
     } on MontyError catch (e) {
-      _write('Error: $e', _LineStyle.error);
+      _write('${e.runtimeType}: ${e.message}', _LineStyle.error);
     }
   }
 
@@ -1127,8 +1135,10 @@ class _SessionPanelState extends State<_SessionPanel> {
             progress = await widget.session.resume(null);
         }
       }
+    } on MontyScriptError catch (e) {
+      _write('${e.excType}: ${e.message}', _LineStyle.error);
     } on MontyError catch (e) {
-      _write('Error: $e', _LineStyle.error);
+      _write('${e.runtimeType}: ${e.message}', _LineStyle.error);
     }
   }
 

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -598,7 +598,7 @@ const _kSamples = <_Sample>[
         'starts; MontyScriptError wraps runtime exceptions with a Python '
         'traceback. Each snippet exercises a different subtype.',
     steps: [
-      _Step(label: 'SyntaxError', code: 'def broken('),
+      _Step(label: 'SyntaxError', code: 'def broken(:'),
       _Step(label: 'ZeroDivisionError', code: '1 / 0'),
       _Step(label: 'NameError', code: 'undefined_name'),
     ],

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -157,8 +157,10 @@ void _initReplPanel() {
       } else if (result.value is! MontyNone) {
         write('=> ${_fmt(result.value)}', className: 'output-line');
       }
+    } on MontyScriptError catch (e) {
+      write('${e.excType}: ${e.message}', className: 'error-line');
     } on MontyError catch (e) {
-      write('Error: $e', className: 'error-line');
+      write('${e.runtimeType}: ${e.message}', className: 'error-line');
     }
     input.focus();
   }
@@ -394,8 +396,10 @@ void _initExternalsPanel() {
             progress = await session.resume(null);
         }
       }
+    } on MontyScriptError catch (e) {
+      write('${e.excType}: ${e.message}', className: 'error-line');
     } on MontyError catch (e) {
-      write('Error: $e', className: 'error-line');
+      write('${e.runtimeType}: ${e.message}', className: 'error-line');
       input.focus();
     }
   }
@@ -460,8 +464,10 @@ void _initVfsPanel() {
       } else if (result.value is! MontyNone) {
         write('=> ${_fmt(result.value)}', className: 'output-line');
       }
+    } on MontyScriptError catch (e) {
+      write('${e.excType}: ${e.message}', className: 'error-line');
     } on MontyError catch (e) {
-      write('Error: $e', className: 'error-line');
+      write('${e.runtimeType}: ${e.message}', className: 'error-line');
     }
     input.focus();
   }


### PR DESCRIPTION
## Summary

- Error output showed `Error: MontyScriptError: division by zero` — Dart class name polluting Python output
- Now catches `MontyScriptError` separately and displays `ZeroDivisionError: division by zero` using `excType`
- Other `MontyError` subtypes (panic, crash, disposed, resource) still show their Dart type since those are infrastructure errors, not Python
- Fixed in both `dart_monty_web` and `dart_monty_flutter` demos

## Test plan

- [ ] Run error taxonomy demo — SyntaxError, ZeroDivisionError, NameError should show Python-native format
- [ ] Infrastructure errors (timeout, disposed) should still show their Dart type name

🤖 Generated with [Claude Code](https://claude.com/claude-code)