### PR TITLE
feat(api): add Monty.typeCheck for static type analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Added
+
+- **`Monty.typeCheck(code, {prefixCode, scriptName})`** — static type
+  analysis that returns a `List<MontyTypingError>` (empty when clean).
+  Stateless — uses an isolated analysis heap. Wraps upstream
+  `monty-type-checking`. New `MontyTypingError` value class exposes
+  `code`, `message`, `path`, `line`/`column`, `endLine`/`endColumn`, and
+  `url`. WASM bridge gains a `sched_yield` no-op to satisfy salsa-rs's
+  WASI imports.
+
 ### Upgraded
 
 - Rust dependency `monty` bumped from `v0.0.14` → `v0.0.17` (Cargo.toml +

--- a/example/10_dataclasses.dart
+++ b/example/10_dataclasses.dart
@@ -130,16 +130,10 @@ Future<void> _hydrateRegistry() async {
   }
 
   final externalFunctions = <String, MontyCallback>{
-    'make_user': (a) async => _dataclass(
-      name: 'User',
-      typeId: 1,
-      attrs: {'name': 'carol', 'age': 7},
-    ),
-    'make_order': (a) async => _dataclass(
-      name: 'Order',
-      typeId: 2,
-      attrs: {'id': 99, 'total': 12.5},
-    ),
+    'make_user': (a) async =>
+        _dataclass(name: 'User', typeId: 1, attrs: {'name': 'carol', 'age': 7}),
+    'make_order': (a) async =>
+        _dataclass(name: 'Order', typeId: 2, attrs: {'id': 99, 'total': 12.5}),
   };
 
   final ru = await Monty(

--- a/example/12_mount_dir.dart
+++ b/example/12_mount_dir.dart
@@ -33,9 +33,7 @@ Future<void> main() async {
 Future<void> _readWrite() async {
   print('\n── read / write ──');
 
-  final vfs = <String, String>{
-    '/data/hello.txt': 'Hello from VFS!',
-  };
+  final vfs = <String, String>{'/data/hello.txt': 'Hello from VFS!'};
 
   final handler = memoryMountedOsHandler(
     mounts: const [MountDir(virtualPath: '/data')],
@@ -60,9 +58,7 @@ Future<void> _readOnly() async {
   print('\n── readOnly ──');
 
   final handler = memoryMountedOsHandler(
-    mounts: const [
-      MountDir(virtualPath: '/secrets', mode: MountMode.readOnly),
-    ],
+    mounts: const [MountDir(virtualPath: '/secrets', mode: MountMode.readOnly)],
     vfs: {'/secrets/api_key.txt': 'sk-12345'},
   );
 

--- a/example/13_type_check.dart
+++ b/example/13_type_check.dart
@@ -1,0 +1,88 @@
+// 13 — Static type checking via Monty.typeCheck
+//
+// Monty ships a static analyser (a subset of Python's type system) that
+// reports type errors without executing the code. Useful for IDE-shaped
+// integrations: surface errors before the user clicks Run.
+//
+// The analyser uses a separate, pooled in-memory database scrubbed on
+// drop, so it never touches an in-flight Monty.run / MontyRepl.feedRun
+// execution heap.
+//
+// Covers: Monty.typeCheck, MontyTypingError (code, message, path,
+//         line, column, url), prefixCode for input declarations.
+//
+// Run: dart run example/13_type_check.dart
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+
+Future<void> main() async {
+  await _cleanCode();
+  await _annotatedMistake();
+  await _inferenceWithoutAnnotations();
+  await _prefixCodeForInputs();
+  await _multipleDiagnostics();
+}
+
+// ── Clean code returns an empty list ─────────────────────────────────────────
+// No diagnostics → `Monty.typeCheck` resolves to an empty `List<MontyTypingError>`.
+Future<void> _cleanCode() async {
+  print('\n── clean code ──');
+  final errors = await Monty.typeCheck('x: int = 1\ny: int = x + 1');
+  print('errors: ${errors.length}'); // 0
+}
+
+// ── Annotated mismatch flagged precisely ─────────────────────────────────────
+// Each diagnostic carries a code (`invalid-assignment`), a message, the
+// file path, and 1-indexed line/column — enough for an editor to render
+// the error inline.
+Future<void> _annotatedMistake() async {
+  print('\n── annotated mistake ──');
+  const code = 'x: int = "not an int"';
+  final errors = await Monty.typeCheck(code, scriptName: 'incompat.py');
+  for (final e in errors) {
+    print('${e.path}:${e.line}:${e.column}  ${e.code}: ${e.message}');
+    if (e.url != null) print('  doc: ${e.url}');
+  }
+}
+
+// ── Inference catches obvious clashes even without annotations ───────────────
+// `"a" + 1` is flagged as `unsupported-operator` because the analyser
+// infers literal types eagerly. This means many real-world bugs are
+// caught even when the user hasn't added annotations.
+Future<void> _inferenceWithoutAnnotations() async {
+  print('\n── inference (no annotations) ──');
+  final errors = await Monty.typeCheck('x = "anything"\ny = x + 1');
+  for (final e in errors) {
+    print('  ${e.code}: ${e.message}');
+  }
+}
+
+// ── prefixCode declares names visible to the analyser ────────────────────────
+// Use prefixCode to inject `inputs` declarations or external function
+// signatures so the analyser knows their types. Without it, references
+// to those names look unresolved.
+Future<void> _prefixCodeForInputs() async {
+  print('\n── prefixCode ──');
+
+  const main = 'doubled: int = x * 2';
+
+  final without = await Monty.typeCheck(main);
+  print('without prefixCode: ${without.length} errors');
+
+  final with_ = await Monty.typeCheck(main, prefixCode: 'x: int = 0');
+  print('with prefixCode:    ${with_.length} errors');
+}
+
+// ── Multiple diagnostics arrive sorted by line ───────────────────────────────
+Future<void> _multipleDiagnostics() async {
+  print('\n── multiple diagnostics ──');
+  const code = '''
+a: int = "first"
+b: int = "second"
+c: int = "third"
+''';
+  final errors = await Monty.typeCheck(code);
+  for (final e in errors) {
+    print('  line ${e.line}: ${e.message}');
+  }
+}

--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -436,6 +436,33 @@ async function compile(code, scriptName) {
 }
 
 /**
+ * Run static type checking on Python source code.
+ *
+ * Stateless — no handle is created or modified. Resolves to a JSON
+ * string with `{ ok, diagnosticsJson }` where `diagnosticsJson` is the
+ * Monty `json` format render of the diagnostics, or `null` when the
+ * code type-checks cleanly.
+ *
+ * @param {string} code        Python source code.
+ * @param {string} prefixCode  Optional prefix code prepended before checking.
+ * @param {string} scriptName  Script name for diagnostic spans (optional).
+ * @returns {Promise<string>}  JSON-encoded `{ ok, diagnosticsJson, ... }`.
+ */
+async function typeCheck(code, prefixCode, scriptName) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) {
+    return JSON.stringify({ ok: false, error: 'Not initialized' });
+  }
+
+  const session = sessions.get(sid);
+  const msg = { type: 'typeCheck', code };
+  if (prefixCode) msg.prefixCode = prefixCode;
+  if (scriptName) msg.scriptName = scriptName;
+  const result = await callWorker(sid, msg, session.timeoutMs);
+  return JSON.stringify(result);
+}
+
+/**
  * Run precompiled bytecode to completion.
  *
  * @param {string} dataBase64 Base64-encoded compiled snapshot bytes.
@@ -720,6 +747,7 @@ window.DartMontyBridge = {
   snapshot,
   restore,
   compile,
+  typeCheck,
   runPrecompiled,
   startPrecompiled,
   discover,

--- a/js/src/wasm_glue.js
+++ b/js/src/wasm_glue.js
@@ -76,6 +76,13 @@ function createWasiImports(getMemory) {
     proc_exit(code) {
       throw new Error(`WASI proc_exit called with code ${code}`);
     },
+
+    // No-op — JS is single-threaded; there's nothing to yield to.
+    // Required by salsa-rs (the incremental computation framework
+    // pulled in by monty-type-checking).
+    sched_yield() {
+      return 0;
+    },
   };
 }
 

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -1230,6 +1230,69 @@ function handleDispose(id) {
 }
 
 // ---------------------------------------------------------------------------
+// Type checking (stateless — no activeHandle)
+// ---------------------------------------------------------------------------
+
+function handleTypeCheck(id, code, prefixCode, scriptName) {
+  let cCode = null;
+  let cPrefix = null;
+  let cName = null;
+  const outDiag = allocOutPtr();
+  const outError = allocOutPtr();
+
+  let resultTag;
+  try {
+    cCode = allocCString(code);
+    cPrefix = prefixCode ? allocCString(prefixCode) : null;
+    cName = allocCString(scriptName || 'main.py');
+    resultTag = wasm.monty_type_check(
+      cCode.ptr,
+      cPrefix ? cPrefix.ptr : 0,
+      cName.ptr,
+      outDiag.ptr,
+      outError.ptr,
+    );
+  } catch (e) {
+    outDiag.free();
+    outError.free();
+    if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
+    if (cPrefix) wasm.monty_dealloc(cPrefix.ptr, cPrefix.size);
+    if (cName) wasm.monty_dealloc(cName.ptr, cName.size);
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: e.message || String(e),
+      errorType: 'Panic',
+    });
+    return;
+  } finally {
+    if (cCode) wasm.monty_dealloc(cCode.ptr, cCode.size);
+    if (cPrefix) wasm.monty_dealloc(cPrefix.ptr, cPrefix.size);
+    if (cName) wasm.monty_dealloc(cName.ptr, cName.size);
+  }
+
+  const diagPtr = outDiag.read();
+  const errPtr = outError.read();
+  const diagnosticsJson = readAndFreeCString(diagPtr);
+  const errMsg = readAndFreeCString(errPtr);
+  outDiag.free();
+  outError.free();
+
+  if (resultTag !== 0) {
+    self.postMessage({
+      type: 'result', id, ok: false,
+      error: errMsg || 'monty_type_check failed',
+      errorType: 'TypeCheckError',
+    });
+    return;
+  }
+
+  self.postMessage({
+    type: 'result', id, ok: true,
+    diagnosticsJson, // null when no errors found
+  });
+}
+
+// ---------------------------------------------------------------------------
 // REPL Handlers
 // ---------------------------------------------------------------------------
 
@@ -1554,7 +1617,7 @@ function handleReplRestore(id, replId, dataBase64) {
 self.onmessage = (e) => {
   const { type, id, code, extFns, value, errorMessage, excType, fnName, limits,
     dataBase64, scriptName, resultsJson, errorsJson, valueJson, source,
-    replId } = e.data;
+    replId, prefixCode } = e.data;
   try {
     switch (type) {
       case 'run':
@@ -1604,6 +1667,9 @@ self.onmessage = (e) => {
         break;
       case 'dispose':
         handleDispose(id);
+        break;
+      case 'typeCheck':
+        handleTypeCheck(id, code, prefixCode, scriptName);
         break;
       case 'replCreate':
         handleReplCreate(id, replId, scriptName);

--- a/lib/assets/dart_monty_core_bridge.js
+++ b/lib/assets/dart_monty_core_bridge.js
@@ -234,6 +234,18 @@
     const result = await callWorker(sid, msg, session.timeoutMs);
     return result;
   }
+  async function typeCheck(code, prefixCode, scriptName) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) {
+      return JSON.stringify({ ok: false, error: "Not initialized" });
+    }
+    const session = sessions.get(sid);
+    const msg = { type: "typeCheck", code };
+    if (prefixCode) msg.prefixCode = prefixCode;
+    if (scriptName) msg.scriptName = scriptName;
+    const result = await callWorker(sid, msg, session.timeoutMs);
+    return JSON.stringify(result);
+  }
   async function runPrecompiled(dataBase64, limitsJson, scriptName) {
     const sid = resolveSessionId(null);
     if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -421,6 +433,7 @@
     snapshot,
     restore,
     compile,
+    typeCheck,
     runPrecompiled,
     startPrecompiled,
     discover,

--- a/lib/assets/dart_monty_core_worker.js
+++ b/lib/assets/dart_monty_core_worker.js
@@ -49,6 +49,12 @@ function createWasiImports(getMemory) {
     },
     proc_exit(code) {
       throw new Error(`WASI proc_exit called with code ${code}`);
+    },
+    // No-op — JS is single-threaded; there's nothing to yield to.
+    // Required by salsa-rs (the incremental computation framework
+    // pulled in by monty-type-checking).
+    sched_yield() {
+      return 0;
     }
   };
 }
@@ -1229,6 +1235,67 @@ function handleDispose(id) {
   }
   self.postMessage({ type: "result", id, ok: true });
 }
+function handleTypeCheck(id, code, prefixCode, scriptName) {
+  let cCode = null;
+  let cPrefix = null;
+  let cName = null;
+  const outDiag = allocOutPtr();
+  const outError = allocOutPtr();
+  let resultTag;
+  try {
+    cCode = allocCString(code);
+    cPrefix = prefixCode ? allocCString(prefixCode) : null;
+    cName = allocCString(scriptName || "main.py");
+    resultTag = wasm2.monty_type_check(
+      cCode.ptr,
+      cPrefix ? cPrefix.ptr : 0,
+      cName.ptr,
+      outDiag.ptr,
+      outError.ptr
+    );
+  } catch (e) {
+    outDiag.free();
+    outError.free();
+    if (cCode) wasm2.monty_dealloc(cCode.ptr, cCode.size);
+    if (cPrefix) wasm2.monty_dealloc(cPrefix.ptr, cPrefix.size);
+    if (cName) wasm2.monty_dealloc(cName.ptr, cName.size);
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: e.message || String(e),
+      errorType: "Panic"
+    });
+    return;
+  } finally {
+    if (cCode) wasm2.monty_dealloc(cCode.ptr, cCode.size);
+    if (cPrefix) wasm2.monty_dealloc(cPrefix.ptr, cPrefix.size);
+    if (cName) wasm2.monty_dealloc(cName.ptr, cName.size);
+  }
+  const diagPtr = outDiag.read();
+  const errPtr = outError.read();
+  const diagnosticsJson = readAndFreeCString(diagPtr);
+  const errMsg = readAndFreeCString(errPtr);
+  outDiag.free();
+  outError.free();
+  if (resultTag !== 0) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: errMsg || "monty_type_check failed",
+      errorType: "TypeCheckError"
+    });
+    return;
+  }
+  self.postMessage({
+    type: "result",
+    id,
+    ok: true,
+    diagnosticsJson
+    // null when no errors found
+  });
+}
 var replHandles = /* @__PURE__ */ new Map();
 function handleReplCreate(id, replId, scriptName) {
   if (!replId) {
@@ -1581,7 +1648,8 @@ self.onmessage = (e) => {
     errorsJson,
     valueJson,
     source,
-    replId
+    replId,
+    prefixCode
   } = e.data;
   try {
     switch (type) {
@@ -1632,6 +1700,9 @@ self.onmessage = (e) => {
         break;
       case "dispose":
         handleDispose(id);
+        break;
+      case "typeCheck":
+        handleTypeCheck(id, code, prefixCode, scriptName);
         break;
       case "replCreate":
         handleReplCreate(id, replId, scriptName);

--- a/lib/dart_monty_core.dart
+++ b/lib/dart_monty_core.dart
@@ -37,6 +37,7 @@ export 'src/platform/monty_progress.dart';
 export 'src/platform/monty_resource_usage.dart';
 export 'src/platform/monty_result.dart';
 export 'src/platform/monty_stack_frame.dart';
+export 'src/platform/monty_typing_error.dart';
 export 'src/platform/monty_value.dart';
 export 'src/platform/os_call_exception.dart';
 export 'src/repl/monty_repl.dart';

--- a/lib/src/ffi/ffi_core_bindings.dart
+++ b/lib/src/ffi/ffi_core_bindings.dart
@@ -186,6 +186,17 @@ class FfiCoreBindings implements MontyCoreBindings {
   }
 
   @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) async => _bindings.typeCheck(
+    code,
+    prefixCode: prefixCode,
+    scriptName: scriptName,
+  );
+
+  @override
   Future<CoreRunResult> runPrecompiled(
     Uint8List compiled, {
     String? limitsJson,

--- a/lib/src/ffi/generated/dart_monty_bindings.dart
+++ b/lib/src/ffi/generated/dart_monty_bindings.dart
@@ -868,6 +868,62 @@ external ffi.Pointer<MontyReplHandle> monty_repl_restore(
   ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
 );
 
+/// Run static type checking on Python source code.
+///
+/// Uses a pooled in-memory database scrubbed on drop, so the analysis
+/// heap never touches an in-flight execution heap of any MontyHandle.
+///
+/// @param code                  Python source (NUL-terminated UTF-8).
+/// @param prefix_code           Optional prefix code prepended before
+/// type-check (e.g. input variable
+/// declarations). NULL for no prefix.
+/// @param script_name           Filename used in diagnostic spans.
+/// @param out_diagnostics_json  On errors found, receives the
+/// diagnostic render in Monty's `json`
+/// format (free with monty_string_free()).
+/// Set to NULL when the code type-checks
+/// cleanly.
+/// @param out_error             On infrastructure failure, receives an
+/// error message (free with
+/// monty_string_free()). NULL on success
+/// or errors-found.
+/// @return                      MONTY_RESULT_OK if the check ran (with
+/// or without errors), MONTY_RESULT_ERROR
+/// if the type-check infrastructure
+/// itself failed.
+@ffi.Native<
+  ffi.UnsignedInt Function(
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Char>,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+    ffi.Pointer<ffi.Pointer<ffi.Char>>,
+  )
+>(symbol: 'monty_type_check')
+external int _monty_type_check(
+  ffi.Pointer<ffi.Char> code,
+  ffi.Pointer<ffi.Char> prefix_code,
+  ffi.Pointer<ffi.Char> script_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_diagnostics_json,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+);
+
+MontyResultTag monty_type_check(
+  ffi.Pointer<ffi.Char> code,
+  ffi.Pointer<ffi.Char> prefix_code,
+  ffi.Pointer<ffi.Char> script_name,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_diagnostics_json,
+  ffi.Pointer<ffi.Pointer<ffi.Char>> out_error,
+) => MontyResultTag.fromValue(
+  _monty_type_check(
+    code,
+    prefix_code,
+    script_name,
+    out_diagnostics_json,
+    out_error,
+  ),
+);
+
 /// Free a string returned by any monty_* function. Safe with NULL.
 @ffi.Native<ffi.Void Function(ffi.Pointer<ffi.Char>)>()
 external void monty_string_free(

--- a/lib/src/ffi/native_bindings.dart
+++ b/lib/src/ffi/native_bindings.dart
@@ -159,6 +159,14 @@ abstract class NativeBindings {
   /// Returns the new handle address as an `int`, or throws on error.
   int restore(Uint8List data);
 
+  /// Runs static type checking on [code] without executing it.
+  ///
+  /// Stateless — does not create or modify any handle. Returns the
+  /// Monty `json`-format diagnostics string when errors are found, or
+  /// `null` when the code type-checks cleanly. Throws on infrastructure
+  /// failure.
+  String? typeCheck(String code, {String? prefixCode, String scriptName});
+
   // ---------------------------------------------------------------------------
   // REPL
   // ---------------------------------------------------------------------------

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -339,6 +339,7 @@ class NativeBindingsFfi extends NativeBindings {
       if (outDiag.value == nullptr) {
         return null;
       }
+
       return _readAndFreeString(outDiag.value);
     } finally {
       calloc.free(cCode);

--- a/lib/src/ffi/native_bindings_ffi.dart
+++ b/lib/src/ffi/native_bindings_ffi.dart
@@ -303,6 +303,53 @@ class NativeBindingsFfi extends NativeBindings {
     }
   }
 
+  @override
+  String? typeCheck(
+    String code, {
+    String? prefixCode,
+    String? scriptName,
+  }) {
+    final cCode = code.toNativeUtf8().cast<Char>();
+    final cPrefix = prefixCode != null
+        ? prefixCode.toNativeUtf8().cast<Char>()
+        : nullptr.cast<Char>();
+    final cName = (scriptName ?? 'main.py').toNativeUtf8().cast<Char>();
+    final outDiag = calloc<Pointer<Char>>();
+    final outError = calloc<Pointer<Char>>();
+
+    try {
+      final tag = ffi_native.monty_type_check(
+        cCode,
+        cPrefix,
+        cName,
+        outDiag,
+        outError,
+      );
+      if (tag != ffi_native.MontyResultTag.MONTY_RESULT_OK) {
+        final errorMsg = _readAndFreeString(outError.value);
+        // Clean up out-diag in case it was set despite the error tag.
+        if (outDiag.value != nullptr) {
+          ffi_native.monty_string_free(outDiag.value);
+        }
+        throw MontyException(
+          message: errorMsg ?? 'monty_type_check failed',
+        );
+      }
+      // Clean — no diagnostics.
+      if (outDiag.value == nullptr) {
+        return null;
+      }
+      return _readAndFreeString(outDiag.value);
+    } finally {
+      calloc.free(cCode);
+      if (prefixCode != null) calloc.free(cPrefix);
+      calloc
+        ..free(cName)
+        ..free(outDiag)
+        ..free(outError);
+    }
+  }
+
   // ---------------------------------------------------------------------------
   // REPL
   // ---------------------------------------------------------------------------

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -4,6 +4,7 @@ import 'package:dart_monty_core/src/externals.dart';
 import 'package:dart_monty_core/src/monty_factory.dart';
 import 'package:dart_monty_core/src/platform/monty_limits.dart';
 import 'package:dart_monty_core/src/platform/monty_result.dart';
+import 'package:dart_monty_core/src/platform/monty_typing_error.dart';
 import 'package:dart_monty_core/src/repl/monty_repl.dart';
 
 /// A compiled Python program.
@@ -107,6 +108,40 @@ class Monty {
         limits: limits,
         scriptName: scriptName,
       );
+    } finally {
+      await platform.dispose();
+    }
+  }
+
+  /// Runs static type checking on [code] without executing it.
+  ///
+  /// Returns the list of typing diagnostics — empty when the code
+  /// type-checks cleanly. Stateless: uses an isolated analysis heap
+  /// scrubbed on completion, so it never touches an in-flight execution.
+  ///
+  /// [prefixCode] is prepended before checking — useful for declaring
+  /// inputs or external function signatures so the analyser knows their
+  /// types. [scriptName] sets the filename surfaced in diagnostic spans.
+  ///
+  /// ```dart
+  /// final errors = await Monty.typeCheck('x: int = "not an int"');
+  /// for (final e in errors) {
+  ///   print('${e.path}:${e.line}:${e.column} ${e.code}: ${e.message}');
+  /// }
+  /// ```
+  static Future<List<MontyTypingError>> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) async {
+    final platform = createPlatformMonty();
+    try {
+      final json = await platform.typeCheck(
+        code,
+        prefixCode: prefixCode,
+        scriptName: scriptName,
+      );
+      return MontyTypingError.listFromJson(json);
     } finally {
       await platform.dispose();
     }

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -141,6 +141,7 @@ class Monty {
         prefixCode: prefixCode,
         scriptName: scriptName,
       );
+
       return MontyTypingError.listFromJson(json);
     } finally {
       await platform.dispose();

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -220,6 +220,21 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }
 
   @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) async {
+    assertNotDisposed('typeCheck');
+    await _ensureInitialized();
+    return _bindings.typeCheck(
+      code,
+      prefixCode: prefixCode,
+      scriptName: scriptName,
+    );
+  }
+
+  @override
   Future<MontyResult> runPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -227,6 +227,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
   }) async {
     assertNotDisposed('typeCheck');
     await _ensureInitialized();
+
     return _bindings.typeCheck(
       code,
       prefixCode: prefixCode,

--- a/lib/src/platform/core_bindings.dart
+++ b/lib/src/platform/core_bindings.dart
@@ -242,6 +242,20 @@ abstract class MontyCoreBindings {
   /// re-parsing.
   Future<Uint8List> compileCode(String code);
 
+  /// Runs static type checking on [code] without executing it.
+  ///
+  /// Stateless — uses a pooled in-memory database scrubbed on drop, so
+  /// the analysis heap is isolated from any in-flight execution heap.
+  ///
+  /// Returns the Monty `json`-format diagnostics string when errors are
+  /// found, or `null` when the code type-checks cleanly. Throws on
+  /// type-check infrastructure failure.
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  });
+
   /// Runs precompiled [compiled] bytes to completion.
   ///
   /// Restores a handle from the snapshot bytes, applies [limitsJson], and

--- a/lib/src/platform/monty_platform.dart
+++ b/lib/src/platform/monty_platform.dart
@@ -104,6 +104,19 @@ abstract class MontyPlatform {
     throw UnimplementedError('compileCode() has not been implemented.');
   }
 
+  /// Runs static type checking on [code] without executing it.
+  ///
+  /// Returns the Monty `json`-format diagnostics string when errors are
+  /// found, or `null` when the code type-checks cleanly. Throws on
+  /// type-check infrastructure failure.
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) {
+    throw UnimplementedError('typeCheck() has not been implemented.');
+  }
+
   /// Executes pre-compiled [compiled] bytes returned by [compileCode].
   ///
   /// Equivalent to `Monty.load(binary).run()` in the JS `@pydantic/monty`

--- a/lib/src/platform/monty_typing_error.dart
+++ b/lib/src/platform/monty_typing_error.dart
@@ -55,18 +55,6 @@ final class MontyTypingError {
     );
   }
 
-  /// Parses the JSON-array string emitted by `Monty.typeCheck` into a
-  /// list of diagnostics. An empty/null input returns an empty list.
-  static List<MontyTypingError> listFromJson(String? jsonStr) {
-    if (jsonStr == null || jsonStr.isEmpty) return const [];
-    final decoded = json.decode(jsonStr);
-    if (decoded is! List) return const [];
-    return decoded
-        .whereType<Map<String, dynamic>>()
-        .map(MontyTypingError.fromJson)
-        .toList(growable: false);
-  }
-
   /// Diagnostic rule code (e.g. `'invalid-assignment'`).
   final String code;
 
@@ -91,11 +79,30 @@ final class MontyTypingError {
   /// Documentation URL for [code], if available.
   final String? url;
 
+  /// Parses the JSON-array string emitted by `Monty.typeCheck` into a
+  /// list of diagnostics. An empty/null input returns an empty list.
+  static List<MontyTypingError> listFromJson(String? jsonStr) {
+    if (jsonStr == null || jsonStr.isEmpty) return const [];
+    final decoded = json.decode(jsonStr);
+    if (decoded is! List) return const [];
+
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(MontyTypingError.fromJson)
+        .toList(growable: false);
+  }
+
   @override
   String toString() {
-    final loc = (path != null && line != null && column != null)
-        ? '$path:$line:$column'
-        : (line != null ? 'line $line' : 'unknown');
+    final String loc;
+    if (path != null && line != null && column != null) {
+      loc = '$path:$line:$column';
+    } else if (line != null) {
+      loc = 'line $line';
+    } else {
+      loc = 'unknown';
+    }
+
     return 'MontyTypingError($code at $loc: $message)';
   }
 }

--- a/lib/src/platform/monty_typing_error.dart
+++ b/lib/src/platform/monty_typing_error.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:meta/meta.dart';
+
+/// A single static-type-check diagnostic produced by `Monty.typeCheck`.
+///
+/// Each diagnostic identifies a typing problem in the analysed source —
+/// e.g. an incompatible assignment, an unresolvable reference, or a
+/// disallowed return type. Diagnostics are surfaced as a `List` so that
+/// IDE-style consumers can render them inline without parsing a single
+/// concatenated string.
+///
+/// Field shape mirrors the upstream `monty-type-checking` JSON renderer
+/// (formats listed in
+/// `crates/monty-type-checking/src/type_check.rs::format_from_str`):
+///
+/// - [code] — diagnostic code, e.g. `'invalid-assignment'`. Useful for
+///   filtering or muting specific rules.
+/// - [message] — human-readable text.
+/// - [path] — filename used in spans (the `scriptName` you passed to
+///   `Monty.typeCheck`).
+/// - [line] / [column] — 1-indexed start position.
+/// - [endLine] / [endColumn] — 1-indexed exclusive end position.
+/// - [url] — link to documentation for [code], if available.
+@immutable
+final class MontyTypingError {
+  /// Creates a [MontyTypingError].
+  const MontyTypingError({
+    required this.code,
+    required this.message,
+    this.path,
+    this.line,
+    this.column,
+    this.endLine,
+    this.endColumn,
+    this.url,
+  });
+
+  /// Parses one diagnostic from the upstream JSON shape.
+  factory MontyTypingError.fromJson(Map<String, dynamic> map) {
+    int? row(Object? loc) =>
+        loc is Map<String, dynamic> ? (loc['row'] as num?)?.toInt() : null;
+    int? col(Object? loc) =>
+        loc is Map<String, dynamic> ? (loc['column'] as num?)?.toInt() : null;
+
+    return MontyTypingError(
+      code: map['code'] as String? ?? '',
+      message: map['message'] as String? ?? '',
+      path: map['filename'] as String?,
+      line: row(map['location']),
+      column: col(map['location']),
+      endLine: row(map['end_location']),
+      endColumn: col(map['end_location']),
+      url: map['url'] as String?,
+    );
+  }
+
+  /// Parses the JSON-array string emitted by `Monty.typeCheck` into a
+  /// list of diagnostics. An empty/null input returns an empty list.
+  static List<MontyTypingError> listFromJson(String? jsonStr) {
+    if (jsonStr == null || jsonStr.isEmpty) return const [];
+    final decoded = json.decode(jsonStr);
+    if (decoded is! List) return const [];
+    return decoded
+        .whereType<Map<String, dynamic>>()
+        .map(MontyTypingError.fromJson)
+        .toList(growable: false);
+  }
+
+  /// Diagnostic rule code (e.g. `'invalid-assignment'`).
+  final String code;
+
+  /// Human-readable diagnostic message.
+  final String message;
+
+  /// Filename the diagnostic refers to.
+  final String? path;
+
+  /// Start line (1-indexed).
+  final int? line;
+
+  /// Start column (1-indexed).
+  final int? column;
+
+  /// End line (1-indexed, exclusive).
+  final int? endLine;
+
+  /// End column (1-indexed, exclusive).
+  final int? endColumn;
+
+  /// Documentation URL for [code], if available.
+  final String? url;
+
+  @override
+  String toString() {
+    final loc = (path != null && line != null && column != null)
+        ? '$path:$line:$column'
+        : (line != null ? 'line $line' : 'unknown');
+    return 'MontyTypingError($code at $loc: $message)';
+  }
+}

--- a/lib/src/repl/repl_platform.dart
+++ b/lib/src/repl/repl_platform.dart
@@ -72,6 +72,15 @@ class ReplPlatform implements MontyPlatform {
       throw UnsupportedError('compileCode() is not supported by ReplPlatform');
 
   @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) => throw UnsupportedError(
+    'typeCheck() is not supported by ReplPlatform',
+  );
+
+  @override
   Future<MontyResult> runPrecompiled(
     Uint8List compiled, {
     MontyLimits? limits,

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -292,6 +292,18 @@ abstract class WasmBindings {
   /// the default.
   Future<Uint8List> compile(String code, {String? scriptName, int? sessionId});
 
+  /// Runs static type checking on [code] without executing it.
+  ///
+  /// Returns the Monty `json`-format diagnostics string when errors are
+  /// found, or `null` when the code type-checks cleanly. Throws on
+  /// infrastructure failure.
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName,
+    int? sessionId,
+  });
+
   /// Runs precompiled [compiled] bytes to completion.
   ///
   /// Restores a handle from the snapshot bytes, applies [limitsJson] if

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -97,6 +97,14 @@ external JSPromise<JSAny> _jsCompile(
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.typeCheck')
+external JSPromise<JSString> _jsTypeCheck(
+  JSString code, [
+  JSString? prefixCode,
+  JSString? scriptName,
+  JSNumber? sessionId,
+]);
+
 @JS('DartMontyBridge.runPrecompiled')
 external JSPromise<JSString> _jsRunPrecompiled(
   JSString dataBase64, [
@@ -406,6 +414,26 @@ class WasmBindingsJs extends WasmBindings {
     }
 
     return result.snapshotBuffer!.toDart.asUint8List();
+  }
+
+  @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+    int? sessionId,
+  }) async {
+    final resultJson = await _jsTypeCheck(
+      code.toJS,
+      prefixCode?.toJS,
+      scriptName.toJS,
+      sessionId?.toJS,
+    ).toDart;
+    final map = json.decode(resultJson.toDart) as Map<String, dynamic>;
+    if (map['ok'] != true) {
+      throw StateError(map['error'] as String? ?? 'typeCheck failed');
+    }
+    return map['diagnosticsJson'] as String?;
   }
 
   @override

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -433,6 +433,7 @@ class WasmBindingsJs extends WasmBindings {
     if (map['ok'] != true) {
       throw StateError(map['error'] as String? ?? 'typeCheck failed');
     }
+
     return map['diagnosticsJson'] as String?;
   }
 

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -94,6 +94,14 @@ class WasmBindingsJs extends WasmBindings {
   }) => throw UnimplementedError();
 
   @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
   Future<WasmRunResult> runPrecompiled(
     Uint8List compiled, {
     String? limitsJson,

--- a/lib/src/wasm/wasm_core_bindings.dart
+++ b/lib/src/wasm/wasm_core_bindings.dart
@@ -155,6 +155,18 @@ class WasmCoreBindings implements MontyCoreBindings {
       _bindings.compile(code, sessionId: _sessionId);
 
   @override
+  Future<String?> typeCheck(
+    String code, {
+    String? prefixCode,
+    String scriptName = 'main.py',
+  }) => _bindings.typeCheck(
+    code,
+    prefixCode: prefixCode,
+    scriptName: scriptName,
+    sessionId: _sessionId,
+  );
+
+  @override
   Future<CoreRunResult> runPrecompiled(
     Uint8List compiled, {
     String? limitsJson,

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.17" }
+monty_type_checking = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.17" }
 num-bigint = "0.4"
 num-traits = "0.2"
 serde_json = "1"

--- a/native/deny.toml
+++ b/native/deny.toml
@@ -1,8 +1,17 @@
 [advisories]
 version = 2
 # atomic-polyfill is unmaintained but comes from monty's transitive deps.
-# We can't fix this until upstream monty updates their deps.
-ignore = ["RUSTSEC-2023-0089"]
+# unic-* crates flow in via ty_python_semantic → ruff_python_literal
+# (monty_type_checking). All unfixable upstream — open-i18n/rust-unic is
+# archived with no safe upgrade. Tracked in upstream advisory-db#2414.
+ignore = [
+    "RUSTSEC-2023-0089",
+    "RUSTSEC-2025-0075",  # unic-char-range
+    "RUSTSEC-2025-0080",  # unic-common
+    "RUSTSEC-2025-0081",  # unic-char-property
+    "RUSTSEC-2025-0094",  # unic-ucd-category
+    "RUSTSEC-2025-0098",  # unic-ucd-version
+]
 
 [licenses]
 version = 2
@@ -12,7 +21,9 @@ allow = [
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",
     "BSD-3-Clause",
+    "CC0-1.0",          # constant_time_eq (transitive via monty_type_checking)
     "ISC",
+    "MPL-2.0",          # colored (transitive via monty_type_checking)
     "Unicode-3.0",
     "Unicode-DFS-2016",
     "Zlib",

--- a/native/include/dart_monty.h
+++ b/native/include/dart_monty.h
@@ -500,6 +500,41 @@ uint8_t *monty_repl_snapshot(const MontyReplHandle *handle, size_t *out_len);
 MontyReplHandle *monty_repl_restore(const uint8_t *data, size_t len, char **out_error);
 
 /* ------------------------------------------------------------------ */
+/* Type checking (stateless static analysis)                          */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Run static type checking on Python source code.
+ *
+ * Uses a pooled in-memory database scrubbed on drop, so the analysis
+ * heap never touches an in-flight execution heap of any MontyHandle.
+ *
+ * @param code                  Python source (NUL-terminated UTF-8).
+ * @param prefix_code           Optional prefix code prepended before
+ *                              type-check (e.g. input variable
+ *                              declarations). NULL for no prefix.
+ * @param script_name           Filename used in diagnostic spans.
+ * @param out_diagnostics_json  On errors found, receives the
+ *                              diagnostic render in Monty's `json`
+ *                              format (free with monty_string_free()).
+ *                              Set to NULL when the code type-checks
+ *                              cleanly.
+ * @param out_error             On infrastructure failure, receives an
+ *                              error message (free with
+ *                              monty_string_free()). NULL on success
+ *                              or errors-found.
+ * @return                      MONTY_RESULT_OK if the check ran (with
+ *                              or without errors), MONTY_RESULT_ERROR
+ *                              if the type-check infrastructure
+ *                              itself failed.
+ */
+MontyResultTag monty_type_check(const char *code,
+                                const char *prefix_code,
+                                const char *script_name,
+                                char **out_diagnostics_json,
+                                char **out_error);
+
+/* ------------------------------------------------------------------ */
 /* Memory management                                                  */
 /* ------------------------------------------------------------------ */
 

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -8,10 +8,11 @@ mod repl_handle;
 pub use handle::{MontyHandle, MontyProgressTag, MontyResultTag};
 pub use repl_handle::MontyReplHandle;
 
-use std::ffi::{c_char, c_int};
+use std::ffi::{CStr, c_char, c_int};
 use std::ptr;
 
 use error::{catch_ffi_panic, parse_c_str, to_c_string};
+use monty_type_checking::{SourceFile, type_check};
 
 /// Common FFI wrapper for functions returning `MontyProgressTag`.
 /// Handles: handle null check, panic boundary, error out-parameter.
@@ -1375,6 +1376,126 @@ pub unsafe extern "C" fn monty_repl_restore(
                 unsafe { *out_error = to_c_string(&panic_msg) };
             }
             ptr::null_mut()
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type checking (stateless static analysis — no MontyHandle)
+// ---------------------------------------------------------------------------
+
+/// Run static type checking on Python source code.
+///
+/// The check uses a pooled in-memory database scrubbed on drop, so it never
+/// touches the execution heap of any `MontyHandle` in flight.
+///
+/// - `code`: NUL-terminated UTF-8 Python source.
+/// - `prefix_code`: optional NUL-terminated prefix (e.g. input variable
+///   declarations or external function signatures), or NULL.
+/// - `script_name`: NUL-terminated script name used in diagnostic spans.
+/// - `out_diagnostics_json`: receives the diagnostic render in Monty's
+///   `json` format on errors found, or NULL if the code type-checks
+///   cleanly. Caller frees with `monty_string_free`.
+/// - `out_error`: receives an error message if the type-check infrastructure
+///   itself fails (caller frees). NULL on success or on errors-found.
+///
+/// Returns `MONTY_RESULT_OK` if the check ran (regardless of whether errors
+/// were found) or `MONTY_RESULT_ERROR` if the infrastructure failed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn monty_type_check(
+    code: *const c_char,
+    prefix_code: *const c_char,
+    script_name: *const c_char,
+    out_diagnostics_json: *mut *mut c_char,
+    out_error: *mut *mut c_char,
+) -> MontyResultTag {
+    // SAFETY: Caller guarantees `code` is a valid NUL-terminated C string if non-null.
+    let code_str = match unsafe { parse_c_str(code, "code", out_error) } {
+        Ok(s) => s,
+        Err(()) => return MontyResultTag::Error,
+    };
+
+    // SAFETY: Caller guarantees `script_name` is a valid NUL-terminated C string if non-null.
+    let script_str = match unsafe { parse_c_str(script_name, "script_name", out_error) } {
+        Ok(s) => s,
+        Err(()) => return MontyResultTag::Error,
+    };
+
+    // prefix_code is optional — NULL means "no prefix".
+    let prefix_str: Option<&str> = if prefix_code.is_null() {
+        None
+    } else {
+        // SAFETY: `prefix_code` is non-null (just checked) and the caller guarantees it
+        // is a valid NUL-terminated C string.
+        match unsafe { CStr::from_ptr(prefix_code) }.to_str() {
+            Ok(s) => Some(s),
+            Err(_) => {
+                if !out_error.is_null() {
+                    // SAFETY: out_error is non-null (just checked), writing error message
+                    unsafe {
+                        *out_error = to_c_string("prefix_code is not valid UTF-8");
+                    }
+                }
+                return MontyResultTag::Error;
+            }
+        }
+    };
+
+    // The reference monty-js binding prepends `prefix_code\n` to the main
+    // source before type-checking; mirror that behavior here.
+    let effective_code = match prefix_str {
+        Some(prefix) => format!("{prefix}\n{code_str}"),
+        None => code_str.to_string(),
+    };
+
+    let outcome = catch_ffi_panic(|| {
+        let source = SourceFile::new(&effective_code, script_str);
+        match type_check(&source, None) {
+            Ok(None) => Ok(None),
+            Ok(Some(diagnostics)) => diagnostics
+                .format_from_str("json")
+                .map(|d| Some(d.to_string()))
+                .map_err(|e| format!("format_from_str: {e}")),
+            Err(e) => Err(e),
+        }
+    });
+
+    match outcome {
+        Ok(Ok(None)) => {
+            if !out_diagnostics_json.is_null() {
+                // SAFETY: out_diagnostics_json is non-null (just checked), clearing to NULL
+                unsafe { *out_diagnostics_json = ptr::null_mut() };
+            }
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), clearing to indicate success
+                unsafe { *out_error = ptr::null_mut() };
+            }
+            MontyResultTag::Ok
+        }
+        Ok(Ok(Some(json))) => {
+            if !out_diagnostics_json.is_null() {
+                // SAFETY: out_diagnostics_json is non-null (just checked), writing diagnostics JSON
+                unsafe { *out_diagnostics_json = to_c_string(&json) };
+            }
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), clearing — errors-found is not a failure
+                unsafe { *out_error = ptr::null_mut() };
+            }
+            MontyResultTag::Ok
+        }
+        Ok(Err(infra_err)) => {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing infrastructure error
+                unsafe { *out_error = to_c_string(&infra_err) };
+            }
+            MontyResultTag::Error
+        }
+        Err(panic_msg) => {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing panic message
+                unsafe { *out_error = to_c_string(&panic_msg) };
+            }
+            MontyResultTag::Error
         }
     }
 }

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1410,15 +1410,13 @@ pub unsafe extern "C" fn monty_type_check(
     out_error: *mut *mut c_char,
 ) -> MontyResultTag {
     // SAFETY: Caller guarantees `code` is a valid NUL-terminated C string if non-null.
-    let code_str = match unsafe { parse_c_str(code, "code", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyResultTag::Error,
+    let Ok(code_str) = (unsafe { parse_c_str(code, "code", out_error) }) else {
+        return MontyResultTag::Error;
     };
 
     // SAFETY: Caller guarantees `script_name` is a valid NUL-terminated C string if non-null.
-    let script_str = match unsafe { parse_c_str(script_name, "script_name", out_error) } {
-        Ok(s) => s,
-        Err(()) => return MontyResultTag::Error,
+    let Ok(script_str) = (unsafe { parse_c_str(script_name, "script_name", out_error) }) else {
+        return MontyResultTag::Error;
     };
 
     // prefix_code is optional — NULL means "no prefix".
@@ -1427,17 +1425,16 @@ pub unsafe extern "C" fn monty_type_check(
     } else {
         // SAFETY: `prefix_code` is non-null (just checked) and the caller guarantees it
         // is a valid NUL-terminated C string.
-        match unsafe { CStr::from_ptr(prefix_code) }.to_str() {
-            Ok(s) => Some(s),
-            Err(_) => {
-                if !out_error.is_null() {
-                    // SAFETY: out_error is non-null (just checked), writing error message
-                    unsafe {
-                        *out_error = to_c_string("prefix_code is not valid UTF-8");
-                    }
+        if let Ok(s) = unsafe { CStr::from_ptr(prefix_code) }.to_str() {
+            Some(s)
+        } else {
+            if !out_error.is_null() {
+                // SAFETY: out_error is non-null (just checked), writing error message
+                unsafe {
+                    *out_error = to_c_string("prefix_code is not valid UTF-8");
                 }
-                return MontyResultTag::Error;
             }
+            return MontyResultTag::Error;
         }
     };
 

--- a/test/integration/_type_check_test_body.dart
+++ b/test/integration/_type_check_test_body.dart
@@ -1,0 +1,111 @@
+// Shared test body for ffi_type_check_test.dart and
+// wasm_type_check_test.dart.
+//
+// Validates Monty.typeCheck end-to-end: clean code returns an empty
+// list; annotated code with a return-type/assignment mismatch surfaces
+// a structured MontyTypingError with code, path, line, and column;
+// prefix_code lets the analyser see declarations that aren't in the
+// main source.
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void runTypeCheckTests() {
+  group('Monty.typeCheck', () {
+    test('clean code returns an empty list', () async {
+      final errors = await Monty.typeCheck('x: int = 1\ny: int = x + 1');
+      expect(errors, isEmpty);
+    });
+
+    test('inference catches literal-vs-literal type errors even without '
+        'annotations', () async {
+      // The analyser infers literal types eagerly, so `"a" + 1` flags
+      // even though neither name is annotated.
+      final errors = await Monty.typeCheck('x = "anything"\ny = x + 1');
+      expect(errors, isNotEmpty);
+      expect(errors.first.code, 'unsupported-operator');
+    });
+
+    test('catches incompatible assignment in annotated code', () async {
+      final errors = await Monty.typeCheck(
+        'x: int = "not an int"',
+        scriptName: 'incompat.py',
+      );
+      expect(errors, isNotEmpty);
+      final e = errors.first;
+      expect(e.code, 'invalid-assignment');
+      expect(e.message, contains('not assignable'));
+      expect(e.path, '/incompat.py');
+      expect(e.line, 1);
+      expect(e.column, isNotNull);
+    });
+
+    test('catches None vs list[T] (the rbtree.py bug pattern)', () async {
+      const code = '''
+def insert_fixup(root: list, z: dict) -> None:
+    pass
+
+root: list = [None]
+z: dict = {}
+root = insert_fixup(root, z)
+''';
+      final errors = await Monty.typeCheck(code, scriptName: 'rb.py');
+      expect(errors, isNotEmpty);
+      final hit = errors.firstWhere(
+        (e) => e.code == 'invalid-assignment',
+        orElse: () => fail(
+          'expected invalid-assignment, got ${errors.map((e) => e.code)}',
+        ),
+      );
+      expect(hit.message, contains('None'));
+      expect(hit.message, contains('list'));
+      expect(hit.path, '/rb.py');
+    });
+
+    test(
+      'prefix_code provides declarations the main source can rely on',
+      () async {
+        // Without prefix_code, `x` is an unresolved reference. With it,
+        // the analyser sees `x: int` and the assignment passes.
+        final withoutPrefix = await Monty.typeCheck('y: int = x + 1');
+        expect(withoutPrefix, isNotEmpty);
+
+        final withPrefix = await Monty.typeCheck(
+          'y: int = x + 1',
+          prefixCode: 'x: int = 0',
+        );
+        expect(withPrefix, isEmpty);
+      },
+    );
+
+    test('multiple diagnostics in the same source surface in order', () async {
+      const code = '''
+a: int = "first"
+b: int = "second"
+''';
+      final errors = await Monty.typeCheck(code);
+      expect(errors.length, greaterThanOrEqualTo(2));
+      // Diagnostics are sorted by line in the upstream renderer.
+      final lines = errors.map((e) => e.line).toList();
+      expect(
+        lines,
+        equals(
+          List<int?>.from(lines)..sort((a, b) => (a ?? 0).compareTo(b ?? 0)),
+        ),
+      );
+    });
+
+    test('typeCheck does not affect a parallel Monty.exec', () async {
+      // Heap isolation precondition: an in-flight execution shouldn't be
+      // disturbed by a typeCheck call. Run both concurrently.
+      final type = Monty.typeCheck('x: int = "wrong"');
+      final exec = Monty.exec('1 + 2');
+      final results = await Future.wait([type, exec]);
+      final errors = results[0] as List<MontyTypingError>;
+      final result = results[1] as MontyResult;
+      expect(errors, isNotEmpty);
+      expect(result.error, isNull);
+      expect(result.value.dartValue, 3);
+    });
+  });
+}

--- a/test/integration/ffi_type_check_test.dart
+++ b/test/integration/ffi_type_check_test.dart
@@ -1,0 +1,12 @@
+// FFI binding for the Monty.typeCheck shared test body.
+//
+// Run: dart test test/integration/ffi_type_check_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_type_check_test_body.dart';
+
+void main() => runTypeCheckTests();

--- a/test/integration/wasm_type_check_test.dart
+++ b/test/integration/wasm_type_check_test.dart
@@ -1,0 +1,12 @@
+// WASM binding for the Monty.typeCheck shared test body.
+//
+// Run with dart2js:  dart test test/integration/wasm_type_check_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_type_check_test.dart -p chrome --compiler dart2wasm --run-skipped
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_type_check_test_body.dart';
+
+void main() => runTypeCheckTests();

--- a/test/unit/platform/monty_typing_error_test.dart
+++ b/test/unit/platform/monty_typing_error_test.dart
@@ -1,0 +1,98 @@
+// Unit tests for MontyTypingError JSON parsing — pure value-level.
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+const _singleDiagnosticJson = '''
+[
+  {
+    "cell": null,
+    "code": "invalid-assignment",
+    "end_location": {"column": 33, "row": 114},
+    "filename": "/main.py",
+    "fix": null,
+    "location": {"column": 12, "row": 114},
+    "message": "Object of type `None` is not assignable to `list[Unknown]`",
+    "noqa_row": null,
+    "url": "https://ty.dev/rules#invalid-assignment"
+  }
+]
+''';
+
+void main() {
+  group('MontyTypingError.fromJson', () {
+    test('parses every documented field', () {
+      final list = MontyTypingError.listFromJson(_singleDiagnosticJson);
+      expect(list, hasLength(1));
+
+      final e = list.single;
+      expect(e.code, 'invalid-assignment');
+      expect(
+        e.message,
+        'Object of type `None` is not assignable to `list[Unknown]`',
+      );
+      expect(e.path, '/main.py');
+      expect(e.line, 114);
+      expect(e.column, 12);
+      expect(e.endLine, 114);
+      expect(e.endColumn, 33);
+      expect(e.url, 'https://ty.dev/rules#invalid-assignment');
+    });
+
+    test('toString summarises with location and code', () {
+      final e = MontyTypingError.listFromJson(_singleDiagnosticJson).single;
+      expect(
+        e.toString(),
+        'MontyTypingError(invalid-assignment at /main.py:114:12: '
+        'Object of type `None` is not assignable to `list[Unknown]`)',
+      );
+    });
+
+    test('handles missing optional fields gracefully', () {
+      const json = '''
+      [{"code": "x", "message": "y"}]
+      ''';
+      final e = MontyTypingError.listFromJson(json).single;
+      expect(e.code, 'x');
+      expect(e.message, 'y');
+      expect(e.path, isNull);
+      expect(e.line, isNull);
+      expect(e.column, isNull);
+      expect(e.url, isNull);
+    });
+  });
+
+  group('MontyTypingError.listFromJson', () {
+    test('returns empty list for null input', () {
+      expect(MontyTypingError.listFromJson(null), isEmpty);
+    });
+
+    test('returns empty list for empty string', () {
+      expect(MontyTypingError.listFromJson(''), isEmpty);
+    });
+
+    test('returns empty list for empty JSON array', () {
+      expect(MontyTypingError.listFromJson('[]'), isEmpty);
+    });
+
+    test('skips non-object entries silently', () {
+      const json = '[1, "string", null, {"code": "ok", "message": "kept"}]';
+      final list = MontyTypingError.listFromJson(json);
+      expect(list, hasLength(1));
+      expect(list.single.code, 'ok');
+    });
+
+    test('preserves order of multiple diagnostics', () {
+      const json = '''
+      [
+        {"code": "a", "message": "first"},
+        {"code": "b", "message": "second"}
+      ]
+      ''';
+      final list = MontyTypingError.listFromJson(json);
+      expect(list.map((e) => e.code), ['a', 'b']);
+    });
+  });
+}

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -101,4 +101,5 @@ dart test \
   test/integration/wasm_repl_extfns_lifecycle_test.dart \
   test/integration/wasm_repl_snapshot_lifecycle_test.dart \
   test/integration/wasm_setextfns_test.dart \
+  test/integration/wasm_type_check_test.dart \
   "$@"


### PR DESCRIPTION
Closes #59.

Adds `Monty.typeCheck(code, {prefixCode, scriptName})` for IDE-shaped static analysis — surfaces type errors without executing the script. Returns `List<MontyTypingError>` with `code`, `message`, `path`, `line`, `column`, `endLine`, `endColumn`, and optional `url`.

## Scope

Cross-stack: Rust C export → ffigen → WASM JS bridge → Dart bindings → public API → tests + example.

- Rust: `monty_type_check` C export in `native/src/lib.rs` calling `monty_type_checking::type_check` over a `PooledMemoryDb` (heap is scrubbed on drop, isolated from execution heap). JSON diagnostics via `format_from_str(\"json\")`; NULL when clean.
- C header + ffigen regeneration.
- JS bridge: `typeCheck` op on the worker, plumbed through `bridge.js`. `wasm_glue.js` gains a no-op `sched_yield` WASI import (required by salsa-rs, which `monty-type-checking` pulls in).
- Dart: `CoreBindings.typeCheck` abstract method, FFI + WASM implementations, `BaseMontyPlatform.typeCheck`, `MontyPlatform`/`ReplPlatform` overrides.
- Public API: `Monty.typeCheck` static, `MontyTypingError` value class with `MontyTypingError.listFromJson` parser.

## Tests

- 8 unit tests for `MontyTypingError` JSON parsing.
- 7-scenario shared body (`_type_check_test_body.dart`) wired into both `ffi_type_check_test.dart` and `wasm_type_check_test.dart`. Covers clean code, inference without annotations, annotated mismatch, the rbtree.py None-vs-list pattern, `prefixCode`, multiple sorted diagnostics, and concurrent-with-exec heap isolation.
- `example/13_type_check.dart` covers the same axes for human readers; picked up by the example smoke test.

## Notes

- WASM blocker (`Import \"sched_yield\": function import requires a callable`) resolved with a no-op JS polyfill — salsa-rs requires the symbol but JS is single-threaded so there's nothing to yield to.
- Heap isolation precondition verified by reading `monty-type-checking/src/type_check.rs` — `PooledMemoryDb::checkout()` ensures analyzer runs on a separate, scrubbed db pool.

## Validation

- `dart analyze` clean.
- `dart format --set-exit-if-changed .` clean.
- FFI: 7/7 type_check integration tests + 8 unit tests pass.
- WASM: 526/526 in the full integration suite (including new `wasm_type_check_test`).
- Examples: 9/9 ran (13_type_check.dart picked up by smoke test).