### PR TITLE
docs: simplify consumer setup (transitive bundling, no redeclaration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,15 +53,15 @@ builds are solved. Regenerate locally when source changes:
 bash tool/prebuild.sh
 ```
 
-Flutter consumers depend on `dart_monty_core` in their pubspec and
-reference each asset explicitly under `flutter.assets` — e.g.
-`- packages/dart_monty_core/assets/dart_monty_core_bridge.js`.
-Flutter then serves them at `packages/dart_monty_core/assets/...`
-(note: the consumer-facing URL omits the `lib/` segment; Flutter
-inserts the `lib/` lookup internally). The high-level
-`DartMonty.ensureInitialized()` API (in `dart_monty`) resolves that
-URL at runtime, so consumers do not need a `<script>` tag in
-`web/index.html`.
+Flutter consumers depend on `dart_monty` (the high-level API).
+`dart_monty_core` comes in transitively, and Flutter bundles a
+dependency's declared `flutter.assets` automatically — no
+consumer-side redeclaration is required. Assets land in the build
+at `assets/packages/dart_monty_core/lib/assets/*` (Flutter preserves the
+`lib/` segment for transitively-bundled package assets). The
+high-level `DartMonty.ensureInitialized()` API in `dart_monty`
+resolves that URL at runtime, so consumers do not need a `<script>`
+tag in `web/index.html`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -64,29 +64,22 @@ dart pub get   # triggers cargo build --release for your platform
 
 ### WASM (Flutter Web)
 
-Flutter consumers use `dart_monty` for the high-level API and depend on
-`dart_monty_core` so Flutter's asset bundler can locate the WASM/JS
-files directly. Flutter's asset resolver does not chase transitive
-references — `- package: X` must name the package that physically
-contains the files — so both deps are required.
+Flutter consumers depend on [`dart_monty`](https://github.com/runyaga/dart_monty)
+(the high-level API). `dart_monty_core` comes in transitively and
+Flutter automatically bundles its declared `flutter.assets` — no
+consumer-side redeclaration needed.
 
 ```yaml
 # pubspec.yaml
 dependencies:
-  dart_monty: ^<version>
-  # Required — Flutter's asset bundler needs this package listed
-  # directly. Do not remove; it is not redundant.
-  dart_monty_core: ^<version>
-
-flutter:
-  assets:
-    - packages/dart_monty_core/assets/dart_monty_core_bridge.js
-    - packages/dart_monty_core/assets/dart_monty_core_worker.js
-    - packages/dart_monty_core/assets/dart_monty_core_native.wasm
+  dart_monty: ^<version>   # dart_monty_core comes in transitively
 ```
 
 ```dart
 // main.dart
+import 'package:dart_monty/dart_monty.dart';
+import 'package:flutter/widgets.dart';
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await DartMonty.ensureInitialized(); // loads bridge on web; no-op on native
@@ -95,15 +88,15 @@ Future<void> main() async {
 ```
 
 `DartMonty.ensureInitialized()` dynamically injects
-`<script src="packages/dart_monty_core/assets/dart_monty_core_bridge.js">`
+`<script src="assets/packages/dart_monty_core/lib/assets/dart_monty_core_bridge.js">`
 into the document, awaits load, and verifies the bridge is ready. No
 `<script>` tag in `web/index.html` is required; `--base-href` is
 honoured automatically. The three built assets
 (`dart_monty_core_bridge.js`, `dart_monty_core_worker.js`, and
-`dart_monty_core_native.wasm`) live under `lib/assets/` (Flutter's
-`packages/<name>/...` URI resolves against a package's `lib/` root)
-and are committed to git — they ship with both pub.dev releases and
-`git:`/`path:` dependencies with no manual `cp` step.
+`dart_monty_core_native.wasm`) live under `lib/assets/` so Flutter's
+`packages/dart_monty_core/...` URI resolves against this package's
+`lib/` root. They are committed to git and ship with both pub.dev
+releases and `git:`/`path:` dependencies with no manual `cp` step.
 
 ### WASM (plain Dart web, no Flutter)
 


### PR DESCRIPTION
## Context

PRs #40 and #42 landed the Mode A asset migration under the assumption that Flutter consumers must (a) depend on \`dart_monty_core\` directly and (b) redeclare the three asset files under their own \`flutter.assets\`. Runtime verification via \`flutter run\` + \`curl\` against the dev server shows that claim is false: Flutter bundles a dependency's own \`flutter.assets\` transitively and serves them at \`/assets/packages/<pkg>/lib/assets/*\`. Consumer just needs \`dart_monty\` in its pubspec.

## What this PR changes

- **README.md \"WASM (Flutter Web)\" section:** drop the peer-dep + redeclaration boilerplate. Consumer adds \`dart_monty\` to pubspec; \`dart_monty_core\` comes in transitively; \`DartMonty.ensureInitialized()\` loads the bridge from the transitive URL.
- **AGENTS.md asset-flow rule:** mirror the simplification. Note that the URL consumers hit is \`assets/packages/dart_monty_core/lib/assets/\*\` (the \`lib/\` segment is preserved under transitive bundling).

## Companion

- runyaga/dart_monty#376 ships the matching \`DartMonty.ensureInitialized()\` URL fix plus a README audit sweep.

## Verified

\`flutter run -d chrome --dart-define=MONTY_ENABLED=true\` on a consumer with pubspec listing only \`dart_monty\` (no \`dart_monty_core\` direct dep, no redeclared \`flutter.assets\`) loads the bridge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)