### PR TITLE
feat(mount): add Path.mkdir / Path.rmdir / Path.rename to memoryMountedOsHandler

### DIFF
--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -78,7 +78,7 @@ OsCallHandler memoryMountedOsHandler({
   return (op, args, kwargs) async {
     if (!op.startsWith('Path.')) return notMine(op, args, kwargs);
 
-    final rawPath = args.isEmpty ? null : args.first;
+    final rawPath = args.firstOrNull;
     if (rawPath is! String) return notMine(op, args, kwargs);
     final path = _normalizePath(rawPath);
     final mount = _findMount(path, normalizedMounts);
@@ -93,6 +93,7 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'FileNotFoundError',
           );
         }
+
         return content;
 
       case 'Path.read_bytes':
@@ -103,11 +104,12 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'FileNotFoundError',
           );
         }
+
         return utf8.encode(content);
 
       case 'Path.write_text':
         _requireWritable(mount, path);
-        final value = args.length > 1 ? args[1] : null;
+        final value = args.elementAtOrNull(1);
         if (value is! String) {
           throw OsCallException(
             'write_text expects a string, got ${value.runtimeType}',
@@ -116,11 +118,12 @@ OsCallHandler memoryMountedOsHandler({
         }
         _enforceLimit(mount, path, utf8.encode(value).length);
         vfs[path] = value;
+
         return value.length;
 
       case 'Path.write_bytes':
         _requireWritable(mount, path);
-        final value = args.length > 1 ? args[1] : null;
+        final value = args.elementAtOrNull(1);
         final List<int> bytes;
         if (value is List) {
           bytes = value.cast<int>();
@@ -132,6 +135,7 @@ OsCallHandler memoryMountedOsHandler({
         }
         _enforceLimit(mount, path, bytes.length);
         vfs[path] = utf8.decode(bytes, allowMalformed: true);
+
         return bytes.length;
 
       case 'Path.exists':
@@ -155,6 +159,7 @@ OsCallHandler memoryMountedOsHandler({
           );
         }
         vfs.remove(path);
+
         return null;
 
       case 'Path.iterdir':
@@ -168,6 +173,7 @@ OsCallHandler memoryMountedOsHandler({
             firstSlash == -1 ? key : '$prefix${tail.substring(0, firstSlash)}',
           );
         }
+
         return children.map(MontyPath.new).toList();
 
       case 'Path.absolute':
@@ -228,7 +234,7 @@ OsCallHandler memoryMountedOsHandler({
 
       case 'Path.rename':
         _requireWritable(mount, path);
-        final rawTarget = args.length > 1 ? args[1] : null;
+        final rawTarget = args.elementAtOrNull(1);
         if (rawTarget is! String) {
           throw OsCallException(
             'rename expects a destination path string, got '
@@ -296,25 +302,34 @@ String _normalizePath(String path) {
     }
     segments.add(part);
   }
-  return isAbs ? '/${segments.join('/')}' : segments.join('/');
+  final joined = segments.join('/');
+
+  return isAbs ? '/$joined' : joined;
 }
 
 MountDir? _findMount(String normalized, List<MountDir> mounts) {
   MountDir? match;
   var matchLen = -1;
   for (final m in mounts) {
-    final prefix = m.virtualPath == '/'
-        ? '/'
-        : (m.virtualPath.endsWith('/') ? m.virtualPath : '${m.virtualPath}/');
+    final virtual = m.virtualPath;
+    final String prefix;
+    if (virtual == '/') {
+      prefix = '/';
+    } else if (virtual.endsWith('/')) {
+      prefix = virtual;
+    } else {
+      prefix = '$virtual/';
+    }
     final inMount =
-        normalized == m.virtualPath ||
+        normalized == virtual ||
         '$normalized/'.startsWith(prefix) ||
-        m.virtualPath == '/';
-    if (inMount && m.virtualPath.length > matchLen) {
+        virtual == '/';
+    if (inMount && virtual.length > matchLen) {
       match = m;
-      matchLen = m.virtualPath.length;
+      matchLen = virtual.length;
     }
   }
+
   return match;
 }
 
@@ -342,6 +357,7 @@ bool _hasChildren(Map<String, String> vfs, String path) {
   for (final key in vfs.keys) {
     if (key.startsWith(prefix)) return true;
   }
+
   return false;
 }
 

--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -36,7 +36,18 @@ import 'package:dart_monty_core/src/platform/monty_value.dart';
 /// Supported operations: `Path.read_text`, `Path.read_bytes`,
 /// `Path.write_text`, `Path.write_bytes`, `Path.exists`, `Path.is_file`,
 /// `Path.is_dir`, `Path.is_symlink`, `Path.unlink`, `Path.iterdir`,
-/// `Path.absolute`, `Path.resolve`. Unsupported ops fall through.
+/// `Path.absolute`, `Path.resolve`, `Path.mkdir`, `Path.rmdir`,
+/// `Path.rename`. Unsupported ops fall through.
+///
+/// Directories are implicit in the flat `Map<String, String>` model: a
+/// path is a directory iff some key with that prefix exists, or the path
+/// itself is a mount root. `Path.mkdir` therefore performs the relevant
+/// error checks (parent missing, target already a file, target already
+/// a non-empty directory under `exist_ok=False`) but does not insert
+/// anything into the map on success — `Path.exists` against a freshly
+/// `mkdir`'d empty directory returns `False` until a child is written.
+/// This matches the trade-off of the flat-map backing store; consumers
+/// that need first-class empty directories should use a richer handler.
 OsCallHandler memoryMountedOsHandler({
   required List<MountDir> mounts,
   required Map<String, String> vfs,
@@ -162,6 +173,111 @@ OsCallHandler memoryMountedOsHandler({
       case 'Path.absolute':
       case 'Path.resolve':
         return path;
+
+      case 'Path.mkdir':
+        _requireWritable(mount, path);
+        final parents = (kwargs?['parents'] as bool?) ?? false;
+        final existOk = (kwargs?['exist_ok'] as bool?) ?? false;
+        if (vfs.containsKey(path)) {
+          // A file occupies the path. exist_ok only applies to existing
+          // directories — Python raises FileExistsError here regardless.
+          throw OsCallException(
+            'File exists at $path',
+            pythonExceptionType: 'FileExistsError',
+          );
+        }
+        if (_hasChildren(vfs, path) || _isMountRoot(path, normalizedMounts)) {
+          if (!existOk) {
+            throw OsCallException(
+              'Directory exists: $path',
+              pythonExceptionType: 'FileExistsError',
+            );
+          }
+
+          return null;
+        }
+        final parentOfTarget = _parentPath(path);
+        if (!parents && !_dirExists(vfs, parentOfTarget, normalizedMounts)) {
+          throw OsCallException(
+            'No such directory: $parentOfTarget',
+            pythonExceptionType: 'FileNotFoundError',
+          );
+        }
+        // No-op: directories are implicit. The target becomes "exists"
+        // the moment a child key is written under it.
+
+        return null;
+
+      case 'Path.rmdir':
+        _requireWritable(mount, path);
+        if (vfs.containsKey(path)) {
+          throw OsCallException(
+            'Not a directory: $path',
+            pythonExceptionType: 'NotADirectoryError',
+          );
+        }
+        if (_hasChildren(vfs, path)) {
+          throw OsCallException(
+            'Directory not empty: $path',
+            pythonExceptionType: 'OSError',
+          );
+        }
+        // Empty/non-existent under the flat-map model — no key to drop.
+
+        return null;
+
+      case 'Path.rename':
+        _requireWritable(mount, path);
+        final rawTarget = args.length > 1 ? args[1] : null;
+        if (rawTarget is! String) {
+          throw OsCallException(
+            'rename expects a destination path string, got '
+            '${rawTarget.runtimeType}',
+            pythonExceptionType: 'TypeError',
+          );
+        }
+        final target = _normalizePath(rawTarget);
+        final targetMount = _findMount(target, normalizedMounts);
+        if (targetMount == null) {
+          return notMine(op, [target], kwargs);
+        }
+        _requireWritable(targetMount, target);
+        final srcContent = vfs[path];
+        if (srcContent != null) {
+          // File rename: re-key.
+          vfs.remove(path);
+          vfs[target] = srcContent;
+
+          return null;
+        }
+        if (_hasChildren(vfs, path)) {
+          // Directory rename: re-prefix every child key. Targeting a
+          // non-empty directory is rejected to avoid silent merges.
+          if (_hasChildren(vfs, target) || vfs.containsKey(target)) {
+            throw OsCallException(
+              'Rename target already exists: $target',
+              pythonExceptionType: 'OSError',
+            );
+          }
+          final oldPrefix = path.endsWith('/') ? path : '$path/';
+          final newPrefix = target.endsWith('/') ? target : '$target/';
+          final moves = <String, String>{};
+          for (final key in vfs.keys) {
+            if (key.startsWith(oldPrefix)) {
+              moves[key] = '$newPrefix${key.substring(oldPrefix.length)}';
+            }
+          }
+          for (final entry in moves.entries) {
+            final value = vfs.remove(entry.key);
+            if (value != null) vfs[entry.value] = value;
+          }
+
+          return null;
+        }
+        throw OsCallException(
+          'No such file or directory: $path',
+          pythonExceptionType: 'FileNotFoundError',
+        );
     }
 
     return notMine(op, args, kwargs);
@@ -227,4 +343,30 @@ bool _hasChildren(Map<String, String> vfs, String path) {
     if (key.startsWith(prefix)) return true;
   }
   return false;
+}
+
+bool _isMountRoot(String normalized, List<MountDir> mounts) {
+  for (final m in mounts) {
+    if (m.virtualPath == normalized) return true;
+  }
+
+  return false;
+}
+
+bool _dirExists(
+  Map<String, String> vfs,
+  String normalized,
+  List<MountDir> mounts,
+) {
+  if (_isMountRoot(normalized, mounts)) return true;
+
+  return _hasChildren(vfs, normalized);
+}
+
+String _parentPath(String normalized) {
+  if (normalized == '/' || normalized.isEmpty) return '/';
+  final i = normalized.lastIndexOf('/');
+  if (i <= 0) return '/';
+
+  return normalized.substring(0, i);
 }

--- a/test/unit/mount/memory_mounted_os_handler_test.dart
+++ b/test/unit/mount/memory_mounted_os_handler_test.dart
@@ -165,14 +165,14 @@ void main() {
         () => readOnly('Path.unlink', ['/data/x.txt'], null),
         throwsA(isA<OsCallException>()),
       );
-      expect(vfs.containsKey('/data/x.txt'), true);
+      expect(vfs, contains('/data/x.txt'));
 
       final writable = memoryMountedOsHandler(
         mounts: const [MountDir(virtualPath: '/data')],
         vfs: vfs,
       );
       await writable('Path.unlink', ['/data/x.txt'], null);
-      expect(vfs.containsKey('/data/x.txt'), false);
+      expect(vfs, isNot(contains('/data/x.txt')));
     });
 
     test('paths outside every mount fall through to fallthrough', () async {
@@ -182,6 +182,7 @@ void main() {
         vfs: const {},
         fallthrough: (op, args, kwargs) async {
           fallthroughCalled++;
+
           return null;
         },
       );
@@ -215,6 +216,7 @@ void main() {
         vfs: const {},
         fallthrough: (op, args, kwargs) async {
           fallthroughOp = op;
+
           return 'env-value';
         },
       );

--- a/test/unit/mount/memory_mounted_os_handler_test.dart
+++ b/test/unit/mount/memory_mounted_os_handler_test.dart
@@ -241,5 +241,316 @@ void main() {
         null,
       );
     });
+
+    // -------------------------------------------------------------------
+    // Path.mkdir
+    // -------------------------------------------------------------------
+
+    test('mkdir succeeds as a no-op when parent (mount root) exists', () async {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: const {},
+      );
+      // Parent is the mount root /sandbox — implicitly exists.
+      final r = await handler('Path.mkdir', ['/sandbox/data'], null);
+      expect(r, isNull);
+    });
+
+    test('mkdir parents=False raises FileNotFoundError on missing parent', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: const {},
+      );
+      expect(
+        () => handler('Path.mkdir', ['/sandbox/a/b/c'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'FileNotFoundError',
+          ),
+        ),
+      );
+    });
+
+    test(
+      'mkdir parents=True succeeds when intermediates are missing',
+      () async {
+        final handler = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/sandbox')],
+          vfs: const {},
+        );
+        final r = await handler(
+          'Path.mkdir',
+          ['/sandbox/a/b/c'],
+          {'parents': true},
+        );
+        expect(r, isNull);
+      },
+    );
+
+    test('mkdir raises FileExistsError when a file occupies the path', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: {'/sandbox/data': 'I am a file pretending to be a dir'},
+      );
+      expect(
+        () => handler('Path.mkdir', ['/sandbox/data'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'FileExistsError',
+          ),
+        ),
+      );
+    });
+
+    test(
+      'mkdir raises FileExistsError on existing implicit dir w/o exist_ok',
+      () {
+        final handler = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/sandbox')],
+          vfs: {'/sandbox/data/file.txt': 'x'},
+        );
+        expect(
+          () => handler('Path.mkdir', ['/sandbox/data'], null),
+          throwsA(
+            isA<OsCallException>().having(
+              (e) => e.pythonExceptionType,
+              'pythonExceptionType',
+              'FileExistsError',
+            ),
+          ),
+        );
+      },
+    );
+
+    test(
+      'mkdir exist_ok=True silently succeeds on existing implicit dir',
+      () async {
+        final handler = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/sandbox')],
+          vfs: {'/sandbox/data/file.txt': 'x'},
+        );
+        final r = await handler(
+          'Path.mkdir',
+          ['/sandbox/data'],
+          {'exist_ok': true},
+        );
+        expect(r, isNull);
+      },
+    );
+
+    test('mkdir on readOnly mount raises PermissionError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/sandbox', mode: MountMode.readOnly),
+        ],
+        vfs: const {},
+      );
+      expect(
+        () => handler('Path.mkdir', ['/sandbox/data'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'PermissionError',
+          ),
+        ),
+      );
+    });
+
+    // -------------------------------------------------------------------
+    // Path.rmdir
+    // -------------------------------------------------------------------
+
+    test('rmdir on a file raises NotADirectoryError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: {'/sandbox/file.txt': 'x'},
+      );
+      expect(
+        () => handler('Path.rmdir', ['/sandbox/file.txt'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'NotADirectoryError',
+          ),
+        ),
+      );
+    });
+
+    test('rmdir on non-empty directory raises OSError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: {'/sandbox/data/file.txt': 'x'},
+      );
+      expect(
+        () => handler('Path.rmdir', ['/sandbox/data'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'OSError',
+          ),
+        ),
+      );
+    });
+
+    test('rmdir on empty/non-existent path is a no-op success', () async {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: const {},
+      );
+      final r = await handler('Path.rmdir', ['/sandbox/empty'], null);
+      expect(r, isNull);
+    });
+
+    test('rmdir on readOnly mount raises PermissionError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/sandbox', mode: MountMode.readOnly),
+        ],
+        vfs: const {},
+      );
+      expect(
+        () => handler('Path.rmdir', ['/sandbox/data'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'PermissionError',
+          ),
+        ),
+      );
+    });
+
+    // -------------------------------------------------------------------
+    // Path.rename
+    // -------------------------------------------------------------------
+
+    test('rename moves a file by re-keying the map', () async {
+      final vfs = {'/sandbox/a.txt': 'alpha'};
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: vfs,
+      );
+      await handler('Path.rename', ['/sandbox/a.txt', '/sandbox/b.txt'], null);
+      expect(vfs.containsKey('/sandbox/a.txt'), false);
+      expect(vfs['/sandbox/b.txt'], 'alpha');
+    });
+
+    test('rename across two writable mounts succeeds', () async {
+      final vfs = {'/data/x.txt': 'x'};
+      final handler = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/data'),
+          MountDir(virtualPath: '/scratch'),
+        ],
+        vfs: vfs,
+      );
+      await handler('Path.rename', ['/data/x.txt', '/scratch/x.txt'], null);
+      expect(vfs['/scratch/x.txt'], 'x');
+      expect(vfs.containsKey('/data/x.txt'), false);
+    });
+
+    test('rename with readOnly source mount raises PermissionError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/data', mode: MountMode.readOnly),
+        ],
+        vfs: {'/data/x.txt': 'x'},
+      );
+      expect(
+        () => handler('Path.rename', ['/data/x.txt', '/data/y.txt'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'PermissionError',
+          ),
+        ),
+      );
+    });
+
+    test('rename with readOnly destination mount raises PermissionError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/src'),
+          MountDir(virtualPath: '/dst', mode: MountMode.readOnly),
+        ],
+        vfs: {'/src/x.txt': 'x'},
+      );
+      expect(
+        () => handler('Path.rename', ['/src/x.txt', '/dst/x.txt'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'PermissionError',
+          ),
+        ),
+      );
+    });
+
+    test('rename of a missing path raises FileNotFoundError', () {
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: const {},
+      );
+      expect(
+        () => handler('Path.rename', ['/sandbox/a', '/sandbox/b'], null),
+        throwsA(
+          isA<OsCallException>().having(
+            (e) => e.pythonExceptionType,
+            'pythonExceptionType',
+            'FileNotFoundError',
+          ),
+        ),
+      );
+    });
+
+    test('rename of an implicit directory re-prefixes every child', () async {
+      final vfs = {
+        '/sandbox/old/a.txt': 'a',
+        '/sandbox/old/sub/b.txt': 'b',
+        '/sandbox/keep.txt': 'keep',
+      };
+      final handler = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/sandbox')],
+        vfs: vfs,
+      );
+      await handler('Path.rename', ['/sandbox/old', '/sandbox/new'], null);
+      expect(vfs.containsKey('/sandbox/old/a.txt'), false);
+      expect(vfs.containsKey('/sandbox/old/sub/b.txt'), false);
+      expect(vfs['/sandbox/new/a.txt'], 'a');
+      expect(vfs['/sandbox/new/sub/b.txt'], 'b');
+      expect(vfs['/sandbox/keep.txt'], 'keep');
+    });
+
+    test(
+      'rename onto an existing non-empty directory raises OSError',
+      () {
+        final handler = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/sandbox')],
+          vfs: {
+            '/sandbox/old/a.txt': 'a',
+            '/sandbox/new/b.txt': 'b',
+          },
+        );
+        expect(
+          () => handler('Path.rename', ['/sandbox/old', '/sandbox/new'], null),
+          throwsA(
+            isA<OsCallException>().having(
+              (e) => e.pythonExceptionType,
+              'pythonExceptionType',
+              'OSError',
+            ),
+          ),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary

Adds `Path.mkdir`, `Path.rmdir`, `Path.rename` to `memoryMountedOsHandler`. Closes #76. Unblocks `dart_monty`'s `vfs_demo` migration off `MemoryFileSystem`+`fsHandler` onto `memoryMountedOsHandler` — the first sample in that demo opens with `Path('/sandbox/data').mkdir(parents=True)` which would currently raise `PermissionError`.

## Semantics

Mirrors `dart_monty/lib/src/os_call/fs_handlers.dart:62-95` and standard `pathlib`:

**`Path.mkdir(parents: bool = False, exist_ok: bool = False)`**
- File at path → `FileExistsError`
- Existing implicit dir, `exist_ok=False` → `FileExistsError`
- Existing implicit dir, `exist_ok=True` → no-op
- `parents=False` AND parent dir missing → `FileNotFoundError`
- readOnly mount → `PermissionError`
- Otherwise → no-op (directories are implicit in the flat-map model — the target becomes \"exists\" the moment a child is written under it; documented in the doc comment)

**`Path.rmdir`**
- File at path → `NotADirectoryError`
- Non-empty implicit dir → `OSError` (\"Directory not empty\")
- readOnly mount → `PermissionError`
- Empty / non-existent under flat-map → no-op success (the flat-map model can't distinguish \"empty\" from \"never existed\"; favouring permissive over strict POSIX)

**`Path.rename(target)`**
- File rename → re-key
- Implicit-dir rename → re-prefix every child key (rejects target that already exists as file or non-empty dir to avoid silent merges)
- Cross-mount: both mounts must be writable; target outside any mount falls through to the user fallthrough.
- Source missing → `FileNotFoundError`
- readOnly source/target → `PermissionError`

Sandbox-boundary enforcement (via `_findMount` + `_normalizePath`) and mode enforcement (via `_requireWritable`) apply on every op. `writeBytesLimit` is not relevant for `mkdir`/`rmdir`; `rename` is a re-key, so limits don't apply there either.

## Test plan

- [x] 19 new unit tests covering each op + every error path. All 31 tests in the file pass.
- [x] `dart analyze --fatal-infos lib/src/mount/ test/unit/mount/` — clean
- [x] `dart format --line-length=80 --set-exit-if-changed lib/src/mount/ test/unit/mount/` — clean
- [x] `dcm analyze lib/src/mount/ test/unit/mount/` — clean (36 → 0 over the two commits; the cleanup commit takes care of pre-existing patterns in the file as well as new code)
- [ ] On merge, `dart_monty` can land its `slim/push-to-core` `vfs_demo` migration

## Commits

1. `feat(mount): add Path.mkdir / Path.rmdir / Path.rename to memoryMountedOsHandler` — the feature itself plus 19 new unit tests.
2. `chore(mount): clear pre-existing DCM warnings in memory_mounted_os_handler` — cleanup pass on the file now that it's in scope. `args.first`/`args[1]` → `firstOrNull`/`elementAtOrNull`, missing newlines-before-return added, nested ternaries flattened, test assertions migrated to `contains` matchers. No semantic change.