### PR TITLE
test: add repros infrastructure + first repro for issue #32

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -283,6 +283,7 @@ jobs:
             test/integration/ffi_datetime_oscall_test.dart \
             test/integration/ffi_multi_repl_test.dart \
             test/integration/ffi_repl_oscall_test.dart \
+            test/integration/repros \
             -p vm --run-skipped --tags=ffi --reporter=expanded
 
   # ---------------------------------------------------------------------------

--- a/test/fixtures/repros/README.md
+++ b/test/fixtures/repros/README.md
@@ -1,0 +1,100 @@
+# Repro fixtures
+
+Each file in this directory is a minimal, self-documenting reproduction of an
+open `dart_monty_core` issue. Repros are designed to be **side-loadable** —
+the same `.py` file documents both the input and the divergence so it can be
+replayed against the reference implementation (CPython / `pydantic-monty`) to
+confirm what the expected behavior is.
+
+## Layout
+
+- `issue_<N>_<slug>.py` — the repro itself. The body is valid,
+  directly-runnable Python so the reference implementation can execute it
+  unmodified. Externals are defined inline as plain Python functions; the
+  Dart-side test replaces those with registered `externalFunctions` callbacks.
+- `test/integration/repros/issue_<N>_<slug>_<backend>_test.dart` —
+  the Dart-side replay. Asserts the **expected reference behavior** wrapped
+  in `xfail('#<N>', () async { ... })`, so the test passes today *because*
+  the inner assertion fails (the bug is reproducing). When the bug is fixed
+  the inner assertion passes, `xfail()` raises, and CI flags the test for
+  promotion to a regular test.
+
+## File format
+
+Each repro `.py` file is structured so that:
+
+1. The top of the file documents the issue, expected reference output, and
+   actual broken output on `dart_monty_core`.
+2. The body is plain, executable Python — you can `python3 issue_NN_*.py`
+   and watch the reference behavior. Comments tagged `# === FEED N ===`
+   delimit the call sequence; on dart_monty_core each FEED becomes a
+   separate `repl.feedRun(...)` call so that the exact multi-call cadence
+   that triggers the bug is preserved.
+3. Stub external definitions sit at the top under
+   `# === EXTERNALS (reference impl) ===`. The Dart-side test
+   registers equivalent callbacks via `externalFunctions:`.
+
+## XFAIL pattern
+
+`package:test` has no native xfail. `test/integration/repros/_xfail.dart`
+provides a helper that wraps the *correct* assertion in an inverted
+expectation:
+
+```dart
+test('issue #32: ...', () async {
+  await xfail('#32', () async {
+    // Asserts the expected reference behavior — exactly what you'd write
+    // for a regular regression test.
+    expect(probe.value, isA<MontyString>()
+        .having((s) => s.value, 'value', 'function'));
+  });
+});
+```
+
+- **Today** (bug reproduces): inner `expect` raises `TestFailure`, `xfail()`
+  catches it via `throwsA(anything)`, the test passes.
+- **After the fix** (bug gone): inner `expect` passes, `xfail()` sees no
+  throw and itself fails — CI tells you "this XFAIL just started passing,
+  promote it."
+
+## Running a repro
+
+**Reference (CPython / pydantic-monty) — confirms expected behavior:**
+
+```bash
+python3 test/fixtures/repros/issue_32_listcomp_global_clobber.py
+```
+
+**dart_monty_core (FFI):**
+
+```bash
+dart test test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart \
+  -p vm --run-skipped --tags=ffi --reporter=expanded
+```
+
+This is wired into the CI `test-ffi` job, so the FFI repros run on every
+PR — staying green while the bugs reproduce, alerting on fix.
+
+## Adding a new repro
+
+1. File a GitHub issue with a minimal repro.
+2. Drop a `issue_<N>_<slug>.py` in this directory documenting the divergence.
+   The body must be valid, directly-runnable Python so the reference
+   implementation can execute it unmodified.
+3. Mirror it as a Dart test under `test/integration/repros/`. Wrap the
+   *correct* (reference) assertion in `xfail('#<N>', () async { ... })`.
+4. Confirm the test passes locally — meaning the inner assertion fails —
+   with `dart test test/integration/repros/<file> --run-skipped --tags=ffi`.
+5. The next CI run picks up the new file via the `test/integration/repros`
+   directory glob in `.github/workflows/ci.yaml`'s `test-ffi` job.
+
+## Promoting a repro to a regression guard
+
+When the underlying bug is fixed:
+
+1. Remove the `xfail('#<N>', () async { ... });` wrapper, so the inner
+   assertion runs directly.
+2. The test now becomes a regular regression guard — CI fails if the bug
+   ever resurfaces.
+3. (Optional) Move or delete the `.py` if it's no longer pedagogically
+   useful, or keep it as a documented historical artifact.

--- a/test/fixtures/repros/issue_32_listcomp_global_clobber.py
+++ b/test/fixtures/repros/issue_32_listcomp_global_clobber.py
@@ -1,0 +1,60 @@
+# Repro: dart_monty_core#32
+#   MontyRepl: host function global binding clobbered to int after
+#   repeat list-comprehension calls.
+#
+# https://github.com/runyaga/dart_monty_core/issues/32
+#
+# Symptom
+# -------
+# When a function registered as an `externalFunction` on `MontyRepl` is
+# invoked from a list comprehension across two or more consecutive
+# `feedRun` calls, the function's global binding is replaced by an int
+# (apparently the comprehension's length / final iteration value).
+# Subsequent calls raise `TypeError: 'int' object is not callable`.
+#
+# Sibling externals (e.g. `delay_fn`, `http_fn`) are not affected — only
+# the name actually called inside the list comp gets clobbered.
+#
+# Workarounds that work today
+# ---------------------------
+#   - Use `for ... : results.append(sync_fn())` instead of a list comp.
+#   - Separate the two list-comp `feedRun`s with any other `feedRun`.
+#   - Use direct calls (`x = sync_fn()`) instead of comprehensions.
+#
+# Side-loading against the reference implementation
+# -------------------------------------------------
+# This file is directly runnable Python. Under CPython or pydantic-monty,
+# `sync_fn` remains a function across all three feeds and the final line
+# prints `function`:
+#
+#   $ python3 test/fixtures/repros/issue_32_listcomp_global_clobber.py
+#   function
+#
+# Under dart_monty_core (current behavior), the equivalent feed sequence
+# (replayed by issue_32_listcomp_global_clobber_ffi_test.dart) makes the
+# final probe see `int`, and any subsequent `sync_fn()` call raises
+# `TypeError: 'int' object is not callable`.
+
+# === EXTERNALS (reference impl) ===
+# The Dart-side test registers `sync_fn` via externalFunctions: (...).
+# Defined inline here so this file is directly runnable for cross-check.
+def sync_fn():
+    return 'sync_ok'
+
+
+# === FEED 1 ===
+# First list-comp call — establishes the bug condition.
+results = [sync_fn() for _ in range(10)]
+
+
+# === FEED 2 ===
+# Second list-comp call — bug triggers here on dart_monty_core.
+results = [sync_fn() for _ in range(5)]
+
+
+# === FEED 3 ===
+# Probe: type of sync_fn after the bug fires.
+#
+# Reference impl (this file under CPython):  function
+# dart_monty_core (issue #32, observed):     int
+print(type(sync_fn).__name__)

--- a/test/integration/repros/_xfail.dart
+++ b/test/integration/repros/_xfail.dart
@@ -1,0 +1,43 @@
+// XFAIL helper — pytest-style "expected to fail" for repro tests.
+//
+// Dart's `package:test` has no native xfail. This helper wraps a body that
+// asserts the *expected reference behavior* and inverts the test outcome:
+// the test passes today *because* the inner assertion fails (the bug is
+// reproducing), and fails the day the inner assertion starts passing
+// (the bug has been fixed — promote this to a regular test).
+//
+// Usage:
+//
+//   test('issue #32: sync_fn survives two list-comp feeds', () async {
+//     await xfail('#32', () async {
+//       final repl = MontyRepl();
+//       // ... feeds ...
+//       expect(probe.value, isA<MontyString>()
+//           .having((s) => s.value, 'value', 'function'));
+//     });
+//   });
+//
+// When the bug is fixed:
+//   1. Replace `await xfail('#32', () async { ... });` with the body inline.
+//   2. Add the test file to ci.yaml's matching backend job invocation.
+
+import 'package:test/test.dart';
+
+/// Asserts that [body] currently fails (any `TestFailure` from inner
+/// `expect`s, or any thrown exception during execution). When the underlying
+/// bug is fixed and [body] starts completing without failure, this helper
+/// raises a `TestFailure`, signalling that the test should be promoted to
+/// a regular test.
+///
+/// [reason] should reference the tracking issue, e.g. `'#32'`.
+Future<void> xfail(String reason, Future<void> Function() body) async {
+  await expectLater(
+    body,
+    throwsA(anything),
+    reason:
+        'XFAIL $reason: expected to fail until the underlying bug is fixed. '
+        'When this assertion fails ("expected throw, none thrown"), the bug '
+        'has been fixed — remove the xfail() wrapper and add the test file '
+        'to .github/workflows/ci.yaml.',
+  );
+}

--- a/test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart
+++ b/test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart
@@ -1,0 +1,105 @@
+// Repro: dart_monty_core#32 — host function global binding clobbered to
+// int after repeat list-comprehension calls on a persistent MontyRepl.
+//
+// Side-loadable companion: test/fixtures/repros/issue_32_listcomp_global_clobber.py
+//   $ python3 test/fixtures/repros/issue_32_listcomp_global_clobber.py
+//   function     # reference behavior
+//
+// This test replays the same feed sequence on `MontyRepl` (FFI backend) with
+// `sync_fn` registered as an external. The body asserts the *expected
+// reference behavior* (`type(sync_fn).__name__ == 'function'`) wrapped in
+// xfail() — so today the test passes precisely because the inner assertion
+// fails (the bug reproduces). When the bug is fixed and the inner assertion
+// starts passing, xfail() raises and CI flags the test for promotion.
+//
+// Run:
+//   dart test test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart \
+//     -p vm --run-skipped --tags=ffi --reporter=expanded
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+import '_xfail.dart';
+
+void main() {
+  group('issue #32 — list-comp external survives repeat feedRun calls', () {
+    Map<String, MontyCallback> externals() => {
+      'sync_fn': (_) async => 'sync_ok',
+    };
+
+    test(
+      'type(sync_fn).__name__ stays "function" after two list-comp feeds',
+      () async {
+        await xfail('#32', () async {
+          final repl = MontyRepl();
+          try {
+            // FEED 1: first list-comp call — establishes the bug condition.
+            await repl.feedRun(
+              'results = [sync_fn() for _ in range(10)]',
+              externalFunctions: externals(),
+            );
+            // FEED 2: second list-comp call — bug triggers on the actual
+            // (broken) backend; the global `sync_fn` gets clobbered to int.
+            await repl.feedRun(
+              'results = [sync_fn() for _ in range(5)]',
+              externalFunctions: externals(),
+            );
+            // FEED 3: probe.
+            final probe = await repl.feedRun(
+              'type(sync_fn).__name__',
+              externalFunctions: externals(),
+            );
+
+            expect(
+              probe.value,
+              isA<MontyString>().having((s) => s.value, 'value', 'function'),
+              reason:
+                  'sync_fn should remain a callable after repeated list-comp '
+                  'invocations across feedRun calls.',
+            );
+          } finally {
+            await repl.dispose();
+          }
+        });
+      },
+    );
+
+    test('sync_fn() remains callable after two list-comp feeds', () async {
+      await xfail('#32', () async {
+        final repl = MontyRepl();
+        try {
+          await repl.feedRun(
+            'results = [sync_fn() for _ in range(10)]',
+            externalFunctions: externals(),
+          );
+          await repl.feedRun(
+            'results = [sync_fn() for _ in range(5)]',
+            externalFunctions: externals(),
+          );
+
+          // After the bug fires, this raises:
+          //   TypeError: 'int' object is not callable
+          final after = await repl.feedRun(
+            'sync_fn()',
+            externalFunctions: externals(),
+          );
+          expect(
+            after.error,
+            isNull,
+            reason:
+                'sync_fn should still be callable. Currently observed: '
+                "TypeError: 'int' object is not callable.",
+          );
+          expect(
+            after.value,
+            isA<MontyString>().having((s) => s.value, 'value', 'sync_ok'),
+          );
+        } finally {
+          await repl.dispose();
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Establishes `test/fixtures/repros/` + `test/integration/repros/` for side-loadable reproduction artifacts of open issues. Refs #32.

Each repro is a pair:

- A `.py` file under `test/fixtures/repros/` — directly runnable under CPython / pydantic-monty so the reference behavior can be confirmed unmodified. Uses \`# === FEED N ===\` comment markers to delimit the per-\`feedRun\` call sequence that triggers the bug.
- A Dart test under `test/integration/repros/` that replays the same feed sequence on \`MontyRepl\` and asserts the *expected reference behavior* wrapped in \`xfail('#<N>', () async { ... })\`.

## XFAIL pattern

\`package:test\` has no native xfail, so \`test/integration/repros/_xfail.dart\` provides one:

\`\`\`dart
test('issue #32: ...', () async {
  await xfail('#32', () async {
    // Asserts the reference behavior — exactly what you'd write
    // for a regular regression test.
    expect(probe.value, isA<MontyString>()
        .having((s) => s.value, 'value', 'function'));
  });
});
\`\`\`

- **Today** (bug reproduces): inner \`expect\` raises \`TestFailure\`, \`xfail()\` catches it via \`throwsA(anything)\`, the test passes. CI green.
- **After the fix** (bug gone): inner \`expect\` passes, \`xfail()\` sees no throw, raises \"expected throw, none thrown\". CI red — \"this XFAIL just started passing, promote it to a regular test.\"

No assertion-flipping, no inversion mental gymnastics — when the fix lands, you delete the \`xfail(...)\` wrapper and the inner assertion runs directly as a regression guard.

## Issue #32 specifically

Reference behavior (\`python3 test/fixtures/repros/issue_32_listcomp_global_clobber.py\`): prints \`function\`. \`dart_monty_core\` observes \`int\` and a subsequent \`sync_fn()\` raises \`TypeError: 'int' object is not callable\`. Both behaviors captured as two separate \`xfail()\` tests:

1. \`type(sync_fn).__name__\` should stay \`'function'\` after two list-comp feeds.
2. \`sync_fn()\` should remain callable after two list-comp feeds.

## CI integration

Wired into the \`test-ffi\` job via the \`test/integration/repros\` directory glob. Adding a new repro file means CI picks it up automatically on the next PR. The repros run continuously, green while bugs reproduce, red the day they don't.

## Test plan

- [x] \`python3 test/fixtures/repros/issue_32_listcomp_global_clobber.py\` → \`function\` (reference impl works as expected)
- [x] \`dart test test/integration/repros/ -p vm --run-skipped --tags=ffi --reporter=expanded\` → \`+2 All tests passed\` (xfail wraps the failures)
- [x] \`dart format --line-length=80 --set-exit-if-changed test/integration/repros/\` clean
- [x] \`dart analyze --fatal-infos test/integration/repros/\` clean