### PR TITLE
PR-A: bug fixes + REPL polish (API alignment series)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,44 @@
   await DartMonty.ensureInitialized();
   ```
 
+### Fixed
+
+- **`Monty.exec` now accepts `externals:`.** `Monty.run` always supported
+  externals; the static one-shot wrapper silently dropped them, leaving
+  Python in `Monty.exec(...)` unable to call back into Dart. Forwarded
+  through to `monty.run` and pinned with FFI + WASM integration tests.
+- **`MontyRepl.feed` re-syncs `ext_fn_names` on every call.** The
+  iterative path called `setExtFns`, the fast path did not, so names
+  registered in a previous feed leaked into the next feed's NameLookup
+  resolution and surfaced as a confusing
+  "No handler registered for: X" error instead of a clean Python
+  NameError. `setExtFns` now runs at the top of `feed()` (with `[]` when
+  externals is empty), covering both paths. Three regression scenarios
+  pinned on FFI + WASM. Note: the upstream list-comprehension shadowing
+  bug (API_REVIEW §4) is a separate engine-level issue.
+
+### Added
+
+- **`MontyRepl.scriptName` / `MontySession.scriptName` getters.** The
+  reference `pydantic_monty` class exposes `script_name`; the Dart side
+  stored `_scriptName` but had no accessor. `Monty.scriptName` returns
+  the same value with a `'main.py'` fallback to match the engine
+  default.
+
+### Changed
+
+- **`MontyRepl.snapshot` / `restore` throw `StateError` mid-pause.**
+  Previously they bubbled an opaque Rust-side error when called while
+  a `feedStart`/`resume` loop was paused. Dart now tracks pending
+  state and throws `StateError` with an actionable message instead.
+- **REPL dartdoc tightened.** Stale "REPL doesn't support NameLookup"
+  comment removed (the Rust handle auto-resolves names via
+  `ext_fn_names`; the Dart branch only fires when a name was not
+  registered). `feedStart`'s `List<String> externalFunctions` shape is
+  now documented as intentional (versus `feed`'s `Map<String,
+  MontyCallback>`), and `detectContinuation` is called out as a
+  Dart-only helper without a `pydantic_monty` equivalent.
+
 ## 0.0.14 - monty upstream upgrade
 
 ### Upgraded

--- a/docs/CONSUMER_MIGRATION.md
+++ b/docs/CONSUMER_MIGRATION.md
@@ -1,0 +1,128 @@
+# Consumer migration: dart_monty_core API alignment
+
+This document tracks every public-API change in `dart_monty_core` that
+downstream consumers need to act on. Recipes land incrementally as
+each PR in the API-alignment series merges.
+
+## PR roadmap
+
+| PR | Status | Scope |
+|---|---|---|
+| **PR-A** | merged | Bug fixes, REPL polish (no breaking changes). |
+| PR-B | upcoming | `Monty(code)` reshape, `externals` → `externalFunctions`, `feed` → `feedRun`, `MontySession.start` → `feedStart`. **Breaking.** |
+| PR-C | upcoming | `printCallback`, `MountDir`, `registerDataclass`. **Additive only.** |
+
+---
+
+## PR-A — bug fixes and REPL polish (non-breaking)
+
+No call-site changes are required. PR-A surfaces strictly improve the
+existing API:
+
+- `Monty.exec(...)` now accepts `externals:` (previously dropped
+  silently).
+- `MontyRepl.feed(...)` correctly clears `ext_fn_names` between calls
+  — code that depended on the leaked-name behavior was always broken;
+  Python NameError is now raised cleanly.
+- New `String? get scriptName` on `MontyRepl` and `MontySession`;
+  `String get scriptName` on `Monty` (defaults to `'main.py'`).
+- `MontyRepl.snapshot()` / `restore()` throw `StateError` instead of
+  an opaque Rust-side error when called while a `feedStart`/`resume`
+  loop is paused.
+
+If your code already wraps `snapshot`/`restore` in a try/catch on a
+generic exception, the type changes from a Rust-derived exception to
+`StateError`. Consider catching `StateError` explicitly.
+
+### Per-package checklist (PR-A)
+
+| Package | Action |
+|---|---|
+| `dart_monty` | None. Verify `dart test` passes after `pub upgrade`. |
+| `soliplex_*` | None. |
+| `dart_monty_plugins` | None. |
+
+---
+
+## PR-B — structural and naming alignment (breaking)
+
+> Recipes land when PR-B is in review. This section is a placeholder.
+
+### Quick mapping table (preview)
+
+| Before | After | Tier |
+|---|---|---|
+| `Monty()` constructor (no args) | `MontySession()` for REPL, `Monty(code)` for one-shot | breaking |
+| `monty.run(code)` (REPL) | `session.feedRun(code)` or `Monty(code).run()` | breaking |
+| `externals: ...` | `externalFunctions: ...` | breaking |
+| `MontySession.start(...)` | `MontySession.feedStart(...)` | breaking |
+| `MontyRepl.feed(...)` | `MontyRepl.feedRun(...)` | breaking |
+
+### Per-package checklist (PR-B) — to be filled in
+
+- `dart_monty`: full call-site enumeration with file paths and counts.
+- `soliplex_*`: same.
+- `dart_monty_plugins`: same.
+- Follow-up consumer ticket: `dart_monty/example/web/web/index.html`
+  HTML/JS snippet update (deferred from main PR pass per agreement).
+
+---
+
+## PR-C — additive new feature parameters
+
+> Recipes land when PR-C is in review.
+
+### Quick mapping table (preview)
+
+| Before | After | Tier |
+|---|---|---|
+| `MontyResult.printOutput` only | `printCallback: (stream, text) {}` parameter (batch) | additive |
+| `OsCallHandler` for fs | `mount: [MountDir(...)]` (or keep `osHandler` for custom logic) | additive |
+| `MontyDataclass` returned | `monty.registerDataclass('User', User.from)` | additive |
+
+### Per-package checklist (PR-C) — to be filled in
+
+- `dart_monty`: which packages benefit from `MountDir` over hand-rolled
+  fs handlers.
+- `soliplex_*`: where `printCallback` replaces stream wiring.
+- Follow-up: dart:io-backed real-filesystem `MountDir` (PR-C ships
+  memory-backed only).
+
+---
+
+## Verification per consumer
+
+After bumping `dart_monty_core`:
+
+```bash
+cd <consumer_repo>
+dart pub upgrade dart_monty_core
+dart analyze --fatal-infos
+dart test
+```
+
+If a consumer breaks on PR-B, run `dart fix --apply` first; the
+analyzer pinpoints every renamed call site since old names cease to
+exist in the package surface.
+
+---
+
+## Deferred — not in this series
+
+These items sit behind separate tickets:
+
+- Streaming `printCallback` (per-flush, not batch) — needs Rust C ABI
+  callback + WASM Worker postMessage protocol changes.
+- Snapshot mid-pause (`progress.dump()` / `load_repl_snapshot`) —
+  needs Rust handle changes for snapshotting from `Paused` state.
+- `type_check` static analysis API — net-new Rust FFI symbol;
+  verifies analysis heap is isolated from execution heap.
+- `run_async` / FutureSnapshot parallel host-future resolution —
+  coordination between Dart event loop and synchronous Rust worker
+  thread (WASM).
+- Native input channel (`input_values: Vec<(String, MontyObject)>`)
+  instead of literal-prefix `inputsToCode` in `feed`.
+- Upstream list-comprehension name-shadowing — engine-level bug;
+  filed upstream.
+- `dart:io`-backed real-filesystem `MountDir` mode — PR-C ships
+  memory-backed only.

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -36,10 +36,8 @@ class Monty {
   ///
   /// Pass [osHandler] to enable Python `pathlib`, `os`, and `datetime`
   /// access. Without it, OS calls resume with a permission error.
-  factory Monty({
-    OsCallHandler? osHandler,
-    String scriptName = 'main.py',
-  }) => Monty._(MontySession(osHandler: osHandler, scriptName: scriptName));
+  factory Monty({OsCallHandler? osHandler, String scriptName = 'main.py'}) =>
+      Monty._(MontySession(osHandler: osHandler, scriptName: scriptName));
 
   Monty._(MontySession session) : _session = session;
 
@@ -136,6 +134,7 @@ class Monty {
     MontyLimits? limits,
     String? scriptName,
     OsCallHandler? osHandler,
+    Map<String, MontyCallback> externals = const {},
     Map<String, Object?>? inputs,
   }) async {
     final monty = Monty(osHandler: osHandler);
@@ -144,6 +143,7 @@ class Monty {
         code,
         limits: limits,
         scriptName: scriptName,
+        externals: externals,
         inputs: inputs,
       );
     } finally {

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -43,6 +43,10 @@ class Monty {
 
   final MontySession _session;
 
+  /// Script name used as the filename in tracebacks and error messages.
+  /// Defaults to `'main.py'` when unset.
+  String get scriptName => _session.scriptName ?? 'main.py';
+
   /// Executes Python [code] and returns the result.
   ///
   /// Variables, functions, classes, and module imports all persist across

--- a/lib/src/monty_session.dart
+++ b/lib/src/monty_session.dart
@@ -53,6 +53,12 @@ class MontySession {
   @visibleForTesting
   bool get isDisposed => _isDisposed;
 
+  /// Script name used as the filename in tracebacks and error messages.
+  ///
+  /// Returns `null` when the session was constructed without one, in which
+  /// case the engine falls back to its default (`'main.py'`).
+  String? get scriptName => _scriptName;
+
   /// Executes [code] with full Python state from previous calls available.
   ///
   /// All Python objects (variables, functions, classes, modules) persist via

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -133,6 +133,12 @@ class MontyRepl {
   bool _created = false;
   bool _disposed = false;
 
+  /// Script name used as the filename in tracebacks and error messages.
+  ///
+  /// Returns `null` when the REPL was constructed without one, in which
+  /// case the engine falls back to its default (`'main.py'`).
+  String? get scriptName => _scriptName;
+
   // ---------------------------------------------------------------------------
   // Synchronous feed
   // ---------------------------------------------------------------------------

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -132,6 +132,7 @@ class MontyRepl {
   final String? _preamble;
   bool _created = false;
   bool _disposed = false;
+  bool _pending = false;
 
   /// Script name used as the filename in tracebacks and error messages.
   ///
@@ -177,6 +178,7 @@ class MontyRepl {
     if (externals.isEmpty && osHandler == null) {
       // Fast path: no externals, use simple feedRun.
       final r = await _bindings.feedRun(effectiveCode);
+      _pending = false;
       if (r.ok) {
         return MontyResult(
           value: MontyValue.fromJson(r.value),
@@ -282,6 +284,7 @@ class MontyRepl {
   /// loop in progress). Throws [StateError] if mid-execution.
   Future<Uint8List> snapshot() {
     _checkNotDisposed();
+    _checkNotPending('snapshot');
 
     return _bindings.snapshot();
   }
@@ -289,9 +292,11 @@ class MontyRepl {
   /// Restores the REPL from bytes produced by [snapshot].
   ///
   /// The current REPL handle is freed and replaced with a new one restored
-  /// from [bytes]. Any in-flight operations must complete before calling this.
+  /// from [bytes]. Any in-flight operations must complete before calling
+  /// this. Throws [StateError] if mid-execution.
   Future<void> restore(Uint8List bytes) {
     _checkNotDisposed();
+    _checkNotPending('restore');
 
     return _bindings.restore(bytes);
   }
@@ -363,12 +368,16 @@ class MontyRepl {
   MontyProgress _translateProgress(CoreProgressResult p) {
     switch (p.state) {
       case 'complete':
+        _pending = false;
         return _buildCompleteProgress(p);
       case 'pending':
+        _pending = true;
         return _buildPendingProgress(p);
       case 'os_call':
+        _pending = true;
         return _buildOsCallProgress(p);
       case 'error':
+        _pending = false;
         _throwReplError(
           message: p.error ?? 'Unknown error',
           excType: p.excType,
@@ -424,6 +433,15 @@ class MontyRepl {
 
   void _checkNotDisposed() {
     if (_disposed) throw StateError('MontyRepl has been disposed.');
+  }
+
+  void _checkNotPending(String op) {
+    if (_pending) {
+      throw StateError(
+        'Cannot $op a MontyRepl that is mid-execution; '
+        'await all feedStart/resume calls until they return MontyComplete.',
+      );
+    }
   }
 }
 

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -197,6 +197,11 @@ class MontyRepl {
   /// Register callback names in [externalFunctions]. When Python calls one,
   /// execution pauses and returns [MontyPending]. Use [resume] or
   /// [resumeWithError] to continue.
+  ///
+  /// [externalFunctions] is `List<String>` (names only) here, distinct from
+  /// the `Map<String, MontyCallback>` form on [feed]. The list shape is
+  /// intentional: the iterative path lets the caller drive dispatch, so
+  /// only the name registry crosses the FFI/WASM boundary.
   Future<MontyProgress> feedStart(
     String code, {
     List<String>? externalFunctions,
@@ -240,6 +245,8 @@ class MontyRepl {
   /// Returns whether [source] is syntactically complete for execution.
   ///
   /// Useful for building REPL UIs that show `>>>` vs `...` prompts.
+  /// Dart-only — the upstream `pydantic_monty` Python package does not
+  /// expose this helper; it wraps the engine's incomplete-input detector.
   Future<ReplContinuationMode> detectContinuation(String source) async {
     _checkNotDisposed();
     await _ensureCreated();
@@ -331,7 +338,9 @@ class MontyRepl {
         case MontyResolveFutures():
           progress = _translateProgress(await _bindings.resume('null'));
         case MontyNameLookup():
-          // REPL doesn't support NameLookup — signal NameError to Python.
+          // The Rust handle auto-resolves NameLookup via ext_fn_names; this
+          // branch only fires when the name was not registered. Signal
+          // NameError back to Python.
           progress = _translateProgress(
             await _bindings.resumeNameLookupUndefined(),
           );

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -167,6 +167,13 @@ class MontyRepl {
         ? '${inputs_encoder.inputsToCode(inputs)}\n$code'
         : code;
 
+    // Always sync the Rust handle's ext_fn_names HashSet to this feed's
+    // externals — including clearing it when externals is empty. Without
+    // this, names registered in a previous feed leak into the next
+    // feed's NameLookup auto-resolve and surface as a confusing
+    // "no handler registered" error instead of NameError.
+    await _bindings.setExtFns(externals.keys.toList());
+
     if (externals.isEmpty && osHandler == null) {
       // Fast path: no externals, use simple feedRun.
       final r = await _bindings.feedRun(effectiveCode);
@@ -186,7 +193,6 @@ class MontyRepl {
     }
 
     // Iterative path: drive the start/resume loop, dispatching externals.
-    await _bindings.setExtFns(externals.keys.toList());
     final initial = _translateProgress(
       await _bindings.feedStart(effectiveCode),
     );

--- a/test/integration/ffi_monty_exec_externals_test.dart
+++ b/test/integration/ffi_monty_exec_externals_test.dart
@@ -1,0 +1,69 @@
+// Integration test: `Monty.exec` accepts and dispatches externals.
+//
+// `Monty.run` has always supported `externals:`; `Monty.exec` did not — Python
+// code passed to one-shot evaluation could not call back into Dart, even
+// though the convenience method otherwise mirrors `run`. This test pins the
+// fix so the parameter does not regress.
+//
+// Run: dart test test/integration/ffi_monty_exec_externals_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Monty.exec externals', () {
+    test('positional args dispatch through externals', () async {
+      final result = await Monty.exec(
+        'add(3, 4)',
+        externals: {
+          'add': (args) async => (args['_0']! as int) + (args['_1']! as int),
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 7);
+    });
+
+    test('keyword args dispatch through externals', () async {
+      final result = await Monty.exec(
+        'greet(name="World")',
+        externals: {'greet': (args) async => 'Hello, ${args['name']}!'},
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hello, World!');
+    });
+
+    test('multiple external calls within a single exec', () async {
+      var calls = 0;
+      final result = await Monty.exec(
+        'double(double(double(1)))',
+        externals: {
+          'double': (args) async {
+            calls++;
+            return (args['_0']! as int) * 2;
+          },
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 8);
+      expect(calls, 3);
+    });
+
+    test('external returning a list round-trips to Python', () async {
+      final result = await Monty.exec(
+        'sum(get_numbers())',
+        externals: {
+          'get_numbers': (_) async => [1, 2, 3, 4],
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 10);
+    });
+  });
+}

--- a/test/integration/ffi_repl_extfns_lifecycle_test.dart
+++ b/test/integration/ffi_repl_extfns_lifecycle_test.dart
@@ -1,0 +1,111 @@
+// Integration test: MontyRepl.feed re-syncs ext_fn_names on every call.
+//
+// Before this fix, MontyRepl.feed only called setExtFns on the iterative
+// path. The Rust handle's persistent ext_fn_names HashSet then leaked
+// names from earlier feeds into later feeds, surfacing as a confusing
+// "No handler registered for: <name>" error instead of a clean Python
+// NameError. The fix moves setExtFns to the top of feed() so it runs on
+// every invocation, including the fast path and including with [] when
+// externals is empty.
+//
+// Run: dart test test/integration/ffi_repl_extfns_lifecycle_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MontyRepl externals lifecycle', () {
+    test(
+      'name registered in feed N is gone in feed N+1 with empty externals',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        // Feed 1: register `fetch`, call it.
+        await repl.feed(
+          'x = fetch(1)',
+          externals: {'fetch': (args) async => (args['_0']! as int) * 10},
+        );
+
+        // Feed 2: no externals. The leftover `fetch` name must NOT be
+        // resolvable — Python should raise NameError on the fast path.
+        await expectLater(
+          repl.feed('y = fetch(2)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'fast-path feed clears externals from a prior iterative feed',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        // Iterative path: register `fetch`.
+        await repl.feed(
+          'x = fetch(7)',
+          externals: {'fetch': (args) async => args['_0']},
+        );
+
+        // Fast-path feed (no externals, no osHandler) sandwiched in
+        // between. The handle's ext_fn_names must be cleared before
+        // this feed runs, so a subsequent iterative feed without
+        // `fetch` raises NameError.
+        await repl.feed('y = x + 1');
+
+        await expectLater(
+          repl.feed('z = fetch(99)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'replacing externals between feeds invalidates the old name',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        // Feed 1: register `a`.
+        await repl.feed(
+          'r = a(5)',
+          externals: {'a': (args) async => (args['_0']! as int) + 1},
+        );
+
+        // Feed 2: register `b` instead. `a` must no longer resolve when
+        // referenced again.
+        await repl.feed(
+          'r = b(5)',
+          externals: {'b': (args) async => (args['_0']! as int) * 2},
+        );
+
+        await expectLater(
+          repl.feed('r = a(5)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/test/integration/ffi_repl_snapshot_lifecycle_test.dart
+++ b/test/integration/ffi_repl_snapshot_lifecycle_test.dart
@@ -1,0 +1,101 @@
+// Integration test: snapshot/restore reject mid-pause execution.
+//
+// Before this fix, calling MontyRepl.snapshot while a feedStart/resume loop
+// was paused returned an opaque Rust-side error. Dart now tracks pending
+// state and throws StateError with an actionable message instead.
+//
+// Run: dart test test/integration/ffi_repl_snapshot_lifecycle_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MontyRepl snapshot/restore lifecycle', () {
+    test('snapshot throws StateError when paused mid-execution', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      final progress = await repl.feedStart(
+        'tool()',
+        externalFunctions: ['tool'],
+      );
+      expect(progress, isA<MontyPending>());
+
+      expect(
+        repl.snapshot,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('mid-execution'),
+          ),
+        ),
+      );
+    });
+
+    test('snapshot succeeds after resume completes the paused call', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feedStart('tool()', externalFunctions: ['tool']);
+      final completed = await repl.resume(42);
+      expect(completed, isA<MontyComplete>());
+
+      final bytes = await repl.snapshot();
+      expect(bytes, isA<Uint8List>());
+      expect(bytes, isNotEmpty);
+    });
+
+    test('restore throws StateError when paused mid-execution', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      // Capture clean snapshot bytes for restore.
+      await repl.feed('x = 1');
+      final bytes = await repl.snapshot();
+
+      // Pause execution and attempt restore.
+      await repl.feedStart('tool()', externalFunctions: ['tool']);
+      expect(
+        () => repl.restore(bytes),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('mid-execution'),
+          ),
+        ),
+      );
+    });
+
+    test('snapshot is allowed after a fast-path feed', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      // Fast path (no externals, no osHandler).
+      await repl.feed('x = 7');
+      final bytes = await repl.snapshot();
+      expect(bytes, isNotEmpty);
+    });
+
+    test('snapshot is allowed after an iterative feed completes', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      // Iterative path that completes naturally — externals dispatched.
+      final r = await repl.feed(
+        'r = double(21)',
+        externals: {'double': (args) async => (args['_0']! as int) * 2},
+      );
+      expect(r.error, isNull);
+
+      final bytes = await repl.snapshot();
+      expect(bytes, isNotEmpty);
+    });
+  });
+}

--- a/test/integration/wasm_monty_exec_externals_test.dart
+++ b/test/integration/wasm_monty_exec_externals_test.dart
@@ -1,0 +1,66 @@
+// Run with dart2js:  dart test test/integration/wasm_monty_exec_externals_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_monty_exec_externals_test.dart -p chrome --compiler dart2wasm --run-skipped
+//
+// WASM twin of ffi_monty_exec_externals_test.dart. `Monty.run` has always
+// supported `externals:`; `Monty.exec` did not. This file pins the fix on
+// the WASM backend so the parameter does not regress in the browser.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Monty.exec externals', () {
+    test('positional args dispatch through externals', () async {
+      final result = await Monty.exec(
+        'add(3, 4)',
+        externals: {
+          'add': (args) async => (args['_0']! as int) + (args['_1']! as int),
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 7);
+    });
+
+    test('keyword args dispatch through externals', () async {
+      final result = await Monty.exec(
+        'greet(name="World")',
+        externals: {'greet': (args) async => 'Hello, ${args['name']}!'},
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 'Hello, World!');
+    });
+
+    test('multiple external calls within a single exec', () async {
+      var calls = 0;
+      final result = await Monty.exec(
+        'double(double(double(1)))',
+        externals: {
+          'double': (args) async {
+            calls++;
+            return (args['_0']! as int) * 2;
+          },
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 8);
+      expect(calls, 3);
+    });
+
+    test('external returning a list round-trips to Python', () async {
+      final result = await Monty.exec(
+        'sum(get_numbers())',
+        externals: {
+          'get_numbers': (_) async => [1, 2, 3, 4],
+        },
+      );
+
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 10);
+    });
+  });
+}

--- a/test/integration/wasm_repl_extfns_lifecycle_test.dart
+++ b/test/integration/wasm_repl_extfns_lifecycle_test.dart
@@ -1,0 +1,95 @@
+// Run with dart2js:  dart test test/integration/wasm_repl_extfns_lifecycle_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_repl_extfns_lifecycle_test.dart -p chrome --compiler dart2wasm --run-skipped
+//
+// WASM twin of ffi_repl_extfns_lifecycle_test.dart. The fix lives in
+// MontyRepl.feed (Dart), but the symptom surfaces through the Rust
+// handle's ext_fn_names HashSet which is identical FFI/WASM. Pin the
+// behavior on both backends.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MontyRepl externals lifecycle', () {
+    test(
+      'name registered in feed N is gone in feed N+1 with empty externals',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        await repl.feed(
+          'x = fetch(1)',
+          externals: {'fetch': (args) async => (args['_0']! as int) * 10},
+        );
+
+        await expectLater(
+          repl.feed('y = fetch(2)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'fast-path feed clears externals from a prior iterative feed',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        await repl.feed(
+          'x = fetch(7)',
+          externals: {'fetch': (args) async => args['_0']},
+        );
+
+        await repl.feed('y = x + 1');
+
+        await expectLater(
+          repl.feed('z = fetch(99)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'replacing externals between feeds invalidates the old name',
+      () async {
+        final repl = MontyRepl();
+        addTearDown(repl.dispose);
+
+        await repl.feed(
+          'r = a(5)',
+          externals: {'a': (args) async => (args['_0']! as int) + 1},
+        );
+
+        await repl.feed(
+          'r = b(5)',
+          externals: {'b': (args) async => (args['_0']! as int) * 2},
+        );
+
+        await expectLater(
+          repl.feed('r = a(5)'),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.excType,
+              'excType',
+              'NameError',
+            ),
+          ),
+        );
+      },
+    );
+  });
+}

--- a/test/integration/wasm_repl_snapshot_lifecycle_test.dart
+++ b/test/integration/wasm_repl_snapshot_lifecycle_test.dart
@@ -1,0 +1,95 @@
+// Run with dart2js:  dart test test/integration/wasm_repl_snapshot_lifecycle_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_repl_snapshot_lifecycle_test.dart -p chrome --compiler dart2wasm --run-skipped
+//
+// WASM twin of ffi_repl_snapshot_lifecycle_test.dart. Pending-state
+// tracking lives in MontyRepl (Dart), so the StateError contract is
+// identical FFI/WASM. Pin the behavior on both backends.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MontyRepl snapshot/restore lifecycle', () {
+    test('snapshot throws StateError when paused mid-execution', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      final progress = await repl.feedStart(
+        'tool()',
+        externalFunctions: ['tool'],
+      );
+      expect(progress, isA<MontyPending>());
+
+      expect(
+        repl.snapshot,
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('mid-execution'),
+          ),
+        ),
+      );
+    });
+
+    test('snapshot succeeds after resume completes the paused call', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feedStart('tool()', externalFunctions: ['tool']);
+      final completed = await repl.resume(42);
+      expect(completed, isA<MontyComplete>());
+
+      final bytes = await repl.snapshot();
+      expect(bytes, isA<Uint8List>());
+      expect(bytes, isNotEmpty);
+    });
+
+    test('restore throws StateError when paused mid-execution', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('x = 1');
+      final bytes = await repl.snapshot();
+
+      await repl.feedStart('tool()', externalFunctions: ['tool']);
+      expect(
+        () => repl.restore(bytes),
+        throwsA(
+          isA<StateError>().having(
+            (e) => e.message,
+            'message',
+            contains('mid-execution'),
+          ),
+        ),
+      );
+    });
+
+    test('snapshot is allowed after a fast-path feed', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      await repl.feed('x = 7');
+      final bytes = await repl.snapshot();
+      expect(bytes, isNotEmpty);
+    });
+
+    test('snapshot is allowed after an iterative feed completes', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+
+      final r = await repl.feed(
+        'r = double(21)',
+        externals: {'double': (args) async => (args['_0']! as int) * 2},
+      );
+      expect(r.error, isNull);
+
+      final bytes = await repl.snapshot();
+      expect(bytes, isNotEmpty);
+    });
+  });
+}

--- a/test/unit/repl/monty_repl_metadata_test.dart
+++ b/test/unit/repl/monty_repl_metadata_test.dart
@@ -1,0 +1,50 @@
+// Unit tests for MontyRepl/MontySession/Monty scriptName getter.
+//
+// scriptName is the filename surfaced in Python tracebacks. Both the REPL
+// (low-level) and the Session (high-level) accept it at construction; Monty
+// defaults to 'main.py' when unset, mirroring the reference Python class.
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('scriptName getter', () {
+    test('Monty defaults to main.py when no scriptName given', () {
+      final monty = Monty();
+      addTearDown(monty.dispose);
+      expect(monty.scriptName, 'main.py');
+    });
+
+    test('Monty round-trips a custom scriptName', () {
+      final monty = Monty(scriptName: 'analysis.py');
+      addTearDown(monty.dispose);
+      expect(monty.scriptName, 'analysis.py');
+    });
+
+    test('MontySession returns null when no scriptName given', () {
+      final session = MontySession();
+      addTearDown(session.dispose);
+      expect(session.scriptName, isNull);
+    });
+
+    test('MontySession round-trips a custom scriptName', () {
+      final session = MontySession(scriptName: 'job.py');
+      addTearDown(session.dispose);
+      expect(session.scriptName, 'job.py');
+    });
+
+    test('MontyRepl returns null when no scriptName given', () async {
+      final repl = MontyRepl();
+      addTearDown(repl.dispose);
+      expect(repl.scriptName, isNull);
+    });
+
+    test('MontyRepl round-trips a custom scriptName', () async {
+      final repl = MontyRepl(scriptName: 'task.py');
+      addTearDown(repl.dispose);
+      expect(repl.scriptName, 'task.py');
+    });
+  });
+}

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -94,5 +94,6 @@ dart test \
   test/integration/wasm_fixture_test.dart \
   test/integration/wasm_monty_exec_externals_test.dart \
   test/integration/wasm_multi_repl_test.dart \
+  test/integration/wasm_repl_extfns_lifecycle_test.dart \
   test/integration/wasm_setextfns_test.dart \
   "$@"

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -95,5 +95,6 @@ dart test \
   test/integration/wasm_monty_exec_externals_test.dart \
   test/integration/wasm_multi_repl_test.dart \
   test/integration/wasm_repl_extfns_lifecycle_test.dart \
+  test/integration/wasm_repl_snapshot_lifecycle_test.dart \
   test/integration/wasm_setextfns_test.dart \
   "$@"

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -92,6 +92,7 @@ dart test \
   --concurrency 2 \
   test/integration/wasm_datetime_oscall_test.dart \
   test/integration/wasm_fixture_test.dart \
+  test/integration/wasm_monty_exec_externals_test.dart \
   test/integration/wasm_multi_repl_test.dart \
   test/integration/wasm_setextfns_test.dart \
   "$@"


### PR DESCRIPTION
First in a 3-PR series aligning `dart_monty_core` with the reference
`pydantic_monty` Python package (per `API_REVIEW.md`,
`MISSING_FEATURES_PLAN.md`, and the planning docs in
`~/dev/plans/dart_monty_core_*`). PR-A is **non-breaking** — it ships
bug fixes, missing accessors, and tightened error semantics so the
larger structural work in PR-B can land on a clean baseline.

Future PRs in the series:
- **PR-B** — `Monty(code)` reshape, `externals` → `externalFunctions`,
  `feed` → `feedRun`, `MontySession.start` → `feedStart`. Breaking
  rename cluster + README overhaul.
- **PR-C** — `printCallback` (batch), `MountDir` (memory-backed),
  dataclass registration. Additive only.

## Commits

| # | Commit | Subject |
|---|---|---|
| c01 | 1caa1e8 | fix(monty): accept externals on Monty.exec |
| c02 | 0946f0d | docs(repl): correct stale NameLookup comment, mark Dart-only helpers |
| c03 | 43d3d75 | feat(repl): expose scriptName as a public getter |
| c04 | 58e80bc | fix(repl): always sync ext_fn_names HashSet across feeds |
| c05 | e74bfb7 | feat(repl): throw StateError for snapshot/restore mid-pause |
| docs | d3d1741 | docs(changelog): describe PR-A + add CONSUMER_MIGRATION.md skeleton |

## What's fixed

- **`Monty.exec` accepts `externals:`** — `Monty.run` always supported
  externals; the static one-shot wrapper silently dropped them.
- **`ext_fn_names` lifecycle bug** — the iterative path called
  `setExtFns`, the fast path didn't. Names registered in a previous
  feed leaked into the next feed's NameLookup resolution and surfaced
  as a confusing "no handler registered" error instead of NameError.
  `setExtFns` now runs at the top of `feed()` (with `[]` when
  externals is empty), covering both paths.
- **Snapshot mid-pause UX** — `MontyRepl.snapshot` / `restore` now
  throw `StateError` with an actionable message instead of bubbling
  an opaque Rust-side error.

## What's added

- **Public `scriptName` getter** on `MontyRepl`, `MontySession`, and
  `Monty`. Mirrors `pydantic_monty._monty.pyi:267`.

## Test plan

- [x] `dart format --line-length=80 --set-exit-if-changed lib/ test/ tool/`
- [x] `dart analyze --fatal-infos` — 0 issues
- [x] **Unit (vm) — 73/73 pass** (`dart test test/unit/`)
- [x] **FFI integration (vm) — 982 pass, 3 pre-existing xfail failures**
      (`oracle_ffi_ext_test.dart::ext_call__name_lookup_fn_{07,08,10}_xfail.py`).
      Those three fixtures are unchanged in this PR (`git diff
      origin/main..HEAD` confirms `oracle_ffi_ext_test.dart` is
      untouched) and surface a `NotImplementedError` vs
      `RuntimeError` mismatch in upstream `monty` engine — tracked
      separately, not introduced here.
- [x] **WASM unit-style (chrome) — 498/498 pass**
      (`bash tool/test_wasm_unit.sh`)
- [x] New tests added on **both** backends:
  - `ffi_monty_exec_externals_test.dart` + WASM twin (4 tests each)
  - `ffi_repl_extfns_lifecycle_test.dart` + WASM twin (3 tests each)
  - `ffi_repl_snapshot_lifecycle_test.dart` + WASM twin (5 tests each)
  - `test/unit/repl/monty_repl_metadata_test.dart` (6 tests)
- [x] WASM twin group names match their FFI counterparts verbatim;
      no platform prefix in test descriptions (file naming +
      `@Tags(['wasm'])` carry that signal).
- [ ] CI green (PR's run)

## Consumer impact

None. PR-A is non-breaking. Per-consumer checklist for the wider
series tracked in `docs/CONSUMER_MIGRATION.md`.