### PR TITLE
ci: add WASM unit-style test runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -458,6 +458,47 @@ jobs:
 
 
   # ---------------------------------------------------------------------------
+  # WASM unit-style tests — package:test scenarios under test/integration/wasm_*_test.dart
+  # (datetime_oscall, multi_repl, setextfns, fixture). Distinct from the
+  # fixture-corpus runner above, which uses a standalone Dart program.
+  # ---------------------------------------------------------------------------
+  test-wasm-unit:
+    name: WASM unit-style tests
+    needs: [changes]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: pub-${{ runner.os }}-
+      - uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('js/package.json') }}
+          restore-keys: npm-
+
+      - run: dart pub get
+
+      - name: Install WASI runtime (npm)
+        run: |
+          set -euo pipefail
+          cd js
+          npm install --force
+
+      - name: Run WASM unit-style tests
+        run: bash tool/test_wasm_unit.sh
+
+  # ---------------------------------------------------------------------------
   # Patch coverage gate — PRs must maintain >= 70% coverage on changed lines
   # ---------------------------------------------------------------------------
   patch-coverage:

--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,11 @@ test/integration/web/wasm_runner.dart.js.map
 test/integration/web/wasm_runner.dart.js.deps
 test/integration/web/@pydantic/
 
+# WASM unit-test staging (copied by tool/test_wasm_unit.sh, removed on exit)
+test/integration/dart_monty_core_bridge.js
+test/integration/dart_monty_core_worker.js
+test/integration/dart_monty_core_native.wasm
+test/integration/@pydantic/
+
 # macOS
 .DS_Store

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,3 +1,5 @@
+custom_html_template_path: test/integration/wasm_test_template.html
+
 tags:
   unit: {}
   integration:
@@ -5,6 +7,6 @@ tags:
   ffi:
     skip: "FFI integration tests. Run: dart test -p vm --run-skipped --tags=ffi"
   wasm:
-    skip: "WASM integration tests. Run: dart test -p chrome --run-skipped --tags=wasm"
+    skip: "WASM integration tests. Run: bash tool/test_wasm_unit.sh"
   ladder:
     skip: "Skipped by default (slow). Run: dart test --run-skipped --tags=ladder"

--- a/test/integration/wasm_test_template.html
+++ b/test/integration/wasm_test_template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>{{testName}}</title>
+  {{testScript}}
+  <script src="dart_monty_core_bridge.js"></script>
+  <script src="packages/test/dart.js"></script>
+</head>
+</html>

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -48,7 +48,9 @@ if [ ! -f "$WASI_PKG/wasi-worker-browser.mjs" ]; then
     echo "FATAL: npm not found. Install Node.js to fetch @pydantic/monty-wasm32-wasi."
     exit 1
   fi
-  (cd "$PKG/js" && npm install --silent)
+  # --force bypasses EBADPLATFORM on arm64 hosts (the WASI package declares
+  # cpu: wasm32). tool/test_wasm.sh and the CI test-wasm job already use --force.
+  (cd "$PKG/js" && npm install --force --silent)
 fi
 if [ ! -f "$WASI_PKG/wasi-worker-browser.mjs" ]; then
   echo "FATAL: $WASI_PKG/wasi-worker-browser.mjs still missing after npm install"

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# =============================================================================
+# dart_monty_core — WASM unit-style test runner
+# =============================================================================
+# Runs the package:test-style WASM tests under test/integration/wasm_*_test.dart
+# (datetime_oscall, multi_repl, setextfns) via `dart test -p chrome`.
+#
+# These tests need window.DartMontyBridge available on the page. The
+# package:test browser harness's default HTML template doesn't include the
+# bridge; dart_test.yaml's `custom_html_template_path` points at
+# test/integration/wasm_test_template.html which adds the <script> tag.
+#
+# Bridge assets must therefore be served from the same path as the test HTML.
+# This script stages them into test/integration/ and removes them on exit.
+# COOP/COEP headers are NOT required — the bridge does not use
+# SharedArrayBuffer or Atomics, so the default dart-test browser server works.
+#
+# Usage: bash tool/test_wasm_unit.sh [-- <extra dart test args>]
+# =============================================================================
+set -euo pipefail
+
+PKG="$(cd "$(dirname "$0")/.." && pwd)"
+INTEG="$PKG/test/integration"
+ASSETS="$PKG/lib/assets"
+WASI_PKG="$PKG/js/node_modules/@pydantic/monty-wasm32-wasi"
+
+cd "$PKG"
+
+echo "=== dart_monty_core WASM unit-style tests ==="
+
+# -----------------------------------------------------------------------------
+# Step 1: Ensure committed assets exist (Mode A — assets/ is the source of truth)
+# -----------------------------------------------------------------------------
+for f in dart_monty_core_bridge.js dart_monty_core_worker.js dart_monty_core_native.wasm; do
+  if [ ! -f "$ASSETS/$f" ]; then
+    echo "FATAL: missing $ASSETS/$f"
+    echo "  Run: bash tool/prebuild.sh"
+    exit 1
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# Step 2: Ensure the WASI runtime is installed (npm dep, gitignored)
+# -----------------------------------------------------------------------------
+if [ ! -f "$WASI_PKG/wasi-worker-browser.mjs" ]; then
+  echo "--- Installing WASI runtime (npm install in js/) ---"
+  if ! command -v npm &>/dev/null; then
+    echo "FATAL: npm not found. Install Node.js to fetch @pydantic/monty-wasm32-wasi."
+    exit 1
+  fi
+  (cd "$PKG/js" && npm install --silent)
+fi
+if [ ! -f "$WASI_PKG/wasi-worker-browser.mjs" ]; then
+  echo "FATAL: $WASI_PKG/wasi-worker-browser.mjs still missing after npm install"
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Step 3: Stage assets into test/integration/ (gitignored; cleaned on exit)
+# -----------------------------------------------------------------------------
+STAGED=(
+  "$INTEG/dart_monty_core_bridge.js"
+  "$INTEG/dart_monty_core_worker.js"
+  "$INTEG/dart_monty_core_native.wasm"
+  "$INTEG/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs"
+)
+cleanup() {
+  rm -f "${STAGED[@]}"
+  rmdir "$INTEG/@pydantic/monty-wasm32-wasi" 2>/dev/null || true
+  rmdir "$INTEG/@pydantic" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cp "$ASSETS/dart_monty_core_bridge.js"   "$INTEG/"
+cp "$ASSETS/dart_monty_core_worker.js"   "$INTEG/"
+cp "$ASSETS/dart_monty_core_native.wasm" "$INTEG/"
+mkdir -p "$INTEG/@pydantic/monty-wasm32-wasi"
+cp "$WASI_PKG/wasi-worker-browser.mjs" "$INTEG/@pydantic/monty-wasm32-wasi/"
+
+# -----------------------------------------------------------------------------
+# Step 4: Run the WASM unit-style tests
+# -----------------------------------------------------------------------------
+echo ""
+echo "--- Running dart test -p chrome --tags=wasm ---"
+dart test \
+  -p chrome \
+  --run-skipped \
+  --tags=wasm \
+  --reporter expanded \
+  --concurrency 2 \
+  test/integration/wasm_datetime_oscall_test.dart \
+  test/integration/wasm_fixture_test.dart \
+  test/integration/wasm_multi_repl_test.dart \
+  test/integration/wasm_setextfns_test.dart \
+  "$@"


### PR DESCRIPTION
## Summary

The four `test/integration/wasm_*_test.dart` files (`datetime_oscall`, `multi_repl`, `setextfns`, `fixture`) — 486 tests in total — were orphaned scaffolding: every CI job either excluded the `wasm` tag or ran a different harness (the standalone fixture-corpus runner via `wasm_runner.html`). They have always failed when run via `dart test -p chrome --run-skipped --tags=wasm` because the default `package:test` browser harness HTML doesn't `<script>`-include `dart_monty_core_bridge.js`, so `window.DartMontyBridge` is undefined and `WasmBindingsJs._ensureInit` blows up.

This PR wires them into actual test runs:

- `test/integration/wasm_test_template.html` — `package:test` custom HTML template. `{{testScript}}` is replaced with a complete `<link rel="x-dart-test" href="…">` element by `package:test` ([compiler_support.dart#L72](https://github.com/dart-lang/test/blob/master/pkgs/test/lib/src/runner/browser/compilers/compiler_support.dart)), so the placeholder sits standalone where the link belongs.
- `dart_test.yaml` — sets `custom_html_template_path` and updates the `wasm` tag's skip message to point at the new wrapper.
- `tool/test_wasm_unit.sh` — stages bridge + worker + WASM + WASI runtime into `test/integration/` with trap-based cleanup; runs `dart test -p chrome --run-skipped --tags=wasm`.
- `.github/workflows/ci.yaml` — new `test-wasm-unit` job runs the wrapper.

The bridge does **not** use `SharedArrayBuffer` or `Atomics`, so COOP/COEP headers are not required — just an HTML host that loads the bridge before the test boots.

## Test plan

- [x] `bash tool/test_wasm_unit.sh` → **486 / 486** on arm64 macOS against committed monty 0.0.14 assets
- [x] `dart test` (unit) → 67/67 — confirms `custom_html_template_path` does not affect non-browser runs
- [x] `--force` on `npm install` (the WASI package declares `cpu: wasm32`, so plain `npm install` errors with `EBADPLATFORM` on arm64/x64; the rest of the tooling already passes `--force`)
- [ ] CI: `test-wasm-unit` job green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)