### PR TITLE
fix(demo): type-clean externalsPrefix + rebase typeCheck line numbers

### DIFF
--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -621,17 +621,18 @@ const _kSamples = <_Sample>[
   ),
   _Sample(
     num: 3,
-    title: 'Multi-line block detection',
+    title: 'Multi-line block detection (typed)',
     panel: 'a',
     desc:
         'detectContinuation() returns incompleteBlock when the statement is '
-        'not yet closed. Paste the full function — the REPL holds input until '
-        'the de-indent completes the block.',
+        'not yet closed. Paste the full annotated function — the REPL holds '
+        'input until the de-indent completes the block, and 🔎 type-checks '
+        'the n: int / -> int signature before you run it.',
     steps: [
       _Step(
         label: '→ REPL',
         code:
-            'def fib(n):\n'
+            'def fib(n: int) -> int:\n'
             '    a, b = 0, 1\n'
             '    for _ in range(n): a, b = b, a+b\n'
             '    return a\n'
@@ -832,11 +833,14 @@ String _fmt(MontyValue v) => switch (v) {
         : value.toString(),
   MontyString(:final value) => '"$value"',
   MontyBytes(:final value) => 'b[${value.length}]',
+  // Show up to 20 items — enough for demo punchlines like
+  // `[fib(i) for i in range(10)]` (Sample #3) without unbounded
+  // rendering for pathological inputs like `range(1_000_000)`.
   MontyList(:final items) =>
-    '[${items.take(3).map(_fmt).join(', ')}${items.length > 3 ? ', …(${items.length})' : ''}]',
+    '[${items.take(20).map(_fmt).join(', ')}${items.length > 20 ? ', …(${items.length})' : ''}]',
   MontyTuple(:final items) => '(${items.map(_fmt).join(', ')})',
   MontyDict(:final entries) =>
-    '{${entries.entries.take(3).map((e) => '"${e.key}": ${_fmt(e.value)}').join(', ')}${entries.length > 3 ? ', …' : ''}}',
+    '{${entries.entries.take(20).map((e) => '"${e.key}": ${_fmt(e.value)}').join(', ')}${entries.length > 20 ? ', …' : ''}}',
   MontySet(:final items) => '{${items.map(_fmt).join(', ')}}',
   MontyFrozenSet(:final items) => 'frozenset({${items.map(_fmt).join(', ')}})',
   MontyDate(:final year, :final month, :final day) => '$year-$month-$day',

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -192,9 +192,17 @@ void _initReplPanel() {
   // Static signatures for Dart-registered externals so Monty.typeCheck
   // recognises calls like host_upper("hi") instead of flagging an
   // undefined name. Kept in sync with the externalFunctions map below.
+  // The body must be type-clean (return a str): Monty's checker treats
+  // `...` as an empty body that implicitly returns None.
   const externalsPrefix = '''
-def host_upper(s: str) -> str: ...
+def host_upper(s: str) -> str:
+    return s
 ''';
+  // Newline count of the prefix — diagnostics in this region come from
+  // the synthetic prefix, not user code, and are filtered out below.
+  // Diagnostics in user code have their line numbers rebased so they
+  // line up with the textarea.
+  final prefixLines = '\n'.allMatches(externalsPrefix).length;
 
   typeCheckBtn.onclick = (web.MouseEvent _) {
     unawaited(() async {
@@ -204,10 +212,13 @@ def host_upper(s: str) -> str: ...
         return;
       }
       try {
-        final errors = await Monty.typeCheck(
+        final raw = await Monty.typeCheck(
           code,
           prefixCode: externalsPrefix,
         );
+        final errors = raw
+            .where((e) => e.line == null || e.line! > prefixLines)
+            .toList(growable: false);
         if (errors.isEmpty) {
           write('🔎 No type errors.', className: 'system-line');
           return;
@@ -217,9 +228,10 @@ def host_upper(s: str) -> str: ...
           className: 'system-line',
         );
         for (final e in errors) {
-          final loc = (e.line != null && e.column != null)
-              ? '${e.line}:${e.column}'
-              : (e.line?.toString() ?? '?');
+          final userLine = e.line == null ? null : e.line! - prefixLines;
+          final loc = (userLine != null && e.column != null)
+              ? '$userLine:${e.column}'
+              : (userLine?.toString() ?? '?');
           write('  $loc  ${e.code}: ${e.message}', className: 'error-line');
         }
       } on Object catch (e) {


### PR DESCRIPTION
## Summary

Two follow-up fixes for #74's 🔎 typeCheck button after live-site smoke surfaced a phantom diagnostic.

### What broke

Clicking 🔎 against any non-empty input produced:

```
🔎 1 type error:
  1:27  empty-body: Function always implicitly returns \`None\`, which is not assignable to return type \`str\`
```

That diagnostic isn't from the user's code at all — it's from the synthetic `externalsPrefix` I added in #74:

```python
def host_upper(s: str) -> str: ...
```

Monty's type checker doesn't accept the Python `...`-stub idiom. It reads `...` as an empty body that implicitly returns `None`, which is incompatible with the declared `str` return type. `1:27` points into the prefix's return annotation, but the user has no idea — the prefix is implementation detail they never see.

### Fix

1. **Type-clean prefix.** Replace `... ` with `return s`. The prefix now type-checks cleanly while still declaring the `host_upper(s: str) -> str` signature for the analyser.
2. **Defensive line-rebase + filter.** Compute `prefixLines` from the prefix's `\n` count, drop diagnostics whose `line` falls inside the prefix region, and subtract `prefixLines` from the line numbers of remaining diagnostics so what the user sees lines up with the textarea (line 1 = first line they typed). A future maintainer adding more prefix declarations shouldn't be able to leak prefix diagnostics into the user-facing output again.

## Test plan

- [x] `dart compile js packages/dart_monty_web/web/repl_demo.dart -o /tmp/x.js --no-source-maps` — clean
- [x] `dart analyze --fatal-infos` — only the pre-existing Panel B `unnecessary_cast` warning
- [ ] Post-deploy: paste any clean snippet → 🔎 → expect `🔎 No type errors.`
- [ ] Post-deploy: paste `x: int = "not an int"` → 🔎 → expect a single `invalid-assignment` diagnostic at user line 1, not line 4