### PR TITLE
test(example): smoke-test every example/*.dart in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -280,6 +280,46 @@ jobs:
             -p vm --run-skipped --tags=ffi --reporter=expanded
 
   # ---------------------------------------------------------------------------
+  # Example smoke tests — every example/*.dart must compile and exit 0.
+  # `dart analyze` only checks types; this is the only thing exercising the
+  # examples at runtime. Broken examples are tracked via markTestSkipped()
+  # with a TODO reason; remove the skip-list entry to enforce.
+  # ---------------------------------------------------------------------------
+  test-examples:
+    name: Example smoke tests
+    needs: [changes, ffigen]
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-${{ runner.os }}-${{ hashFiles('pubspec.yaml') }}
+          restore-keys: pub-${{ runner.os }}-
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: native
+      - name: Download FFI bindings
+        uses: actions/download-artifact@v4
+        with:
+          name: ffi-bindings
+          path: lib/src/ffi/generated
+      - name: Build native library
+        working-directory: native
+        run: cargo build --release
+      - run: dart pub get
+      - name: Run example smoke tests
+        run: |
+          dart test test/integration/example_smoke_test.dart \
+            -p vm --run-skipped --tags=example --reporter=expanded
+
+  # ---------------------------------------------------------------------------
   # WASM/JS integration tests — 464 fixtures through MontyWasm in headless Chrome
   # Uses the dart_monty JS bridge (sparse-checkout) + freshly built WASM binary.
   # ---------------------------------------------------------------------------

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,5 +8,7 @@ tags:
     skip: "FFI integration tests. Run: dart test -p vm --run-skipped --tags=ffi"
   wasm:
     skip: "WASM integration tests. Run: bash tool/test_wasm_unit.sh"
+  example:
+    skip: "Example smoke tests. Run: dart test -p vm --run-skipped --tags=example"
   ladder:
     skip: "Skipped by default (slow). Run: dart test --run-skipped --tags=ladder"

--- a/test/integration/example_smoke_test.dart
+++ b/test/integration/example_smoke_test.dart
@@ -1,0 +1,70 @@
+// Smoke test: every example/*.dart compiles and exits 0.
+//
+// `dart analyze` and `dart pub publish` only check that examples type-check;
+// neither runs them. This test fills the runtime-rot gap. Each example file
+// is invoked via `dart run` from the repo root and asserted to exit 0 within
+// a generous timeout. stdout / stderr surface in the failure reason so a
+// regression is debuggable from the test report.
+//
+// Tagged 'example' (skipped in default `dart test` runs because each example
+// boots an FFI dylib + interpreter — slow for fast-loop unit testing).
+//
+// Run: dart test -p vm --run-skipped --tags=example
+
+@Tags(['integration', 'example'])
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// Examples that currently fail or hang on `main`. Each entry is a
+/// regression to fix; once fixed, remove the entry so the test enforces
+/// the example.
+const _skipReasons = <String, String>{
+  'example/06_compile_and_platform.dart':
+      'TODO: UnimplementedError — resumeNameLookupValue is not supported by '
+          'the FFI backend (FfiCoreBindings:165). Binding gap, not docs rot.',
+  'example/07_all_values.dart':
+      'TODO: type cast error at line 157 — MontyNone vs MontyNamedTuple.',
+  'example/08_all_errors.dart':
+      'TODO: hangs in the MontyResourceError (timeout) section.',
+  'example/09_limits_and_code_capture.dart':
+      'TODO: hangs after the MontyLimits banner.',
+};
+
+void main() {
+  final examples = Directory('example')
+      .listSync()
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.dart'))
+      .map((f) => f.path)
+      .toList()
+    ..sort();
+
+  group('example smoke', () {
+    for (final ex in examples) {
+      test(
+        ex,
+        () async {
+          // Runtime skip — survives `--run-skipped`, which the tag-level
+          // skip directive in dart_test.yaml requires to enable this suite.
+          final skipReason = _skipReasons[ex];
+          if (skipReason != null) {
+            markTestSkipped(skipReason);
+            return;
+          }
+          final result = await Process.run('dart', ['run', ex]);
+          expect(
+            result.exitCode,
+            equals(0),
+            reason: 'exit=${result.exitCode}\n'
+                '--- stdout ---\n${result.stdout}\n'
+                '--- stderr ---\n${result.stderr}',
+          );
+        },
+        timeout: const Timeout(Duration(minutes: 2)),
+      );
+    }
+  });
+}

--- a/test/integration/example_smoke_test.dart
+++ b/test/integration/example_smoke_test.dart
@@ -21,10 +21,10 @@ import 'package:test/test.dart';
 /// Examples that currently fail or hang on `main`. Each entry is a
 /// regression to fix; once fixed, remove the entry so the test enforces
 /// the example.
-const _skipReasons = <String, String>{
+const _skipReasons = {
   'example/06_compile_and_platform.dart':
       'TODO: UnimplementedError — resumeNameLookupValue is not supported by '
-          'the FFI backend (FfiCoreBindings:165). Binding gap, not docs rot.',
+      'the FFI backend (FfiCoreBindings:165). Binding gap, not docs rot.',
   'example/07_all_values.dart':
       'TODO: type cast error at line 157 — MontyNone vs MontyNamedTuple.',
   'example/08_all_errors.dart':
@@ -34,13 +34,14 @@ const _skipReasons = <String, String>{
 };
 
 void main() {
-  final examples = Directory('example')
-      .listSync()
-      .whereType<File>()
-      .where((f) => f.path.endsWith('.dart'))
-      .map((f) => f.path)
-      .toList()
-    ..sort();
+  final examples =
+      Directory('example')
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.dart'))
+          .map((f) => f.path)
+          .toList()
+        ..sort();
 
   group('example smoke', () {
     for (final ex in examples) {
@@ -52,13 +53,15 @@ void main() {
           final skipReason = _skipReasons[ex];
           if (skipReason != null) {
             markTestSkipped(skipReason);
+
             return;
           }
           final result = await Process.run('dart', ['run', ex]);
           expect(
             result.exitCode,
             equals(0),
-            reason: 'exit=${result.exitCode}\n'
+            reason:
+                'exit=${result.exitCode}\n'
                 '--- stdout ---\n${result.stdout}\n'
                 '--- stderr ---\n${result.stderr}',
           );


### PR DESCRIPTION
## Summary

`dart analyze` and `dart pub publish` only type-check `example/*.dart`; nothing in CI ever ran them. Smoke-running each one locally surfaced **4 broken examples already on `main`**:

| File | Failure |
|---|---|
| `06_compile_and_platform.dart` | `UnimplementedError: resumeNameLookupValue is not supported by the FFI backend` (FfiCoreBindings:165) |
| `07_all_values.dart` | `type 'MontyNone' is not a subtype of type 'MontyNamedTuple' in type cast` (line 157) |
| `08_all_errors.dart` | hangs in the `MontyResourceError (timeout)` section |
| `09_limits_and_code_capture.dart` | hangs after the `MontyLimits` banner |

These are pre-existing — none introduced by this PR or any in-flight branch.

## Change

- **`test/integration/example_smoke_test.dart`** — discovers every `example/*.dart`, runs `Process.run('dart', ['run', ex])`, asserts `exit == 0`. Output captured for debuggable failure reasons.
- **`dart_test.yaml`** — new `example` tag, opt-in (parallels `ffi` / `wasm`). Skipped from default `dart test` so fast-loop unit testing isn't slowed.
- **`.github/workflows/ci.yaml`** — new `test-examples` job, sibling to `test-ffi`, runs the suite.

## Skip strategy

The 4 broken examples are tracked in a `_skipReasons` map and skipped at runtime via `markTestSkipped()` (which survives `--run-skipped`, unlike the per-test `skip:` parameter). Each entry is a TODO; deleting it forces the test to enforce the example. The skip reasons appear in the test report so the rot is visible, not hidden.

## Test plan

- [x] **Local**: `dart test -p vm --run-skipped --tags=example test/integration/example_smoke_test.dart` → **5 passed, 4 skipped with TODO reasons**
- [ ] CI: `test-examples` job green on this PR (5 passed, 4 skipped)

## Follow-ups (separate PRs / issues)

- Each entry in `_skipReasons` is a follow-up. The most interesting is **#06** — `resumeNameLookupValue` is genuinely missing from FFI; that's a binding gap, not docs rot. Worth its own issue.
- 07/08/09 look like example-side bugs (cast wrong type, hangs in timeout demo, hangs in limits demo) — smaller scope, fixable in `example/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)