### PR TITLE
fix(error): drop exception-type prefix from MontyException.message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,19 @@
 - **Web assets are now committed to git** instead of built at publish
   time and force-staged. Git-dep consumers get a working `pub get`
   without running any build step. See README "Building from source".
+- **`MontyException.message` no longer carries the exception-type prefix.**
+  The Rust shim was setting `"message": e.summary()`, where upstream's
+  `summary()` returns `"ExcType: msg"`. Combined with the separately-
+  exposed `excType` field, the natural `${e.excType}: ${e.message}`
+  idiom produced doubled output: `SyntaxError: SyntaxError: …`,
+  `ZeroDivisionError: ZeroDivisionError: division by zero`, etc.
+  `message` now carries just the raw exception message (or empty
+  string when upstream reports `None`). Same change applies to the
+  oracle binary's JSON output (`native/src/bin/oracle.rs`). The C
+  out-error fallback in `lib.rs` and the secondary `Option<String>`
+  returned alongside JSON envelopes from `handle.rs`/`repl_handle.rs`
+  intentionally still use `summary()` — those paths have no separate
+  `excType` field for the consumer to compose with.
 
 ### Removed — BREAKING
 

--- a/native/src/bin/oracle.rs
+++ b/native/src/bin/oracle.rs
@@ -102,7 +102,7 @@ fn build_error_json(e: &MontyException, print_buf: &str) -> Value {
 /// Mirrors `monty_exception_to_json` in `error.rs` exactly.
 fn exception_to_json(e: &MontyException) -> Value {
     let mut obj = json!({
-        "message": e.summary(),
+        "message": e.message().unwrap_or(""),
         "exc_type": e.exc_type().to_string(),
     });
     let map = obj.as_object_mut().unwrap();

--- a/native/src/error.rs
+++ b/native/src/error.rs
@@ -59,9 +59,15 @@ pub unsafe fn parse_c_str<'a>(
 ///
 /// Includes `exc_type` (e.g. `"ValueError"`) and full `traceback` array
 /// with all frames from the upstream exception.
+///
+/// `message` carries only the raw exception message (without the type
+/// prefix that upstream's `summary()` would prepend). Consumers compose
+/// it with `exc_type` themselves — `${e.excType}: ${e.message}` is the
+/// idiomatic form. Storing the prefix on both fields produced
+/// `SyntaxError: SyntaxError: …` output downstream.
 pub fn monty_exception_to_json(e: &MontyException) -> Value {
     let mut obj = json!({
-        "message": e.summary(),
+        "message": e.message().unwrap_or(""),
         "exc_type": e.exc_type().to_string(),
     });
     let map = obj.as_object_mut().unwrap();


### PR DESCRIPTION
## Summary

`monty_exception_to_json` was setting `"message": e.summary()`, where upstream's `summary()` already returns `"ExcType: msg"`. Combined with the separately-exposed `exc_type` field, the natural `\${e.excType}: \${e.message}` idiom produced doubled output:

```
SyntaxError: SyntaxError: Expected a parameter ...
ZeroDivisionError: ZeroDivisionError: division by zero
```

This affects every consumer that follows the natural compose-the-fields idiom — including `packages/dart_monty_web/web/repl_demo.dart` (5 sites), `example/08_all_errors.dart`, and the README error example.

## Change

- `native/src/error.rs:64` — `e.summary()` → `e.message().unwrap_or("")`
- `native/src/bin/oracle.rs:105` — same (mirrors the JSON envelope)
- `lib/assets/dart_monty_core_native.wasm` — rebuilt via `tool/prebuild.sh`
- `CHANGELOG.md` — entry under "Changed"

The C out-error fallback (`lib.rs:110`) and the secondary `Option<String>` returned alongside JSON envelopes from `handle.rs` / `repl_handle.rs` intentionally keep `summary()` — those paths return a single string with no separate `exc_type` field for the consumer to compose with.

## Test plan

- [x] `cargo check` / `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 232/232 (188 lib + 44 integration; `snapshot_format_pinning` still pinned correctly)
- [x] `dart analyze` clean
- [x] `dart test` (unit) — 67/67
- [x] `dart test -p vm --run-skipped --tags=ffi` — **965/965** including the full pydantic/monty fixture corpus through `oracle_ffi_test.dart` + `oracle_ffi_ext_test.dart`
- [x] `cargo build --target wasm32-wasip1` clean → `lib/assets/dart_monty_core_native.wasm` rebuilt (5.9 MB)
- [ ] CI: `test-wasm` job (fixture corpus through `wasm_runner.dart` / `wasm_runner_wasm.dart`) — canonical WASM verification

## Behaviour change — opt-in for downstream

Pre-1.0, but worth flagging: any consumer that read `e.message` standalone and expected the type prefix will see different output. The fix is to switch to the idiomatic `\${e.excType}: \${e.message}` (which now produces the right thing instead of doubling). No code in this repo reads `e.message` standalone — the README example, `example/08_all_errors.dart`, and the demo all already used the compose-the-fields idiom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)