### PR TITLE
feat(api): add MontyResult.ok and MontyResult.excType convenience getters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   `code`, `message`, `path`, `line`/`column`, `endLine`/`endColumn`, and
   `url`. WASM bridge gains a `sched_yield` no-op to satisfy salsa-rs's
   WASI imports.
+- **`MontyResult.ok` and `MontyResult.excType`** convenience getters.
+  `ok` is the positive-form alias of `isError` (`bool get ok => error == null`);
+  `excType` is shorthand for `error?.excType`. Read more naturally in test
+  harnesses and UI code (`expect(result.ok, isTrue)`, `if (result.excType ==
+  'ValueError')`). Closes #38.
 
 ### Upgraded
 
@@ -86,11 +91,6 @@
 
 ### Added
 
-- **`MontyResult.ok` and `MontyResult.excType`** convenience getters.
-  `ok` is the positive-form alias of `isError` (`bool get ok => error == null`);
-  `excType` is shorthand for `error?.excType`. Read more naturally in test
-  harnesses and UI code (`expect(result.ok, isTrue)`, `if (result.excType ==
-  'ValueError')`). Closes #38.
 - **`flutter.assets` pubspec stanza.** Flutter consumers can reference
   `- package: dart_monty_core` under their own `flutter.assets` to have
   the WASM/JS bridge files served at `packages/dart_monty_core/assets/...`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@
 
 ### Added
 
+- **`MontyResult.ok` and `MontyResult.excType`** convenience getters.
+  `ok` is the positive-form alias of `isError` (`bool get ok => error == null`);
+  `excType` is shorthand for `error?.excType`. Read more naturally in test
+  harnesses and UI code (`expect(result.ok, isTrue)`, `if (result.excType ==
+  'ValueError')`). Closes #38.
 - **`flutter.assets` pubspec stanza.** Flutter consumers can reference
   `- package: dart_monty_core` under their own `flutter.assets` to have
   the WASM/JS bridge files served at `packages/dart_monty_core/assets/...`

--- a/lib/src/platform/monty_result.dart
+++ b/lib/src/platform/monty_result.dart
@@ -63,6 +63,23 @@ final class MontyResult {
   /// Whether this result represents an error.
   bool get isError => error != null;
 
+  /// Whether this result represents a successful execution.
+  ///
+  /// Equivalent to `error == null`. Provided as a positive-form alias of
+  /// [isError] for use sites that read more naturally as a success check
+  /// (`if (result.ok) ...`, `expect(result.ok, isTrue)`).
+  bool get ok => error == null;
+
+  /// The Python exception class name when [error] is set, else `null`.
+  ///
+  /// Shorthand for `result.error?.excType`. Useful when filtering on the
+  /// exception type without first null-checking [error]:
+  ///
+  /// ```dart
+  /// if (result.excType == 'ValueError') { ... }
+  /// ```
+  String? get excType => error?.excType;
+
   /// Serializes this result to a JSON-compatible map.
   Map<String, dynamic> toJson() {
     return {

--- a/test/unit/platform/monty_result_getters_test.dart
+++ b/test/unit/platform/monty_result_getters_test.dart
@@ -1,0 +1,68 @@
+// Unit tests for MontyResult convenience getters: ok, excType.
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+const _zeroUsage = MontyResourceUsage(
+  memoryBytesUsed: 0,
+  timeElapsedMs: 0,
+  stackDepthUsed: 0,
+);
+
+void main() {
+  group('MontyResult.ok', () {
+    test('returns true when error is null', () {
+      const r = MontyResult(value: MontyInt(42), usage: _zeroUsage);
+      expect(r.ok, isTrue);
+      expect(r.isError, isFalse);
+    });
+
+    test('returns false when error is set', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'boom'),
+        usage: _zeroUsage,
+      );
+      expect(r.ok, isFalse);
+      expect(r.isError, isTrue);
+    });
+
+    test('is the inverse of isError', () {
+      const ok = MontyResult(value: MontyInt(1), usage: _zeroUsage);
+      const err = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'x'),
+        usage: _zeroUsage,
+      );
+      expect(ok.ok, equals(!ok.isError));
+      expect(err.ok, equals(!err.isError));
+    });
+  });
+
+  group('MontyResult.excType', () {
+    test('returns null when error is null', () {
+      const r = MontyResult(value: MontyInt(42), usage: _zeroUsage);
+      expect(r.excType, isNull);
+    });
+
+    test('returns null when error is set without excType', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'unknown'),
+        usage: _zeroUsage,
+      );
+      expect(r.excType, isNull);
+    });
+
+    test('forwards error.excType when set', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'bad value', excType: 'ValueError'),
+        usage: _zeroUsage,
+      );
+      expect(r.excType, 'ValueError');
+    });
+  });
+}


### PR DESCRIPTION
Closes #38.

Adds two pure derived getters to `MontyResult`:

- `bool get ok => error == null` — positive-form alias of `isError`. Reads naturally as a success check.
- `String? get excType => error?.excType` — shorthand for filtering on Python exception class without first null-checking `error`.

```dart
expect(result.ok, isTrue);
if (result.excType == 'ValueError') { ... }
```

## Tests

6 unit tests in `test/unit/platform/monty_result_getters_test.dart`:
- `ok` true/false parity with `isError`
- `excType` is null when error is null
- `excType` is null when error has no `excType`
- `excType` forwards `error.excType` when set

## Notes

- No behavioural change; pure getters. `isError` remains for back-compat / pattern-matching style.
- Examples were left as-is — they read `r.error?.excType` deliberately, teaching readers the structure of `MontyException`.
- CHANGELOG entry under Unreleased › Added.