### PR TITLE
docs(readme): remove stale Flutter REPL demo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,9 +512,6 @@ bash tool/serve_demo.sh
 
 # dart2wasm variant
 bash tool/serve_demo.sh --dart2wasm
-
-# Flutter REPL (mobile/desktop) — requires FFI dylib (build step above)
-bash tool/run_flutter_demo.sh [--device macos]
 ```
 
 ### dart2wasm Support & Benchmarks


### PR DESCRIPTION
## Summary

The README's \"Demos\" section pointed at \`tool/run_flutter_demo.sh\`, which does not exist:

\`\`\`
$ ls tool/ | grep -i flutter
(no output)
\`\`\`

The Flutter sidecar and its demo runner were removed in the \"Removed — BREAKING\" CHANGELOG entry that introduced the \`flutter.assets\` pubspec stanza. The README pointer was missed.

This PR drops the two lines. Web REPL demos (dart2js + dart2wasm) remain — both still work.

## Diff

\`\`\`diff
 # dart2wasm variant
 bash tool/serve_demo.sh --dart2wasm
-
-# Flutter REPL (mobile/desktop) — requires FFI dylib (build step above)
-bash tool/run_flutter_demo.sh [--device macos]
 \`\`\`
\`\`\`

## Test plan

- [x] No code paths affected
- [ ] CI green (markdownlint, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)