### PR TITLE
docs(example): add 10_dataclasses, 11_print_callback, 12_mount_dir

### DIFF
--- a/example/10_dataclasses.dart
+++ b/example/10_dataclasses.dart
@@ -1,0 +1,154 @@
+// 10 — Dataclasses: MontyDataclass + dartAttrs + hydrate
+//
+// Python `@dataclass` values cross the boundary as `MontyDataclass`. Dart
+// can read their fields directly, convert all attrs to plain Dart values
+// via `dartAttrs`, or hydrate into a user class with `hydrate(factory)`.
+//
+// Covers: MontyDataclass.name / attrs / fieldNames / frozen,
+//         MontyDataclass.dartAttrs, MontyDataclass.hydrate,
+//         caller-side registry pattern for multiple types.
+//
+// Run: dart run example/10_dataclasses.dart
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+
+// ── User-defined Dart classes the example hydrates into. ──────────────────────
+
+class User {
+  const User({required this.name, required this.age});
+
+  factory User.fromAttrs(Map<String, Object?> a) =>
+      User(name: a['name']! as String, age: a['age']! as int);
+
+  final String name;
+  final int age;
+
+  @override
+  String toString() => 'User(name=$name, age=$age)';
+}
+
+class Order {
+  const Order({required this.id, required this.total});
+
+  factory Order.fromAttrs(Map<String, Object?> a) =>
+      Order(id: a['id']! as int, total: a['total']! as double);
+
+  final int id;
+  final double total;
+
+  @override
+  String toString() => 'Order(id=$id, total=$total)';
+}
+
+// ── Helper: build the dataclass JSON envelope returned from a Dart callback.
+// ─────────────────────────────────────────────────────────────────────────────
+
+Map<String, Object?> _dataclass({
+  required String name,
+  required int typeId,
+  required Map<String, Object?> attrs,
+  bool frozen = false,
+}) => {
+  '__type': 'dataclass',
+  'name': name,
+  'type_id': typeId,
+  'field_names': attrs.keys.toList(),
+  'attrs': attrs,
+  'frozen': frozen,
+};
+
+Future<void> main() async {
+  await _readingFields();
+  await _hydrateOne();
+  await _hydrateRegistry();
+}
+
+// ── Read fields directly off MontyDataclass ──────────────────────────────────
+// MontyDataclass exposes name, fieldNames, frozen, and the typed attrs map.
+// Use dartAttrs when you want a plain `Map<String, Object?>` instead of
+// `Map<String, MontyValue>`.
+Future<void> _readingFields() async {
+  print('\n── reading fields ──');
+
+  final r = await Monty('make_user("alice", 30)').run(
+    externalFunctions: {
+      'make_user': (args) async => _dataclass(
+        name: 'User',
+        typeId: 1,
+        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+      ),
+    },
+  );
+
+  final dc = r.value as MontyDataclass;
+  print('name:       ${dc.name}'); // User
+  print('typeId:     ${dc.typeId}'); // 1
+  print('fields:     ${dc.fieldNames}'); // [name, age]
+  print('frozen:     ${dc.frozen}'); // false
+  print('attrs[name]: ${dc.attrs["name"]}'); // MontyString(alice)
+  print('dartAttrs:   ${dc.dartAttrs}'); // {name: alice, age: 30}
+}
+
+// ── Hydrate into a user-supplied Dart class via a factory ────────────────────
+// hydrate<T>(factory) calls factory(dartAttrs) and returns the typed object.
+// The factory signature is `T Function(Map<String, Object?> attrs)`.
+Future<void> _hydrateOne() async {
+  print('\n── hydrate (one type) ──');
+
+  final r = await Monty('make_user("bob", 42)').run(
+    externalFunctions: {
+      'make_user': (args) async => _dataclass(
+        name: 'User',
+        typeId: 1,
+        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+      ),
+    },
+  );
+
+  final dc = r.value as MontyDataclass;
+  final user = dc.hydrate(User.fromAttrs);
+  print(user); // User(name=bob, age=42)
+}
+
+// ── Caller-side registry for multiple dataclass types ────────────────────────
+// A `Map<String, Object Function(Map<String, Object?>)>` keyed by dataclass
+// name is the natural way to dispatch. The framework doesn't ship a built-in
+// registry on Monty/MontyRepl — composing one at the call site keeps the
+// public surface small and the type story clear.
+Future<void> _hydrateRegistry() async {
+  print('\n── hydrate (registry) ──');
+
+  final factories = <String, Object Function(Map<String, Object?>)>{
+    'User': User.fromAttrs,
+    'Order': Order.fromAttrs,
+  };
+
+  Object? hydrate(MontyValue value) {
+    if (value is! MontyDataclass) return value;
+    final factory = factories[value.name];
+    return factory == null ? value : factory(value.dartAttrs);
+  }
+
+  final externalFunctions = <String, MontyCallback>{
+    'make_user': (a) async => _dataclass(
+      name: 'User',
+      typeId: 1,
+      attrs: {'name': 'carol', 'age': 7},
+    ),
+    'make_order': (a) async => _dataclass(
+      name: 'Order',
+      typeId: 2,
+      attrs: {'id': 99, 'total': 12.5},
+    ),
+  };
+
+  final ru = await Monty(
+    'make_user()',
+  ).run(externalFunctions: externalFunctions);
+  final ro = await Monty(
+    'make_order()',
+  ).run(externalFunctions: externalFunctions);
+
+  print(hydrate(ru.value)); // User(name=carol, age=7)
+  print(hydrate(ro.value)); // Order(id=99, total=12.5)
+}

--- a/example/11_print_callback.dart
+++ b/example/11_print_callback.dart
@@ -1,0 +1,88 @@
+// 11 — printCallback
+//
+// Python's `print()` output is normally surfaced via `MontyResult.printOutput`
+// after execution finishes. The `printCallback` parameter delivers the same
+// output to a Dart callback before run/feedRun returns — useful for piping
+// to a logger, UI buffer, or stream.
+//
+// printCallback is a *batch* callback: it fires once per call with the
+// entire captured stdout text. Per-flush streaming requires Rust + WASM
+// Worker postMessage extensions and is a separate item.
+//
+// Covers: printCallback on Monty.exec, Monty(code).run, MontyRepl.feedRun;
+//         the stream argument is always 'stdout'.
+//
+// Run: dart run example/11_print_callback.dart
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+
+Future<void> main() async {
+  await _oneShot();
+  await _replPerFeed();
+  await _piping();
+}
+
+// ── Monty.exec / Monty(code).run ─────────────────────────────────────────────
+// The callback fires once with the entire stdout buffer. `stream` is always
+// 'stdout' for now (matches Python's Literal['stdout']).
+Future<void> _oneShot() async {
+  print('\n── one-shot exec ──');
+
+  await Monty.exec(
+    'print("hello")\nprint("from python")',
+    printCallback: (stream, text) {
+      print('[$stream] ${text.trimRight()}');
+    },
+  );
+}
+
+// ── MontyRepl.feedRun ────────────────────────────────────────────────────────
+// On a stateful REPL the callback fires per feedRun call, not per print.
+// The captured text is the full stdout buffer for that feed.
+Future<void> _replPerFeed() async {
+  print('\n── stateful repl ──');
+
+  final repl = MontyRepl();
+  try {
+    await repl.feedRun(
+      'print("first feed line 1")\nprint("first feed line 2")',
+      printCallback: (stream, text) => print('[feed 1] ${text.trimRight()}'),
+    );
+
+    await repl.feedRun(
+      'print("second feed")',
+      printCallback: (stream, text) => print('[feed 2] ${text.trimRight()}'),
+    );
+
+    // Calls without printCallback still populate MontyResult.printOutput.
+    final r = await repl.feedRun('print("third feed (read from result)")');
+    print('[result.printOutput] ${r.printOutput?.trimRight()}');
+  } finally {
+    await repl.dispose();
+  }
+}
+
+// ── Common idiom: pipe Python prints to a Dart logger or buffer ──────────────
+// The callback closes over Dart-side state, so accumulating into a list,
+// forwarding to a Logger, or pushing to a StreamController is direct.
+Future<void> _piping() async {
+  print('\n── piping ──');
+
+  final lines = <String>[];
+
+  void capture(String stream, String text) {
+    for (final line in text.split('\n')) {
+      if (line.isNotEmpty) lines.add(line);
+    }
+  }
+
+  await Monty(
+    'for i in range(3):\n'
+    '    print(f"line {i}")',
+  ).run(printCallback: capture);
+
+  print('captured ${lines.length} lines:');
+  for (final line in lines) {
+    print('  - $line');
+  }
+}

--- a/example/12_mount_dir.dart
+++ b/example/12_mount_dir.dart
@@ -1,0 +1,143 @@
+// 12 — MountDir + memoryMountedOsHandler
+//
+// Python `pathlib.Path` operations route through an OsCallHandler. For
+// the common case of "give Python access to a sandboxed filesystem,"
+// memoryMountedOsHandler builds a handler from a list of MountDir
+// declarations and an in-memory `Map<String, String>` backing store.
+//
+// The handler enforces:
+//  - Path normalisation (`.`, `..`, empty segments collapsed).
+//  - Sandbox boundary — `..` traversal that escapes raises
+//    PermissionError.
+//  - MountMode (readOnly rejects writes).
+//  - Per-write writeBytesLimit (cumulative tracking is a follow-up).
+//
+// Compared to a hand-rolled OsCallHandler (see example 03), MountDir
+// declares the policy once and lets the helper enforce it.
+//
+// Covers: MountDir, MountMode, memoryMountedOsHandler, fallthrough
+//         handler chaining for non-Path operations.
+//
+// Run: dart run example/12_mount_dir.dart
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+
+Future<void> main() async {
+  await _readWrite();
+  await _readOnly();
+  await _writeLimit();
+  await _fallthrough();
+}
+
+// ── Basic read/write through a single mount ──────────────────────────────────
+Future<void> _readWrite() async {
+  print('\n── read / write ──');
+
+  final vfs = <String, String>{
+    '/data/hello.txt': 'Hello from VFS!',
+  };
+
+  final handler = memoryMountedOsHandler(
+    mounts: const [MountDir(virtualPath: '/data')],
+    vfs: vfs,
+  );
+
+  final read = await Monty(
+    'import pathlib\npathlib.Path("/data/hello.txt").read_text()',
+  ).run(osHandler: handler);
+  print('read:   ${read.value}');
+
+  await Monty(
+    'import pathlib\n'
+    'pathlib.Path("/data/new.txt").write_text("written from Python")',
+  ).run(osHandler: handler);
+  print('wrote:  ${vfs["/data/new.txt"]}');
+}
+
+// ── readOnly mounts reject writes from Python ────────────────────────────────
+// PermissionError surfaces to the caller via MontyResult.error.
+Future<void> _readOnly() async {
+  print('\n── readOnly ──');
+
+  final handler = memoryMountedOsHandler(
+    mounts: const [
+      MountDir(virtualPath: '/secrets', mode: MountMode.readOnly),
+    ],
+    vfs: {'/secrets/api_key.txt': 'sk-12345'},
+  );
+
+  // Reads succeed.
+  final ok = await Monty(
+    'import pathlib\npathlib.Path("/secrets/api_key.txt").read_text()',
+  ).run(osHandler: handler);
+  print('read:   ${ok.value}');
+
+  // Writes fail.
+  final fail = await Monty(
+    'import pathlib\n'
+    'pathlib.Path("/secrets/api_key.txt").write_text("hijacked")',
+  ).run(osHandler: handler);
+  print('write:  error="${fail.error?.message}"');
+}
+
+// ── writeBytesLimit caps per-call write size ─────────────────────────────────
+// Useful when accepting writes from Python you don't fully trust.
+Future<void> _writeLimit() async {
+  print('\n── writeBytesLimit ──');
+
+  final handler = memoryMountedOsHandler(
+    mounts: const [MountDir(virtualPath: '/tmp', writeBytesLimit: 16)],
+    vfs: <String, String>{},
+  );
+
+  final small = await Monty(
+    'import pathlib\npathlib.Path("/tmp/ok.txt").write_text("short")',
+  ).run(osHandler: handler);
+  print(
+    'small:  error=${small.error == null ? "<none>" : small.error?.message}',
+  );
+
+  final big = await Monty(
+    'import pathlib\n'
+    'pathlib.Path("/tmp/big.txt").write_text("x" * 100)',
+  ).run(osHandler: handler);
+  print('big:    error="${big.error?.message}"');
+}
+
+// ── fallthrough — chain another handler for non-mount operations ────────────
+// memoryMountedOsHandler only intercepts Path.* operations under a known
+// mount. Anything else (os.getenv, datetime.now, paths outside any mount)
+// is forwarded to fallthrough — typically your existing OsCallHandler.
+Future<void> _fallthrough() async {
+  print('\n── fallthrough ──');
+
+  Future<Object?> envHandler(
+    String op,
+    List<Object?> args,
+    Map<String, Object?>? kwargs,
+  ) async {
+    if (op == 'os.getenv') {
+      const env = {'APP_ENV': 'production', 'DEBUG': 'false'};
+      return env[args.first! as String];
+    }
+    return null;
+  }
+
+  final handler = memoryMountedOsHandler(
+    mounts: const [MountDir(virtualPath: '/data')],
+    vfs: {'/data/hello.txt': 'Hello!'},
+    fallthrough: envHandler,
+  );
+
+  // Routes through memoryMountedOsHandler.
+  final read = await Monty(
+    'import pathlib\npathlib.Path("/data/hello.txt").read_text()',
+  ).run(osHandler: handler);
+  print('mount:  ${read.value}');
+
+  // Routes through fallthrough.
+  final env = await Monty(
+    'import os\nos.getenv("APP_ENV")',
+  ).run(osHandler: handler);
+  print('env:    ${env.value}');
+}


### PR DESCRIPTION
Adds three runnable examples covering the additive features that landed in PR-A/B/C:

- **`10_dataclasses.dart`** — `MontyDataclass.dartAttrs`, `hydrate(factory)`, and the caller-side registry pattern keyed by `MontyDataclass.name`.
- **`11_print_callback.dart`** — `printCallback` on `Monty.exec`, `Monty(code).run`, and `MontyRepl.feedRun`. Three sections: one-shot, per-feed on a stateful REPL, and an "accumulate to a Dart buffer" idiom.
- **`12_mount_dir.dart`** — `MountDir` + `memoryMountedOsHandler`. Read/write, `MountMode.readOnly`, `writeBytesLimit`, and chaining a `fallthrough` handler for `os.getenv` / `datetime.now`.

Sits alongside `03_externals_and_os.dart` (raw `OsCallHandler`) — 12 is the "declarative" alternative for filesystem-shaped sandboxes.

## Test plan

- [x] `dart format` clean
- [x] `dart analyze` only the standard `avoid_print` example warnings
- [x] `dart run example/{10,11,12}_*.dart` all exit 0 with expected output
- [x] `example_smoke_test.dart` picks up all three: 8/8 ran + 4 pre-skipped (the 4 are pre-existing TODOs from `_skipReasons`)