### PR TITLE
test: unit tests for MontyValue subtypes + MontyResult/MontyException/MontyError

### DIFF
--- a/test/unit/platform/monty_error_result_test.dart
+++ b/test/unit/platform/monty_error_result_test.dart
@@ -1,0 +1,501 @@
+// Unit tests for MontyResult, MontyException, and the MontyError subclasses
+// that aren't already covered (MontyPanicError, MontyCrashError,
+// MontyDisposedError, MontyResourceError).
+//
+// Existing coverage skipped to avoid duplication:
+//   - MontyResult.ok / .excType   → monty_result_getters_test.dart
+//   - MontySyntaxError hierarchy  → monty_syntax_error_test.dart
+//   - MontyTypingError            → monty_typing_error_test.dart
+//
+// Pure value-level tests: no interpreter, no FFI, no WASM.
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+const _zeroUsage = MontyResourceUsage(
+  memoryBytesUsed: 0,
+  timeElapsedMs: 0,
+  stackDepthUsed: 0,
+);
+
+const _someUsage = MontyResourceUsage(
+  memoryBytesUsed: 1024,
+  timeElapsedMs: 42,
+  stackDepthUsed: 7,
+);
+
+void main() {
+  // ------------------------------------------------------------------
+  // MontyResult
+  // ------------------------------------------------------------------
+
+  group('MontyResult equality + hashCode', () {
+    test('two identical success results compare equal', () {
+      const a = MontyResult(value: MontyInt(42), usage: _zeroUsage);
+      const b = MontyResult(value: MontyInt(42), usage: _zeroUsage);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('two identical error results compare equal', () {
+      const a = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'boom', excType: 'ValueError'),
+        usage: _zeroUsage,
+      );
+      const b = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'boom', excType: 'ValueError'),
+        usage: _zeroUsage,
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different value field is not equal', () {
+      expect(
+        const MontyResult(value: MontyInt(1), usage: _zeroUsage),
+        isNot(const MontyResult(value: MontyInt(2), usage: _zeroUsage)),
+      );
+    });
+
+    test('different error message is not equal', () {
+      const a = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'a'),
+        usage: _zeroUsage,
+      );
+      const b = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'b'),
+        usage: _zeroUsage,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('different usage stats is not equal', () {
+      expect(
+        const MontyResult(value: MontyInt(1), usage: _zeroUsage),
+        isNot(const MontyResult(value: MontyInt(1), usage: _someUsage)),
+      );
+    });
+
+    test('different printOutput is not equal', () {
+      expect(
+        const MontyResult(
+          value: MontyInt(1),
+          usage: _zeroUsage,
+          printOutput: 'hi',
+        ),
+        isNot(
+          const MontyResult(
+            value: MontyInt(1),
+            usage: _zeroUsage,
+            printOutput: 'bye',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('MontyResult JSON round-trip', () {
+    test('success result with value', () {
+      const r = MontyResult(value: MontyInt(42), usage: _someUsage);
+      expect(MontyResult.fromJson(r.toJson()), r);
+    });
+
+    test('error result preserves all exception fields', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(
+          message: 'division by zero',
+          filename: 'main.py',
+          lineNumber: 5,
+          columnNumber: 12,
+          sourceCode: '1 / 0',
+          excType: 'ZeroDivisionError',
+        ),
+        usage: _zeroUsage,
+      );
+      expect(MontyResult.fromJson(r.toJson()), r);
+    });
+
+    test('result with printOutput round-trips', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        usage: _zeroUsage,
+        printOutput: 'hello\nworld',
+      );
+      expect(MontyResult.fromJson(r.toJson()), r);
+    });
+
+    test('toJson omits null printOutput entirely', () {
+      const r = MontyResult(value: MontyInt(1), usage: _zeroUsage);
+      expect(r.toJson().containsKey('print_output'), isFalse);
+    });
+
+    test('toJson omits null error entirely', () {
+      const r = MontyResult(value: MontyInt(1), usage: _zeroUsage);
+      expect(r.toJson().containsKey('error'), isFalse);
+    });
+
+    test('toJson includes error key when error is set', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'x'),
+        usage: _zeroUsage,
+      );
+      expect(r.toJson().containsKey('error'), isTrue);
+    });
+  });
+
+  group('MontyResult.toString', () {
+    test('value variant', () {
+      expect(
+        const MontyResult(
+          value: MontyInt(42),
+          usage: _zeroUsage,
+        ).toString(),
+        contains('MontyInt(42)'),
+      );
+    });
+
+    test('error variant uses error.message', () {
+      const r = MontyResult(
+        value: MontyNone(),
+        error: MontyException(message: 'boom'),
+        usage: _zeroUsage,
+      );
+      expect(r.toString(), contains('boom'));
+      expect(r.toString(), contains('error'));
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // MontyException
+  // ------------------------------------------------------------------
+
+  group('MontyException equality + hashCode', () {
+    test('identical fields compare equal', () {
+      const a = MontyException(
+        message: 'm',
+        filename: 'f.py',
+        lineNumber: 1,
+        columnNumber: 2,
+        sourceCode: 'x',
+        excType: 'ValueError',
+      );
+      const b = MontyException(
+        message: 'm',
+        filename: 'f.py',
+        lineNumber: 1,
+        columnNumber: 2,
+        sourceCode: 'x',
+        excType: 'ValueError',
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different excType is not equal', () {
+      expect(
+        const MontyException(message: 'x', excType: 'ValueError'),
+        isNot(const MontyException(message: 'x', excType: 'TypeError')),
+      );
+    });
+
+    test('different lineNumber is not equal', () {
+      expect(
+        const MontyException(message: 'x', lineNumber: 1),
+        isNot(const MontyException(message: 'x', lineNumber: 2)),
+      );
+    });
+
+    test('traceback uses deep equality (independent List instances)', () {
+      // Build the traceback lists at runtime so they are guaranteed to be
+      // distinct List instances (no const canonicalisation). Each holds
+      // the same canonical MontyStackFrame, but the *lists* are not
+      // identical — exactly the scenario where deep equality matters.
+      final tracebackA = List<MontyStackFrame>.from(const [
+        MontyStackFrame(filename: 'f.py', startLine: 1, startColumn: 0),
+      ]);
+      final tracebackB = List<MontyStackFrame>.from(const [
+        MontyStackFrame(filename: 'f.py', startLine: 1, startColumn: 0),
+      ]);
+      expect(identical(tracebackA, tracebackB), isFalse);
+
+      final a = MontyException(message: 'x', traceback: tracebackA);
+      final b = MontyException(message: 'x', traceback: tracebackB);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different traceback length is not equal', () {
+      const oneFrame = [
+        MontyStackFrame(filename: 'f.py', startLine: 1, startColumn: 0),
+      ];
+      const twoFrames = [
+        MontyStackFrame(filename: 'f.py', startLine: 1, startColumn: 0),
+        MontyStackFrame(filename: 'g.py', startLine: 2, startColumn: 0),
+      ];
+      expect(
+        const MontyException(message: 'x', traceback: oneFrame),
+        isNot(const MontyException(message: 'x', traceback: twoFrames)),
+      );
+    });
+  });
+
+  group('MontyException JSON round-trip', () {
+    test('minimal exception (message only)', () {
+      const e = MontyException(message: 'plain');
+      expect(MontyException.fromJson(e.toJson()), e);
+    });
+
+    test('full exception with all optional fields populated', () {
+      const e = MontyException(
+        message: 'bad value',
+        filename: 'main.py',
+        lineNumber: 10,
+        columnNumber: 4,
+        sourceCode: "raise ValueError('bad')",
+        excType: 'ValueError',
+        traceback: [
+          MontyStackFrame(
+            filename: 'main.py',
+            startLine: 10,
+            startColumn: 4,
+            frameName: '<module>',
+            previewLine: "raise ValueError('bad')",
+          ),
+        ],
+      );
+      expect(MontyException.fromJson(e.toJson()), e);
+    });
+
+    test('toJson omits all null fields', () {
+      const e = MontyException(message: 'plain');
+      final json = e.toJson();
+      expect(json.keys, ['message']);
+    });
+
+    test('toJson omits empty traceback list', () {
+      const e = MontyException(message: 'x', excType: 'ValueError');
+      final json = e.toJson();
+      expect(json.containsKey('traceback'), isFalse);
+    });
+
+    test('toJson includes traceback when non-empty', () {
+      const e = MontyException(
+        message: 'x',
+        traceback: [
+          MontyStackFrame(filename: 'a.py', startLine: 1, startColumn: 0),
+        ],
+      );
+      expect(e.toJson()['traceback'], isA<List<Object?>>());
+    });
+  });
+
+  group('MontyException.toString', () {
+    test('message-only', () {
+      expect(
+        const MontyException(message: 'plain').toString(),
+        'MontyException: plain',
+      );
+    });
+
+    test('with excType prepends the type', () {
+      expect(
+        const MontyException(message: 'bad', excType: 'ValueError').toString(),
+        'MontyException: ValueError: bad',
+      );
+    });
+
+    test('with filename appends a (path) suffix', () {
+      expect(
+        const MontyException(message: 'x', filename: 'main.py').toString(),
+        'MontyException: x (main.py)',
+      );
+    });
+
+    test('with filename + lineNumber appends (path:line)', () {
+      expect(
+        const MontyException(
+          message: 'x',
+          filename: 'main.py',
+          lineNumber: 5,
+        ).toString(),
+        'MontyException: x (main.py:5)',
+      );
+    });
+
+    test(
+      'with filename + lineNumber + columnNumber appends (path:line:col)',
+      () {
+        expect(
+          const MontyException(
+            message: 'x',
+            filename: 'main.py',
+            lineNumber: 5,
+            columnNumber: 12,
+          ).toString(),
+          'MontyException: x (main.py:5:12)',
+        );
+      },
+    );
+
+    test('column without filename does not produce a position suffix', () {
+      // Defensive: filename is the gate — no filename means no (path)
+      // suffix even if line/column are set.
+      expect(
+        const MontyException(
+          message: 'x',
+          lineNumber: 5,
+          columnNumber: 12,
+        ).toString(),
+        'MontyException: x',
+      );
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // MontyError subclasses (other than MontySyntaxError, already covered)
+  // ------------------------------------------------------------------
+
+  group('MontyPanicError', () {
+    test('is a MontyError + Exception', () {
+      const e = MontyPanicError('rust panicked');
+      expect(e, isA<MontyError>());
+      expect(e, isA<Exception>());
+    });
+
+    test('is NOT a MontyScriptError (different supervisor action)', () {
+      const e = MontyPanicError('rust panicked');
+      expect(e, isNot(isA<MontyScriptError>()));
+    });
+
+    test('toString contains type name and message', () {
+      const e = MontyPanicError('boom');
+      expect(e.toString(), 'MontyPanicError: boom');
+    });
+
+    test('message is preserved', () {
+      const e = MontyPanicError('detailed message here');
+      expect(e.message, 'detailed message here');
+    });
+  });
+
+  group('MontyCrashError', () {
+    test('default message when none supplied', () {
+      expect(
+        const MontyCrashError().message,
+        'Interpreter crashed unexpectedly',
+      );
+    });
+
+    test('custom message overrides default', () {
+      expect(
+        const MontyCrashError('worker exited 137').message,
+        'worker exited 137',
+      );
+    });
+
+    test('toString contains type name and message', () {
+      expect(
+        const MontyCrashError().toString(),
+        'MontyCrashError: Interpreter crashed unexpectedly',
+      );
+    });
+
+    test('is a MontyError + Exception', () {
+      const e = MontyCrashError();
+      expect(e, isA<MontyError>());
+      expect(e, isA<Exception>());
+    });
+  });
+
+  group('MontyDisposedError', () {
+    test('default message when none supplied', () {
+      expect(
+        const MontyDisposedError().message,
+        'Interpreter disposed during execution',
+      );
+    });
+
+    test('custom message overrides default', () {
+      expect(
+        const MontyDisposedError('disposed mid-feedRun').message,
+        'disposed mid-feedRun',
+      );
+    });
+
+    test('toString contains type name and message', () {
+      expect(
+        const MontyDisposedError().toString(),
+        'MontyDisposedError: Interpreter disposed during execution',
+      );
+    });
+
+    test('is a MontyError + Exception', () {
+      const e = MontyDisposedError();
+      expect(e, isA<MontyError>());
+      expect(e, isA<Exception>());
+    });
+  });
+
+  group('MontyResourceError', () {
+    test('toString contains type name and message', () {
+      const e = MontyResourceError('memory limit exceeded');
+      expect(e.toString(), 'MontyResourceError: memory limit exceeded');
+    });
+
+    test('message is preserved', () {
+      const e = MontyResourceError('oom');
+      expect(e.message, 'oom');
+    });
+
+    test('is a MontyError + Exception', () {
+      const e = MontyResourceError('x');
+      expect(e, isA<MontyError>());
+      expect(e, isA<Exception>());
+    });
+  });
+
+  group('MontyError sealed-hierarchy exhaustiveness', () {
+    test('switch over all subtypes compiles + dispatches correctly', () {
+      // Touching every concrete subtype keeps a cross-check that no new
+      // subclass slips into the hierarchy without a corresponding test
+      // file. If a new subclass is added, this switch stops being
+      // exhaustive and the analyser flags it.
+      const errors = <MontyError>[
+        MontyScriptError('s'),
+        MontySyntaxError('y'),
+        MontyPanicError('p'),
+        MontyCrashError('c'),
+        MontyDisposedError('d'),
+        MontyResourceError('r'),
+      ];
+      final names = errors.map((e) {
+        return switch (e) {
+          MontySyntaxError() => 'syntax',
+          MontyScriptError() => 'script',
+          MontyPanicError() => 'panic',
+          MontyCrashError() => 'crash',
+          MontyDisposedError() => 'disposed',
+          MontyResourceError() => 'resource',
+        };
+      }).toList();
+      expect(names, [
+        // MontySyntaxError is more specific than MontyScriptError, so
+        // the syntax-specific branch of the switch must come first.
+        'script',
+        'syntax',
+        'panic',
+        'crash',
+        'disposed',
+        'resource',
+      ]);
+    });
+  });
+}

--- a/test/unit/platform/monty_value_test.dart
+++ b/test/unit/platform/monty_value_test.dart
@@ -1,0 +1,811 @@
+// Unit tests for the 18 MontyValue subtypes — equality, hashCode,
+// JSON round-trip, and dartValue projection.
+//
+// Pure value-level tests: no interpreter, no FFI, no WASM. Catches
+// regressions in deep-equality, JSON shape drift, and the
+// MontyValue.fromJson __type dispatcher without needing the
+// integration harness to fire.
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+/// Shorthand: assert a value JSON-round-trips back to itself.
+void _expectRoundTrip(MontyValue v) {
+  expect(MontyValue.fromJson(v.toJson()), v);
+}
+
+void main() {
+  // ------------------------------------------------------------------
+  // Scalars
+  // ------------------------------------------------------------------
+
+  group('MontyNone', () {
+    test('all instances compare equal and share a hashCode', () {
+      const a = MontyNone();
+      const b = MontyNone();
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('toJson is null and round-trips', () {
+      const a = MontyNone();
+      expect(a.toJson(), isNull);
+      _expectRoundTrip(a);
+    });
+
+    test('dartValue is null', () {
+      expect(const MontyNone().dartValue, isNull);
+    });
+
+    test('toString contains type name', () {
+      expect(const MontyNone().toString(), 'MontyNone()');
+    });
+  });
+
+  group('MontyBool', () {
+    test('equality + hashCode agree on value', () {
+      const a = MontyBool(true);
+      const b = MontyBool(true);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(const MontyBool(false)));
+    });
+
+    test('not equal to other MontyValue subtypes', () {
+      expect(const MontyBool(true), isNot(const MontyInt(1)));
+    });
+
+    test('toJson + dartValue + round-trip', () {
+      expect(const MontyBool(true).toJson(), true);
+      expect(const MontyBool(false).dartValue, false);
+      _expectRoundTrip(const MontyBool(true));
+      _expectRoundTrip(const MontyBool(false));
+    });
+  });
+
+  group('MontyInt', () {
+    test('equality + hashCode', () {
+      const a = MontyInt(42);
+      const b = MontyInt(42);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(const MontyInt(43)));
+      expect(const MontyInt(0), isNot(const MontyBool(false)));
+    });
+
+    test('toJson + dartValue + round-trip', () {
+      expect(const MontyInt(42).toJson(), 42);
+      expect(const MontyInt(-7).dartValue, -7);
+      _expectRoundTrip(const MontyInt(0));
+      _expectRoundTrip(const MontyInt(-42));
+      _expectRoundTrip(const MontyInt(0x7FFFFFFFFFFFFFFF));
+    });
+  });
+
+  group('MontyFloat', () {
+    test('regular value equality + hashCode', () {
+      const a = MontyFloat(3.14);
+      const b = MontyFloat(3.14);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(const MontyFloat(2.71)));
+    });
+
+    test('NaN equals NaN (Python semantics, divergent from Dart double)', () {
+      const a = MontyFloat(double.nan);
+      const b = MontyFloat(double.nan);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('infinities and their negatives compare correctly', () {
+      expect(
+        const MontyFloat(double.infinity),
+        const MontyFloat(double.infinity),
+      );
+      expect(
+        const MontyFloat(double.negativeInfinity),
+        const MontyFloat(double.negativeInfinity),
+      );
+      expect(
+        const MontyFloat(double.infinity),
+        isNot(const MontyFloat(double.negativeInfinity)),
+      );
+    });
+
+    test('toJson encodes specials as strings', () {
+      expect(const MontyFloat(double.nan).toJson(), 'NaN');
+      expect(const MontyFloat(double.infinity).toJson(), 'Infinity');
+      expect(const MontyFloat(double.negativeInfinity).toJson(), '-Infinity');
+      expect(const MontyFloat(3.14).toJson(), 3.14);
+    });
+
+    test('round-trip preserves regular values and specials', () {
+      _expectRoundTrip(const MontyFloat(3.14));
+      _expectRoundTrip(const MontyFloat(0));
+      _expectRoundTrip(const MontyFloat(-1.5));
+      _expectRoundTrip(const MontyFloat(double.nan));
+      _expectRoundTrip(const MontyFloat(double.infinity));
+      _expectRoundTrip(const MontyFloat(double.negativeInfinity));
+    });
+  });
+
+  group('MontyString', () {
+    test('equality + hashCode', () {
+      const a = MontyString('hi');
+      const b = MontyString('hi');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(const MontyString('bye')));
+    });
+
+    test('toJson + dartValue + round-trip', () {
+      expect(const MontyString('hello').toJson(), 'hello');
+      expect(const MontyString('').dartValue, '');
+      _expectRoundTrip(const MontyString('hello'));
+      _expectRoundTrip(const MontyString(''));
+      _expectRoundTrip(const MontyString('unicode: π α 🎉'));
+    });
+
+    test(
+      'special-float strings are NOT mistaken for strings on round-trip',
+      () {
+        // NaN-as-string is parsed back as MontyFloat by fromJson — that's the
+        // intended escape encoding. A genuine MontyString('NaN') would
+        // round-trip differently. Document the limit:
+        final got = MontyValue.fromJson(const MontyString('NaN').toJson());
+        expect(got, isA<MontyFloat>());
+      },
+    );
+  });
+
+  // ------------------------------------------------------------------
+  // Collections
+  // ------------------------------------------------------------------
+
+  group('MontyBytes', () {
+    test('deep equality on byte list', () {
+      const a = MontyBytes([1, 2, 3]);
+      const b = MontyBytes([1, 2, 3]);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      expect(a, isNot(const MontyBytes([1, 2, 4])));
+    });
+
+    test('round-trip preserves bytes', () {
+      _expectRoundTrip(const MontyBytes([0, 127, 255]));
+      _expectRoundTrip(const MontyBytes([]));
+    });
+
+    test('dartValue exposes the byte list', () {
+      expect(const MontyBytes([1, 2, 3]).dartValue, [1, 2, 3]);
+    });
+  });
+
+  group('MontyList', () {
+    test('deep equality across nested values', () {
+      const a = MontyList([MontyInt(1), MontyString('x'), MontyBool(true)]);
+      const b = MontyList([MontyInt(1), MontyString('x'), MontyBool(true)]);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different element order is not equal', () {
+      expect(
+        const MontyList([MontyInt(1), MontyInt(2)]),
+        isNot(const MontyList([MontyInt(2), MontyInt(1)])),
+      );
+    });
+
+    test('toJson recursively serialises elements', () {
+      expect(
+        const MontyList([MontyInt(1), MontyString('x')]).toJson(),
+        [1, 'x'],
+      );
+    });
+
+    test('round-trip preserves nested heterogeneous values', () {
+      _expectRoundTrip(
+        const MontyList([
+          MontyInt(1),
+          MontyString('x'),
+          MontyList([MontyBool(true), MontyNone()]),
+        ]),
+      );
+    });
+
+    test('dartValue recursively projects', () {
+      expect(
+        const MontyList([MontyInt(1), MontyString('x')]).dartValue,
+        [1, 'x'],
+      );
+    });
+  });
+
+  group('MontyTuple', () {
+    test('equality + hashCode', () {
+      const a = MontyTuple([MontyInt(1), MontyString('x')]);
+      const b = MontyTuple([MontyInt(1), MontyString('x')]);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('not equal to a MontyList with the same elements', () {
+      const t = MontyTuple([MontyInt(1)]);
+      const l = MontyList([MontyInt(1)]);
+      expect(t, isNot(l));
+    });
+
+    test('toJson includes __type discriminator', () {
+      expect(
+        const MontyTuple([MontyInt(1)]).toJson(),
+        {
+          '__type': 'tuple',
+          'value': [1],
+        },
+      );
+    });
+
+    test('round-trip', () {
+      _expectRoundTrip(
+        const MontyTuple([MontyInt(1), MontyString('a'), MontyBool(false)]),
+      );
+    });
+  });
+
+  group('MontyDict', () {
+    test('equality + hashCode (deep)', () {
+      const a = MontyDict({'k': MontyInt(1)});
+      const b = MontyDict({'k': MontyInt(1)});
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different key order on the same map is still equal', () {
+      // Dart Map equality semantics — same key/value pairs.
+      const a = MontyDict({'a': MontyInt(1), 'b': MontyInt(2)});
+      const b = MontyDict({'b': MontyInt(2), 'a': MontyInt(1)});
+      expect(a, b);
+    });
+
+    test('toJson preserves the entry shape (no __type)', () {
+      expect(
+        const MontyDict({'k': MontyInt(1), 's': MontyString('x')}).toJson(),
+        {'k': 1, 's': 'x'},
+      );
+    });
+
+    test('round-trip via fromJson dispatcher (no __type → MontyDict)', () {
+      _expectRoundTrip(
+        const MontyDict({
+          'k': MontyInt(1),
+          'nested': MontyList([MontyInt(2), MontyInt(3)]),
+        }),
+      );
+    });
+
+    test('dartValue recursively projects', () {
+      expect(
+        const MontyDict({'a': MontyInt(1), 'b': MontyString('x')}).dartValue,
+        {'a': 1, 'b': 'x'},
+      );
+    });
+  });
+
+  group('MontySet', () {
+    test(
+      'equality + hashCode (treated as ordered list under deep equality)',
+      () {
+        const a = MontySet([MontyInt(1), MontyInt(2)]);
+        const b = MontySet([MontyInt(1), MontyInt(2)]);
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      },
+    );
+
+    test('toJson includes __type', () {
+      expect(
+        const MontySet([MontyInt(1)]).toJson(),
+        {
+          '__type': 'set',
+          'value': [1],
+        },
+      );
+    });
+
+    test('round-trip', () {
+      _expectRoundTrip(const MontySet([MontyInt(1), MontyInt(2), MontyInt(3)]));
+    });
+
+    test('not equal to a MontyFrozenSet with the same items', () {
+      const s = MontySet([MontyInt(1)]);
+      const fs = MontyFrozenSet([MontyInt(1)]);
+      expect(s, isNot(fs));
+    });
+  });
+
+  group('MontyFrozenSet', () {
+    test('equality + hashCode', () {
+      const a = MontyFrozenSet([MontyInt(1), MontyInt(2)]);
+      const b = MontyFrozenSet([MontyInt(1), MontyInt(2)]);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('round-trip', () {
+      _expectRoundTrip(
+        const MontyFrozenSet([MontyInt(1), MontyString('x')]),
+      );
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // DateTime types
+  // ------------------------------------------------------------------
+
+  group('MontyDate', () {
+    test('equality + hashCode + round-trip', () {
+      const a = MontyDate(year: 2026, month: 4, day: 28);
+      const b = MontyDate(year: 2026, month: 4, day: 28);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      _expectRoundTrip(a);
+    });
+
+    test('different field is not equal', () {
+      expect(
+        const MontyDate(year: 2026, month: 4, day: 28),
+        isNot(const MontyDate(year: 2026, month: 4, day: 27)),
+      );
+    });
+
+    test('dartValue is a Dart DateTime at midnight', () {
+      const d = MontyDate(year: 2026, month: 4, day: 28);
+      expect(d.dartValue, DateTime(2026, 4, 28));
+    });
+
+    test('toString pads month and day', () {
+      expect(
+        const MontyDate(year: 2026, month: 1, day: 5).toString(),
+        'MontyDate(2026-01-05)',
+      );
+    });
+  });
+
+  group('MontyDateTime', () {
+    test('equality + hashCode (naive)', () {
+      const a = MontyDateTime(
+        year: 2026,
+        month: 4,
+        day: 28,
+        hour: 15,
+        minute: 30,
+        second: 45,
+      );
+      const b = MontyDateTime(
+        year: 2026,
+        month: 4,
+        day: 28,
+        hour: 15,
+        minute: 30,
+        second: 45,
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('tz-aware: offsetSeconds + name participate in equality', () {
+      const naive = MontyDateTime(
+        year: 2026,
+        month: 4,
+        day: 28,
+        hour: 15,
+        minute: 30,
+        second: 45,
+      );
+      const aware = MontyDateTime(
+        year: 2026,
+        month: 4,
+        day: 28,
+        hour: 15,
+        minute: 30,
+        second: 45,
+        offsetSeconds: 0,
+        timezoneName: 'UTC',
+      );
+      expect(naive, isNot(aware));
+    });
+
+    test('round-trip preserves microsecond + tz fields', () {
+      _expectRoundTrip(
+        const MontyDateTime(
+          year: 2026,
+          month: 4,
+          day: 28,
+          hour: 15,
+          minute: 30,
+          second: 45,
+          microsecond: 123456,
+          offsetSeconds: -28800,
+          timezoneName: 'PST',
+        ),
+      );
+    });
+
+    test('round-trip omits null tz fields cleanly', () {
+      _expectRoundTrip(
+        const MontyDateTime(
+          year: 2026,
+          month: 4,
+          day: 28,
+          hour: 0,
+          minute: 0,
+          second: 0,
+        ),
+      );
+    });
+  });
+
+  group('MontyTimeDelta', () {
+    test('equality + hashCode', () {
+      const a = MontyTimeDelta(days: 1, seconds: 3600, microseconds: 500);
+      const b = MontyTimeDelta(days: 1, seconds: 3600, microseconds: 500);
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('round-trip', () {
+      _expectRoundTrip(const MontyTimeDelta(days: 5, seconds: 0));
+      _expectRoundTrip(
+        const MontyTimeDelta(days: -1, seconds: 86399, microseconds: 999999),
+      );
+    });
+
+    test('dartValue is a Duration', () {
+      expect(
+        const MontyTimeDelta(days: 1, seconds: 3600).dartValue,
+        const Duration(days: 1, seconds: 3600),
+      );
+    });
+  });
+
+  group('MontyTimeZone', () {
+    test('equality + hashCode + round-trip (named)', () {
+      const a = MontyTimeZone(offsetSeconds: -28800, name: 'PST');
+      const b = MontyTimeZone(offsetSeconds: -28800, name: 'PST');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      _expectRoundTrip(a);
+    });
+
+    test('round-trip preserves null name', () {
+      _expectRoundTrip(const MontyTimeZone(offsetSeconds: 0));
+    });
+
+    test('different offsets are not equal', () {
+      expect(
+        const MontyTimeZone(offsetSeconds: 0, name: 'UTC'),
+        isNot(const MontyTimeZone(offsetSeconds: 3600, name: 'UTC')),
+      );
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Structured types
+  // ------------------------------------------------------------------
+
+  group('MontyPath', () {
+    test('equality + hashCode + round-trip', () {
+      const a = MontyPath('/data/hello.txt');
+      const b = MontyPath('/data/hello.txt');
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      _expectRoundTrip(a);
+    });
+
+    test('dartValue is the path string', () {
+      expect(const MontyPath('/etc').dartValue, '/etc');
+    });
+
+    test('different paths are not equal', () {
+      expect(const MontyPath('/a'), isNot(const MontyPath('/b')));
+    });
+  });
+
+  group('MontyNamedTuple', () {
+    test('equality + hashCode (typeName + fields + values)', () {
+      const a = MontyNamedTuple(
+        typeName: 'sys.version_info',
+        fieldNames: ['major', 'minor', 'micro'],
+        values: [MontyInt(3), MontyInt(14), MontyInt(0)],
+      );
+      const b = MontyNamedTuple(
+        typeName: 'sys.version_info',
+        fieldNames: ['major', 'minor', 'micro'],
+        values: [MontyInt(3), MontyInt(14), MontyInt(0)],
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('different typeName is not equal (even with identical fields)', () {
+      const a = MontyNamedTuple(
+        typeName: 'Point',
+        fieldNames: ['x', 'y'],
+        values: [MontyInt(1), MontyInt(2)],
+      );
+      const b = MontyNamedTuple(
+        typeName: 'Vec',
+        fieldNames: ['x', 'y'],
+        values: [MontyInt(1), MontyInt(2)],
+      );
+      expect(a, isNot(b));
+    });
+
+    test('different field values are not equal', () {
+      const a = MontyNamedTuple(
+        typeName: 'Point',
+        fieldNames: ['x', 'y'],
+        values: [MontyInt(1), MontyInt(2)],
+      );
+      const b = MontyNamedTuple(
+        typeName: 'Point',
+        fieldNames: ['x', 'y'],
+        values: [MontyInt(1), MontyInt(3)],
+      );
+      expect(a, isNot(b));
+    });
+
+    test('round-trip preserves typeName, fieldNames, values', () {
+      _expectRoundTrip(
+        const MontyNamedTuple(
+          typeName: 'sys.version_info',
+          fieldNames: ['major', 'minor', 'micro', 'releaselevel', 'serial'],
+          values: [
+            MontyInt(3),
+            MontyInt(14),
+            MontyInt(0),
+            MontyString('final'),
+            MontyInt(0),
+          ],
+        ),
+      );
+    });
+
+    test('dartValue exposes the toJson map', () {
+      const nt = MontyNamedTuple(
+        typeName: 'Point',
+        fieldNames: ['x'],
+        values: [MontyInt(1)],
+      );
+      expect(nt.dartValue, nt.toJson());
+    });
+
+    test('_fromMap tolerates missing fields (defaults to empty)', () {
+      // Round-trip via fromJson with an under-populated payload.
+      final got = MontyValue.fromJson(<String, dynamic>{
+        '__type': 'namedtuple',
+      });
+      expect(got, isA<MontyNamedTuple>());
+      final nt = got as MontyNamedTuple;
+      expect(nt.typeName, '');
+      expect(nt.fieldNames, isEmpty);
+      expect(nt.values, isEmpty);
+    });
+  });
+
+  group('MontyDataclass', () {
+    test('equality + hashCode + round-trip (incl. frozen flag)', () {
+      const a = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: ['name', 'age'],
+        attrs: {'name': MontyString('alice'), 'age': MontyInt(30)},
+        frozen: true,
+      );
+      const b = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: ['name', 'age'],
+        attrs: {'name': MontyString('alice'), 'age': MontyInt(30)},
+        frozen: true,
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+      _expectRoundTrip(a);
+    });
+
+    test('different frozen flag is not equal', () {
+      const a = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: ['name'],
+        attrs: {'name': MontyString('alice')},
+      );
+      const b = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: ['name'],
+        attrs: {'name': MontyString('alice')},
+        frozen: true,
+      );
+      expect(a, isNot(b));
+    });
+
+    test('different typeId is not equal', () {
+      const a = MontyDataclass(
+        name: 'User',
+        typeId: 1,
+        fieldNames: [],
+        attrs: {},
+      );
+      const b = MontyDataclass(
+        name: 'User',
+        typeId: 2,
+        fieldNames: [],
+        attrs: {},
+      );
+      expect(a, isNot(b));
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // MontyValue.fromJson dispatcher + MontyValue.fromDart
+  // ------------------------------------------------------------------
+
+  group('MontyValue.fromJson', () {
+    test('null → MontyNone', () {
+      expect(MontyValue.fromJson(null), const MontyNone());
+    });
+
+    test('bool / int / double → matching scalar', () {
+      expect(MontyValue.fromJson(true), const MontyBool(true));
+      expect(MontyValue.fromJson(42), const MontyInt(42));
+      expect(MontyValue.fromJson(3.14), const MontyFloat(3.14));
+    });
+
+    test('string with no special-float marker → MontyString', () {
+      expect(MontyValue.fromJson('hi'), const MontyString('hi'));
+    });
+
+    test('special-float marker strings → MontyFloat', () {
+      expect(MontyValue.fromJson('NaN'), isA<MontyFloat>());
+      expect(
+        MontyValue.fromJson('Infinity'),
+        const MontyFloat(double.infinity),
+      );
+      expect(
+        MontyValue.fromJson('-Infinity'),
+        const MontyFloat(double.negativeInfinity),
+      );
+    });
+
+    test('plain List → MontyList', () {
+      final got = MontyValue.fromJson(<dynamic>[1, 'x']);
+      expect(got, const MontyList([MontyInt(1), MontyString('x')]));
+    });
+
+    test('Map without __type → MontyDict', () {
+      final got = MontyValue.fromJson(<String, dynamic>{'k': 1});
+      expect(got, const MontyDict({'k': MontyInt(1)}));
+    });
+
+    test('Map with unknown __type falls back to MontyDict', () {
+      // Defensive path: a future Rust-side type unknown to this Dart
+      // version should still surface as a structurally-valid dict
+      // rather than throwing. The whole map (including __type) is
+      // wrapped — that's the documented contract of _parseMap.
+      final got = MontyValue.fromJson(<String, dynamic>{
+        '__type': 'unknown_future_type',
+        'value': 1,
+      });
+      expect(got, isA<MontyDict>());
+    });
+
+    test('throws for unsupported runtime types', () {
+      expect(
+        () => MontyValue.fromJson(Object()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  group('MontyValue.fromDart', () {
+    test('passes MontyValue instances through', () {
+      const v = MontyInt(42);
+      expect(MontyValue.fromDart(v), same(v));
+    });
+
+    test('null / bool / int / double / String → matching scalar', () {
+      expect(MontyValue.fromDart(null), const MontyNone());
+      expect(MontyValue.fromDart(true), const MontyBool(true));
+      expect(MontyValue.fromDart(42), const MontyInt(42));
+      expect(MontyValue.fromDart(3.14), const MontyFloat(3.14));
+      expect(MontyValue.fromDart('hi'), const MontyString('hi'));
+    });
+
+    test('Dart DateTime → MontyDateTime in UTC', () {
+      final dt = DateTime.utc(2026, 4, 28, 15, 30, 45, 0, 123);
+      final got = MontyValue.fromDart(dt);
+      expect(got, isA<MontyDateTime>());
+      final mdt = got as MontyDateTime;
+      expect(mdt.year, 2026);
+      expect(mdt.month, 4);
+      expect(mdt.day, 28);
+      expect(mdt.hour, 15);
+      expect(mdt.minute, 30);
+      expect(mdt.second, 45);
+      expect(mdt.microsecond, 123);
+    });
+
+    test('Dart List → MontyList with recursive conversion', () {
+      final got = MontyValue.fromDart([1, 'x', true]);
+      expect(
+        got,
+        const MontyList([MontyInt(1), MontyString('x'), MontyBool(true)]),
+      );
+    });
+
+    test('Dart Map → MontyDict with stringified keys + recursive values', () {
+      final got = MontyValue.fromDart({'k': 1, 'n': null});
+      expect(got, const MontyDict({'k': MontyInt(1), 'n': MontyNone()}));
+    });
+
+    test('Map with non-String keys coerces via toString()', () {
+      final got = MontyValue.fromDart({1: 'one', 2: 'two'});
+      expect(
+        got,
+        const MontyDict({'1': MontyString('one'), '2': MontyString('two')}),
+      );
+    });
+
+    test('throws for unsupported runtime types', () {
+      expect(
+        () => MontyValue.fromDart(Object()),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+  });
+
+  // ------------------------------------------------------------------
+  // Cross-type checks
+  // ------------------------------------------------------------------
+
+  group('cross-type', () {
+    test('MontyValue subtypes never compare equal across distinct types', () {
+      // Smoke check on a representative sample. The sealed hierarchy
+      // means any pair of distinct concrete subtypes must not be ==.
+      const samples = <MontyValue>[
+        MontyNone(),
+        MontyBool(true),
+        MontyInt(0),
+        MontyFloat(0),
+        MontyString(''),
+        MontyBytes([]),
+        MontyList([]),
+        MontyTuple([]),
+        MontyDict({}),
+        MontySet([]),
+        MontyFrozenSet([]),
+        MontyDate(year: 1, month: 1, day: 1),
+        MontyTimeDelta(days: 0, seconds: 0),
+        MontyTimeZone(offsetSeconds: 0),
+        MontyPath(''),
+      ];
+      for (var i = 0; i < samples.length; i++) {
+        for (var j = 0; j < samples.length; j++) {
+          if (i == j) continue;
+          expect(
+            samples[i] == samples[j],
+            isFalse,
+            reason:
+                '${samples[i].runtimeType} should not equal '
+                '${samples[j].runtimeType}',
+          );
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the unit-test gaps on the platform value/error surface. Before this PR, unit coverage was uneven: most surface area was exercised only indirectly through the integration corpus, so a regression in deep equality, JSON shape, or the type-hierarchy contracts surfaced only on a full FFI/WASM run.

Two files, **128 tests total**, ~50ms full run, no interpreter.

## Commit 1 — `test/unit/platform/monty_value_test.dart` (82 tests)

All 18 \`MontyValue\` subtypes get equality / hashCode / toJson / JSON round-trip / dartValue coverage.

- **Scalars** (\`MontyNone\`, \`MontyBool\`, \`MontyInt\`, \`MontyFloat\`, \`MontyString\`)
  - \`MontyFloat\` covers NaN==NaN (Python semantics, divergent from Dart double), ±Infinity, JSON marker-string round-trip
  - \`MontyString\` documents the special-float marker collision (\`MontyString('NaN')\` round-trips as \`MontyFloat\`)
- **Collections** (\`MontyBytes\`, \`MontyList\`, \`MontyTuple\`, \`MontyDict\`, \`MontySet\`, \`MontyFrozenSet\`)
  - Deep equality via \`DeepCollectionEquality\` pinned
  - Tuple/Set/FrozenSet are explicitly *not* equal to a List with the same items — catches type-tag regressions
- **DateTime types** (\`MontyDate\`, \`MontyDateTime\`, \`MontyTimeDelta\`, \`MontyTimeZone\`)
  - \`MontyDateTime\` naive vs tz-aware (offset + zone name), microsecond round-trip
- **Structured types** (\`MontyPath\`, \`MontyNamedTuple\`, \`MontyDataclass\`)
  - \`MontyNamedTuple\` pins typeName participation in equality and defensive \`_fromMap\` behaviour
- **Dispatchers** — \`MontyValue.fromJson\` (primitives, special floats, lists, dict-without-\`__type\`, dict-with-known-\`__type\`, dict-with-unknown-\`__type\` fallback to MontyDict, throw on unsupported); \`MontyValue.fromDart\` (passthrough, scalars, DateTime → UTC MontyDateTime, recursive list/map, non-String key coercion, throw on unsupported)
- **Cross-type smoke** — pairwise check across 15 distinct concrete subtypes confirms no two ever compare equal

## Commit 2 — `test/unit/platform/monty_error_result_test.dart` (46 tests)

Covers what wasn't already in \`monty_result_getters_test.dart\` / \`monty_syntax_error_test.dart\` / \`monty_typing_error_test.dart\`:

- **\`MontyResult\`** — equality + hashCode across all field combinations, JSON round-trip including optional \`error\` / \`printOutput\`, \`toJson\` correctly omits null fields, value- vs error-variant \`toString\` rendering
- **\`MontyException\`** — equality across the full surface (msg / filename / line / column / sourceCode / excType / traceback); traceback uses deep equality, verified with runtime-constructed List instances so canonicalisation can't leak through identity; \`toJson\` round-trip on minimal and fully-populated forms; \`toString\` assembles \"ExcType: message (file:line:col)\" precisely, including the corner case where filename is missing — line/col are then suppressed too (defensive, pinned)
- **\`MontyError\` subclasses not previously covered** (\`MontyPanicError\`, \`MontyCrashError\`, \`MontyDisposedError\`, \`MontyResourceError\`) — is-a chain (\`MontyError\` + \`Exception\`, *not* \`MontyScriptError\` since they map to a different supervisor action), default vs custom message handling, \`toString\` format
- **Sealed-hierarchy exhaustiveness check** — switch over all 6 concrete subtypes. If a new subclass is added without a corresponding test file, the switch stops being exhaustive and the analyser flags it.

## Test plan

- [x] \`dart test test/unit/platform/monty_value_test.dart\` — 82/82 pass
- [x] \`dart test test/unit/platform/monty_error_result_test.dart\` — 46/46 pass
- [x] \`dart analyze --fatal-infos\` — clean across both files
- [x] \`dart format --line-length=80 --set-exit-if-changed\` — clean across both files
- [x] \`dcm analyze\` — clean across both files

## Cost

- 2 files, 1312 lines.
- Runs as part of the existing \`test\` (Dart JIT) job — no new CI step.