### PR TITLE
fix(test): correct excType + gate oracle_ffi_ext_test.dart in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -485,6 +485,10 @@ jobs:
             FAILURES=$(grep -o 'FIXTURE_RESULT:{[^}]*}' "$log" | grep '"ok":false' | wc -l || echo 0)
             if [ "$FAILURES" -gt 0 ]; then
               echo "ERROR ($label): $FAILURES fixtures failed"
+              echo "  --- failed fixtures ---"
+              grep -o 'FIXTURE_RESULT:{[^}]*}' "$log" | grep '"ok":false' | while IFS= read -r line; do
+                echo "    ${line#*FIXTURE_RESULT:}"
+              done
               TOTAL_FAILURES=$((TOTAL_FAILURES + FAILURES))
             fi
             rm -f "$log"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,6 +279,9 @@ jobs:
           dart test \
             test/integration/oracle_ffi_test.dart \
             test/integration/oracle_ffi_ext_test.dart \
+            test/integration/ffi_datetime_oscall_test.dart \
+            test/integration/ffi_multi_repl_test.dart \
+            test/integration/ffi_repl_oscall_test.dart \
             -p vm --run-skipped --tags=ffi --reporter=expanded
 
   # ---------------------------------------------------------------------------

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,7 +276,9 @@ jobs:
       - run: dart pub get
       - name: Run FFI integration tests
         run: |
-          dart test test/integration/oracle_ffi_test.dart \
+          dart test \
+            test/integration/oracle_ffi_test.dart \
+            test/integration/oracle_ffi_ext_test.dart \
             -p vm --run-skipped --tags=ffi --reporter=expanded
 
   # ---------------------------------------------------------------------------

--- a/test/integration/_fixture_corpus.dart
+++ b/test/integration/_fixture_corpus.dart
@@ -306,13 +306,13 @@ const Map<String, String> fixtureCorpus = {
   'ext_call__name_lookup_fn_06_conditional.py':
       "# call-external\n# First-class ext fn reference: in conditional expression.\nop = add_ints if True else add_ints\nresult = op(10, 5)\nassert result == 15, f'expected 15, got {result}'\n",
   'ext_call__name_lookup_fn_07_map_two_args_xfail.py':
-      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# map() cannot suspend for external function calls.\n# When upstream adds support, this test will fail — remove Raise= directive.\nlist(map(add_ints, [1, 2, 3], [10, 20, 30]))\n# Raise=RuntimeError\n",
+      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# map() cannot suspend for external function calls.\n# When upstream adds support, change Raise= to Return=[11, 22, 33].\nlist(map(add_ints, [1, 2, 3], [10, 20, 30]))\n# Raise=NotImplementedError\n",
   'ext_call__name_lookup_fn_08_map_one_arg_xfail.py':
-      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# map() cannot suspend for external function calls.\n# When upstream adds support, this test will fail — remove Raise= directive.\nlist(map(return_value, [1, 2, 3]))\n# Raise=RuntimeError\n",
+      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# map() cannot suspend for external function calls.\n# When upstream adds support, change Raise= to Return=[1, 2, 3].\nlist(map(return_value, [1, 2, 3]))\n# Raise=NotImplementedError\n",
   'ext_call__name_lookup_fn_09_user_fn_in_map.py':
       "# call-external\n# Control: map() with user-defined (pure Python) fn works fine.\n# Only external functions trip the upstream limitation.\ndef my_add(a, b):\n    return a + b\nresult = list(map(my_add, [1, 2, 3], [10, 20, 30]))\nassert result == [11, 22, 33], f'expected [11, 22, 33], got {result}'\n",
   'ext_call__name_lookup_fn_10_lambda_in_map_xfail.py':
-      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# Wrapping an external function in a lambda does NOT escape the limitation —\n# the suspend point is still inside map()'s stack frame.\n# When upstream adds support, this test will fail — remove Raise= directive.\nlist(map(lambda x: add_ints(x, 100), [1, 2, 3]))\n# Raise=RuntimeError\n",
+      "# call-external\n# KNOWN UPSTREAM LIMITATION (pydantic/monty):\n# Wrapping an external function in a lambda does NOT escape the limitation —\n# the suspend point is still inside map()'s stack frame.\n# When upstream adds support, change Raise= to Return=[101, 102, 103].\nlist(map(lambda x: add_ints(x, 100), [1, 2, 3]))\n# Raise=NotImplementedError\n",
   'ext_call__name_lookup_undefined.py':
       "# call-external\n# When NameLookup returns Undefined for an unknown name, NameError is raised.\ntotally_unknown_name\n# Raise=NameError(\"name 'totally_unknown_name' is not defined\")\n",
   'ext_call__nested_calls.py':


### PR DESCRIPTION
## Summary

Two bugs surfaced by the monty 0.0.17 bump (#50):

### 1. Wrong \`excType\` in 3 xfail fixtures

The fixtures \`ext_call__name_lookup_fn_{07,08,10}_*_xfail.py\` declared \`# Raise=RuntimeError\`, but upstream's \`crates/monty/src/bytecode/vm/call.rs:341\` actually returns \`NotImplementedError\` (\"external functions are not yet supported in this context\"). The mismatch was harmless on monty 0.0.14 because CI never ran this test file (see #2 below).

**0.0.17 did not fix the limitation** — \`map(ext_fn, ...)\` is still unsupported on FFI/WASM. The 0.0.14 → 0.0.17 bump only made the existing failure observable through stricter type enforcement. My initial bump-PR description claimed the fixtures \"now pass upstream\" — that was wrong. Corrected here.

\`\`\`diff
-list(map(add_ints, [1, 2, 3], [10, 20, 30]))
-# Raise=RuntimeError
+list(map(add_ints, [1, 2, 3], [10, 20, 30]))
+# Raise=NotImplementedError
\`\`\`

The \`_xfail\` suffix stays — the regression marker still applies, just with the right exception type.

### 2. \`oracle_ffi_ext_test.dart\` was orphaned in CI

CI's FFI integration step only invoked \`test/integration/oracle_ffi_test.dart\`, so failures in the sibling \`_ext_\` file (the only thing exercising ext-fn dispatch on FFI) never blocked merges. The bump PR's body assumed CI would surface the 3 fixture failures, but that never happened — main was green despite the broken test file.

\`\`\`diff
   dart test \\
+    test/integration/oracle_ffi_test.dart \\
+    test/integration/oracle_ffi_ext_test.dart \\
     -p vm --run-skipped --tags=ffi --reporter=expanded
\`\`\`

Same orphan-CI pattern fixed here as #47 fixed for wasm_*_test.dart.

## Test plan

- [x] \`dart test test/integration/oracle_ffi_ext_test.dart -p vm --run-skipped --tags=ffi\` → **474/474** local
- [ ] CI's \`FFI integration tests\` job runs both files and stays green

🤖 Generated with [Claude Code](https://claude.com/claude-code)