### PR TITLE
fix(test_wasm): pass --force to npm install

### DIFF
--- a/tool/test_wasm.sh
+++ b/tool/test_wasm.sh
@@ -71,7 +71,10 @@ if [ "$SKIP_BUILD" = false ]; then
     exit 1
   fi
   cd "$JS_DIR"
-  npm install --silent
+  # --force bypasses EBADPLATFORM on arm64/x64 hosts (the WASI package
+  # @pydantic/monty-wasm32-wasi declares cpu: wasm32). The CI test-wasm
+  # job already uses --force.
+  npm install --force --silent
   # build.js copies the WASM binary from native/target/ into assets/ under the
   # deployed name (dart_monty_core_native.wasm) —
   # point it at our assets dir by running it from there


### PR DESCRIPTION
## Summary

`@pydantic/monty-wasm32-wasi` declares `cpu: wasm32`, so plain `npm install` fails with `EBADPLATFORM` on arm64 / x64 hosts. Combined with `--silent`, the failure is invisible — the script exits silently with `set -e` right after printing `"--- Building JS bridge (npm) ---"`, leaving the developer with no error message and no fixture results.

The CI `test-wasm` job (`.github/workflows/ci.yaml:324`) already uses `--force`; `tool/test_wasm_unit.sh` (PR #47) already does too. This brings `tool/test_wasm.sh` in line so local fixture-corpus runs work on arm64 macOS.

## Change

```diff
   cd "$JS_DIR"
-  npm install --silent
+  npm install --force --silent
```

One line. No behaviour change for CI (linux/amd64 didn't trip `EBADPLATFORM` in the first place — `--force` is a no-op there).

## Test plan

- [x] On arm64 macOS, the script previously died silently after `"Building JS bridge (npm)"`. With `--force` it proceeds to `node build.js` → `dart compile js` → headless Chrome → fixture corpus.
- [ ] CI `test-wasm` job remains green (no behaviour change on Linux x86_64).

🤖 Generated with [Claude Code](https://claude.com/claude-code)