### PR TITLE
fix(demo): port Panel VFS to MontyRepl + add CI compile gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
               - 'native/**'
               - 'hook/**'
               - 'tool/**'
+              - 'packages/**'
               - 'pubspec.*'
               - 'analysis_options.yaml'
               - 'dart_test.yaml'
@@ -323,6 +324,15 @@ jobs:
         run: |
           dart test test/integration/example_smoke_test.dart \
             -p vm --run-skipped --tags=example --reporter=expanded
+
+      # Compile-only smoke for the Pages demo. Catches API drift between
+      # `Monty`/`MontyRepl` refactors and packages/dart_monty_web at PR time
+      # rather than after merge (deploy-pages.yml only runs on push:main).
+      - name: Build web REPL (compile-only smoke)
+        run: |
+          cd packages/dart_monty_web && dart pub get && cd ../..
+          dart compile js packages/dart_monty_web/web/repl_demo.dart \
+            -o /tmp/repl_demo.dart.js --no-source-maps
 
   # ---------------------------------------------------------------------------
   # WASM/JS integration tests — 464 fixtures through MontyWasm in headless Chrome

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -11,9 +11,10 @@
 //    Each call is logged with its arguments and return value so the flow
 //    is visible.
 //
-//  Panel VFS — Monty + osHandler (virtual filesystem, snapshot/restore)
-//    Exercises: Monty(osHandler:), pathlib, OsCallException, snapshot,
-//               restore, MontyPath value type.
+//  Panel VFS — MontyRepl + per-call osHandler (virtual filesystem,
+//  snapshot/restore)
+//    Exercises: MontyRepl.feedRun(osHandler:), pathlib, OsCallException,
+//               snapshot, restore, MontyPath value type.
 import 'dart:async';
 import 'dart:js_interop';
 import 'dart:typed_data';
@@ -415,7 +416,7 @@ void _initExternalsPanel() {
 }
 
 // ---------------------------------------------------------------------------
-// Panel VFS — Monty with osHandler, pathlib, snapshot/restore
+// Panel VFS — MontyRepl with per-call osHandler, pathlib, snapshot/restore
 // ---------------------------------------------------------------------------
 void _initVfsPanel() {
   final output = _div('output-vfs');
@@ -425,14 +426,14 @@ void _initVfsPanel() {
   final restoreBtn = _button('restore-vfs');
 
   Uint8List? savedSnap;
-  final monty = Monty(osHandler: _vfsOsHandler);
+  final repl = MontyRepl();
 
   void write(String text, {String? className}) =>
       _appendLine(output, text, className: className);
 
   output.innerHTML = ''.toJS;
   write(
-    'VFS panel — Monty with osHandler. State persists across run() calls.',
+    'VFS panel — MontyRepl with per-call osHandler. State persists across feedRun calls.',
     className: 'system-line',
   );
   write('Files: ${_vfs.keys.join(", ")}', className: 'system-line');
@@ -451,7 +452,7 @@ void _initVfsPanel() {
     write('>>> $code', className: 'input-line');
 
     try {
-      final result = await monty.run(code);
+      final result = await repl.feedRun(code, osHandler: _vfsOsHandler);
 
       if (result.printOutput != null && result.printOutput!.isNotEmpty) {
         write(result.printOutput!.trimRight(), className: 'print-line');
@@ -474,7 +475,7 @@ void _initVfsPanel() {
 
   snapBtn.onclick = (web.MouseEvent _) {
     unawaited(() async {
-      final b = await monty.snapshot();
+      final b = await repl.snapshot();
       savedSnap = b;
       write('📸 Snapshot (${b.length} bytes).', className: 'system-line');
     }());
@@ -487,7 +488,7 @@ void _initVfsPanel() {
       return;
     }
     unawaited(() async {
-      await monty.restore(s);
+      await repl.restore(s);
       write('↩ Restored.', className: 'system-line');
     }());
   }.toJS;


### PR DESCRIPTION
## Summary

- Ports Panel VFS in `packages/dart_monty_web/web/repl_demo.dart` to `MontyRepl` with a per-call `osHandler`. PR-B (#a3dbb14) removed `Monty(osHandler:)` and dropped `snapshot`/`restore` from `Monty`, but the web demo wasn't updated. `deploy-pages.yml` only runs on `push:main`, so the breakage shipped to `main` and Pages has been failing since.
- Adds a `dart compile js` compile-only smoke step to the existing `test-examples` job and includes `packages/**` in the path filter, so a future `Monty`/`MontyRepl` refactor catches demo drift at PR time.

Closes #72.

## What changed in repl_demo.dart

- Panel VFS swapped from `Monty(osHandler: …)` + `monty.run(code)` to `MontyRepl()` + `repl.feedRun(code, osHandler: _vfsOsHandler)`. Same UX: persistent state across runs, ↩ restore, 📸 snapshot.
- Snapshot/restore now hang off `MontyRepl` (where they live post-PR-B). No behaviour change for the user.
- File-header docstring, panel header, and welcome line updated to reflect the new shape.

Panels A and B were already on `MontyRepl` and unchanged.

## Test plan

- [x] `dart compile js packages/dart_monty_web/web/repl_demo.dart -o /tmp/x.js --no-source-maps` — clean
- [x] `dart compile wasm packages/dart_monty_web/web/repl_demo.dart -o /tmp/x.wasm` — clean
- [x] `dart analyze --fatal-infos packages/dart_monty_web/web/repl_demo.dart` — only the pre-existing `unnecessary_cast` warning at line 372 (Panel B, not touched here)
- [ ] Post-merge: Pages deploy on `main` goes green, three-panel smoke against the live site (Panel VFS: `import pathlib` → `pathlib.Path("/data/hello.txt").read_text()` → expect `"Hello from the virtual filesystem!"`; 📸 → write a new file → ↩ → exists check returns `False`)

## Out of scope

`MountDir` / `memoryMountedOsHandler` showcase, `Monty.typeCheck` pre-flight button, `printCallback` stream pane, hydrated-dataclass viewer — each needs new UI surface and belongs in a follow-up demo refresh.