### PR TITLE
docs: rewrite AGENTS.md for post-0.17.0 reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,547 +1,213 @@
 # AGENTS.md — dart_monty_core build & test guide
 
-This file is the authoritative reference for building every artifact in this
-repo, running every test suite, and operating every demo — locally and in CI.
-Read it before touching any build step.
+Maintainer reference for building, testing, and releasing this package.
 
----
+## Toolchain prerequisites
 
-## Artifact flow — the mental model
+| Need | macOS | Linux | Windows |
+|---|---|---|---|
+| Rust | rustup.rs | rustup.rs | rustup.rs |
+| C linker | `xcode-select --install` | `apt install build-essential` | VS Build Tools w/ C++ |
+| Dart SDK ≥ 3.10 | `brew install dart` | dart.dev/get-dart | dart.dev/get-dart |
+| Web tests | Node 20+ + Chrome | Node 20+ + Chrome | Node 20+ + Chrome |
 
-```
-native/src/ (Rust)
-  ├─ cargo build --release
-  │     → libdart_monty_core_native.{dylib,so,dll}   [FFI backend: VM/desktop]
-  │
-  ├─ cargo build --bin oracle
-  │     → native/target/debug/oracle             [FFI test oracle]
-  │
-  └─ cargo build --target wasm32-wasip1 --release
-        → dart_monty_core_native.wasm   (copied to lib/assets/)
-              │
-              ▼
-js/src/ (esbuild via node build.js)
-  └─────────────────────────────── lib/assets/      ← canonical staging area
-                                   ├── dart_monty_core_native.wasm
-                                   ├── dart_monty_core_bridge.js
-                                   └── dart_monty_core_worker.js
-                                         │
-              ┌──────────────────────────────┐
-              ▼                              ▼
-  test/integration/web/           packages/dart_monty_web/web/
-  ├── dart_monty_core_bridge.js    ├── dart_monty_core_bridge.js
-  ├── dart_monty_core_worker.js    ├── dart_monty_core_worker.js
-  ├── dart_monty_core_native.wasm  ├── dart_monty_core_native.wasm
-  ├── @pydantic/wasi-*             ├── @pydantic/wasi-*
-  ├── wasm_runner.dart.js     └── repl_demo.dart.js
-  └── wasm_runner.wasm            (dart compile js)
-      (dart compile wasm)
-```
-
-**Rule**: `lib/assets/` is the only directory that receives build
-output directly. Everything else copies from `lib/assets/`. The three
-built files in `lib/assets/` **are committed to git** (Mode A asset
-distribution). The files must live under `lib/` because Flutter's
-`packages/<name>/...` URI scheme resolves against a package's `lib/`
-root — assets at the repo root are invisible to cross-package
-consumers. CI exercises the WASM/JS bridge through the `test-wasm`
-integration suite on every PR; byte-level drift-check
-(rebuild-and-compare) is deferred until reproducible cross-host WASM
-builds are solved. Regenerate locally when source changes:
+Cross-compilation targets:
 
 ```bash
-bash tool/prebuild.sh
+rustup target add wasm32-wasip1
+rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios   # iOS
+rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi  # Android (also needs NDK + cargo-ndk)
 ```
 
-Flutter consumers depend on `dart_monty` (the high-level API).
-`dart_monty_core` comes in transitively, and Flutter bundles a
-dependency's declared `flutter.assets` automatically — no
-consumer-side redeclaration is required. Assets land in the build
-at `assets/packages/dart_monty_core/lib/assets/*` (Flutter preserves the
-`lib/` segment for transitively-bundled package assets). The
-high-level `DartMonty.ensureInitialized()` API in `dart_monty`
-resolves that URL at runtime, so consumers do not need a `<script>`
-tag in `web/index.html`.
+`dart_monty_core` does **not** ship pre-built FFI dylibs — they're built
+from source on every consumer's machine via `hook/build.dart`. WASM
+consumers get pre-built artefacts from `lib/assets/` (Mode A). Flutter
+consumers should depend on
+[`dart_monty`](https://github.com/runyaga/dart_monty), which bundles
+per-arch binaries.
 
----
+## Architecture
+
+```
+native/src/  (Rust crate: lib, convert, error, handle, repl_handle)
+  ├─ cargo build --release           → libdart_monty_core_native.{dylib,so,dll}   [FFI]
+  ├─ cargo build --bin oracle        → native/target/debug/oracle              [oracle]
+  └─ cargo build --target wasm32     → dart_monty_core_native.wasm             [WASM]
+                                              │
+js/src/  (esbuild via node build.js)          ▼
+  ├─ bridge.js (main thread)       ┐
+  └─ worker_src.js + wasm_glue     ┴── lib/assets/  (committed; ships on pub.dev)
+```
+
+`lib/assets/` is the only directory that receives build output. Everything
+else copies from it. The three files there are committed to git so web
+consumers don't need a Rust toolchain.
 
 ## Repository layout
 
 ```
-dart_monty_core/
-├── native/                     # Rust crate (monty engine + C ABI)
-│   ├── src/lib.rs              # FFI C exports + wasm target
-│   ├── src/bin/oracle.rs       # Oracle CLI binary (FFI test source of truth)
-│   ├── include/dart_monty.h    # C header (source for ffigen)
-│   └── target/                 # Cargo output (git-ignored)
-│
-├── js/                         # JS bridge (esbuild)
-│   ├── src/bridge.js           # Main-thread IIFE → dart_monty_core_bridge.js
-│   ├── src/worker_src.js       # Worker ESM → dart_monty_core_worker.js
-│   ├── src/wasm_glue.js        # WASM C API wrappers (imported by worker)
-│   ├── build.js                # esbuild bundler script
-│   └── package.json
-│
-├── lib/                        # Dart library source
-│   ├── assets/                      # Built JS+WASM artefacts (committed)
-│   │   ├── dart_monty_core_bridge.js    ← node js/build.js
-│   │   ├── dart_monty_core_worker.js    ← node js/build.js
-│   │   └── dart_monty_core_native.wasm  ← cargo build wasm32-wasip1
-│   └── src/
-│       ├── ffi/                # FFI backend (dart:ffi)
-│       │   └── generated/dart_monty_bindings.dart  ← ffigen output
-│       ├── wasm/               # WASM backend (JS interop)
-│       └── platform/           # Shared platform abstractions
-│
-├── test/integration/
-│   ├── wasm_runner.dart        # dart2js fixture runner (464 tests)
-│   ├── wasm_runner_wasm.dart   # dart2wasm fixture runner (464 tests)
-│   ├── oracle_ffi_test.dart    # FFI conformance (spawns oracle binary)
-│   ├── _fixture_corpus.dart    # 464 Python fixtures (embedded const map)
-│   └── web/                    # Served by test HTTP server
-│       ├── fixtures.html       # dart2js entry point
-│       └── wasm_runner_wasm.html  # dart2wasm entry point
-│
-├── packages/
-│   └── dart_monty_web/         # Browser REPL demo (pure Dart web)
-│
-├── docs/
-│   └── index.html              # GitHub Pages cover page
-│
-└── tool/
-    ├── prebuild.sh             # Rebuild committed assets (cargo + node)
-    ├── test_wasm.sh            # Full WASM test pipeline
-    ├── serve_demo.sh           # Web demo build + serve
-    ├── generate_bindings.sh    # ffigen regeneration
-    ├── install-hooks.sh        # Install pre-commit hook
-    └── pre-commit.sh           # Pre-commit checks (fmt, analyze, bindings)
+native/                       Rust shim (5 source files; cargo crate)
+js/                           JS bridge source (esbuild)
+lib/                          Dart library; lib/assets/ is the committed JS+WASM bundle
+hook/                         native-assets build hook (cargo on consumer pub get)
+test/unit/                    pure-Dart unit tests (functional)
+test/integration/             FFI + WASM integration + oracle conformance
+  ├── ffi_*_test.dart         FFI feature tests
+  ├── wasm_*_test.dart        WASM feature tests (mirror of ffi_*)
+  ├── oracle_ffi_*_test.dart  oracle conformance (464 fixtures)
+  ├── wasm_runner*.dart       WASM corpus runners (dart2js + dart2wasm)
+  └── repros/                 xfail repros + _xfail.dart helper
+test/fixtures/                test data (corpus symlink + side-loadable .py repros)
+packages/dart_monty_web/      browser REPL demo (pure Dart web)
+tool/                         maintainer scripts (prebuild, test_wasm, …)
+.github/workflows/            ci.yaml, publish.yaml, deploy-pages.yml
 ```
 
----
-
-## One-time setup
+## Build
 
 ```bash
-# Install pre-commit hooks
-bash tool/install-hooks.sh
-
-# Add Rust targets
-rustup target add wasm32-wasip1          # WASM builds
-rustup component add rustfmt clippy      # code quality
+bash tool/prebuild.sh                 # rebuilds everything under lib/assets/
 ```
 
----
-
-## Build step 1 — Rust FFI dylib (for VM/desktop tests and Flutter)
+Or do steps manually:
 
 ```bash
 cd native
-cargo build --release
-```
+cargo build --release                                  # FFI dylib
+cargo build --bin oracle                               # oracle binary
+cargo build --target wasm32-wasip1 --release           # WASM binary
+cd ../js && npm install --force && node build.js       # JS bridge → lib/assets/
 
-**Output** (platform-specific):
-- macOS: `native/target/release/libdart_monty_core_native.dylib`
-- Linux: `native/target/release/libdart_monty_core_native.so`
-- Windows: `native/target/release/dart_monty_core_native.dll`
-
-**Used by**: `MontyFfi` backend (dart:ffi), Flutter REPL demo, FFI conformance tests.
-
----
-
-## Build step 1b — Rust oracle binary (for FFI conformance tests)
-
-```bash
-cd native
-cargo build --bin oracle
-```
-
-**Output**: `native/target/debug/oracle`
-
-**Used by**: `oracle_ffi_test.dart` — spawns oracle as a subprocess. Each of
-the 464 fixtures is run through both the oracle and the FFI binding; outputs
-must match exactly.
-
-**How the oracle works**:
-```
-dart test oracle_ffi_test.dart
-  │
-  ├── for each fixture:
-  │     oracle process ← fixture source code (stdin)
-  │     oracle stdout  → expected result (value or exception type)
-  │     FFI binding    ← same fixture source code
-  │     FFI result     → actual result
-  │     assert oracle == FFI
-  │
-  └── 464 fixtures, all must pass
-```
-
-The oracle binary, FFI dylib, and WASM binary are **all compiled from the same
-`native/src/lib.rs`** — they must stay in sync. If you change Rust source,
-rebuild all three.
-
----
-
-## Build step 2 — Rust WASM binary
-
-```bash
-cd native
-cargo build --target wasm32-wasip1 --release
-```
-
-**Output**: `native/target/wasm32-wasip1/release/dart_monty_core_native.wasm`
-
-The WASM binary is the monty interpreter compiled to run inside a browser
-WASM Worker. It is loaded by `dart_monty_core_worker.js` at runtime.
-
----
-
-## Build step 3 — JS bridge (esbuild)
-
-```bash
-cd js
-
-# --force required on x64 Linux: @pydantic/monty-wasm32-wasi declares
-# cpu:wasm32; npm refuses to install on non-wasm32 hosts without --force.
-# The package is a WASM binary that runs in a WASI runtime regardless of
-# host CPU — the platform check is a false positive.
-npm install --force
-
-node build.js
-```
-
-**Output** (written directly to `assets/`):
-- `lib/assets/dart_monty_core_bridge.js` — IIFE, loaded on the main thread
-- `lib/assets/dart_monty_core_worker.js` — ESM Worker, loads + runs the WASM binary
-- `lib/assets/dart_monty_core_native.wasm` — copied from `native/target/wasm32-wasip1/release/dart_monty_core_native.wasm`
-
-`build.js` copies the WASM binary automatically, so build step 2 is only
-needed if you run steps out of order.
-
----
-
-## Build step 3b — WASI runtime (required for dart2wasm tests and web demo)
-
-The dart2wasm runner and the web demo both require the WASI browser runtime
-from `@pydantic/monty-wasm32-wasi`. `node build.js` does **not** copy this
-file — it must be copied manually.
-
-```bash
-# For WASM fixture tests:
-mkdir -p test/integration/web/@pydantic/monty-wasm32-wasi
+# WASM tests + web demo also need the WASI runtime (esbuild doesn't copy it):
 cp js/node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs \
    test/integration/web/@pydantic/monty-wasm32-wasi/
-
-# For web demo:
-mkdir -p packages/dart_monty_web/web/@pydantic/monty-wasm32-wasi
-cp js/node_modules/@pydantic/monty-wasm32-wasi/wasi-worker-browser.mjs \
-   packages/dart_monty_web/web/@pydantic/monty-wasm32-wasi/
 ```
 
-**Symptom if missing**: headless Chrome loads `wasm_runner_wasm.html` and
-reports `TypeError: Cannot read properties of undefined (reading 'init')` for
-every fixture. The `wasi-worker-browser.mjs` file is the WASI polyfill that
-the worker needs to initialise the WASM module.
+If you change `native/include/dart_monty.h`, regenerate bindings:
+`bash tool/generate_bindings.sh`.
 
----
+## Tests — three categories
 
-## Build step 4 — dart2js test runner
+**Functional (`test/unit/`)** — pure Dart, no interpreter, ~50ms.
+Covers `MontyValue` (18 subtypes), `MontyResult`, `MontyException`,
+the `MontyError` hierarchy, mount handler, REPL metadata.
 
 ```bash
-dart pub get
-dart compile js \
-  test/integration/wasm_runner.dart \
-  -o test/integration/web/wasm_runner.dart.js \
-  --no-source-maps
+dart test --exclude-tags=ffi,wasm,integration,ladder,example
 ```
 
-**Output**: `test/integration/web/wasm_runner.dart.js`
-
----
-
-## Build step 5 — dart2wasm test runner
-
-```bash
-dart compile wasm \
-  test/integration/wasm_runner_wasm.dart \
-  -o test/integration/web/wasm_runner.wasm
-```
-
-**Output** (dart compile wasm always produces both):
-- `test/integration/web/wasm_runner.wasm`
-- `test/integration/web/wasm_runner.mjs`
-
----
-
-## Copy assets to test web dir
-
-Before running tests manually, copy from `assets/` into `test/integration/web/`.
-`tool/test_wasm.sh` does this automatically; its cleanup trap removes them on exit.
+**Integration (`test/integration/{ffi,wasm}_*_test.dart`)** —
+exercises the real interpreter through one of the two backends. Each
+feature usually has `ffi_<feature>_test.dart` and
+`wasm_<feature>_test.dart` sharing a `_<feature>_test_body.dart`.
 
 ```bash
-cp lib/assets/dart_monty_core_bridge.js   test/integration/web/
-cp lib/assets/dart_monty_core_worker.js   test/integration/web/
-cp lib/assets/dart_monty_core_native.wasm test/integration/web/
-# Also copy WASI runtime (step 3b above)
-```
+# FFI
+cd native && cargo build --release && cd ..
+dart test test/integration/ffi_*_test.dart -p vm --run-skipped --tags=ffi
 
----
-
-## Running the FFI conformance tests (464 fixtures)
-
-```bash
-# Build prerequisites (steps 1 + 1b)
-cd native && cargo build --release && cargo build --bin oracle && cd ..
-dart pub get
-dart test test/integration/oracle_ffi_test.dart \
-  -p vm --run-skipped --tags=ffi --reporter=expanded
-```
-
-**Expected**: 464 fixtures pass.
-
----
-
-## Running the WASM conformance tests (464 fixtures)
-
-### dart2js — full build pipeline
-
-```bash
+# WASM (full pipeline; --skip-build to reuse assets)
 bash tool/test_wasm.sh
-# Runs: cargo build → npm install --force → node build.js → dart compile js
-#       → copy assets → COOP/COEP server → headless Chrome
 ```
 
-### dart2js — skip build (assets already built)
+**Oracle conformance (`test/integration/oracle_ffi_*_test.dart`)** —
+464 Python fixtures × Rust oracle binary vs Dart FFI. Outputs must
+match exactly. The same corpus is replayed through WASM via
+`wasm_runner.dart` (dart2js) and `wasm_runner_wasm.dart` (dart2wasm),
+both driven by `tool/test_wasm.sh`.
 
 ```bash
-bash tool/test_wasm.sh --skip-build
-# Skips cargo + npm; still re-compiles wasm_runner.dart and copies assets
+cd native && cargo build --bin oracle && cd ..
+dart test test/integration/oracle_ffi_test.dart \
+          test/integration/oracle_ffi_ext_test.dart \
+  -p vm --run-skipped --tags=ffi
 ```
 
-### dart2wasm — manual run
+**Repros (`test/integration/repros/`)** — side-loadable `.py` + xfail
+Dart test pair for each upstream-blocked bug. `xfail()` inverts the
+assertion: today the inner expectation fails (bug reproduces), test
+passes. When upstream fixes it, `xfail()` raises and CI flags the
+test for promotion. Removing the wrapper is the only change needed.
+
+## Static checks
 
 ```bash
-# 1. Ensure assets are built (steps 1–3b above)
-# 2. Build dart2wasm runner (step 5)
-# 3. Copy assets to test web dir
-# 4. Ensure COOP/COEP server is running on :8097 (test_wasm.sh starts one)
-CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-LOG=$(mktemp)
-timeout 120 "$CHROME" --headless=new --disable-gpu --no-sandbox \
-  --disable-dev-shm-usage --enable-logging=stderr --v=0 \
-  "http://127.0.0.1:8097/wasm_runner_wasm.html" 2>"$LOG" || true
-python3 -c "
-import re, sys
-log = open('$LOG').read()
-for f in re.findall(r'FIXTURE_RESULT:\{[^}]+\"ok\":false[^}]*\}', log)[:10]: print(f)
-for d in re.findall(r'FIXTURE_DONE:\{[^}]+\}', log): print(d)
-"
-rm "$LOG"
-```
-
-**Expected**: `FIXTURE_DONE:{"total":464,"passed":464,"failed":0,"skipped":0,...}`
-
----
-
-## Running Rust checks
-
-All four checks run inside `native/`:
-
-```bash
-cd native
-
-# Format
-cargo fmt --check
-
-# Lints (all clippy pedantic + extras; -D warnings = fail on any warning)
-cargo clippy -- -D warnings
-
-# Dependency audit (licenses, advisories, bans)
-cargo deny check
-
-# Tests with line-coverage gate (≥60% required; src/bin/ excluded from measurement)
-cargo llvm-cov --summary-only --ignore-filename-regex 'src/bin/'
-```
-
-`cargo llvm-cov` requires the `llvm-tools-preview` component and `cargo-llvm-cov`:
-
-```bash
-rustup component add llvm-tools-preview
-cargo install cargo-llvm-cov
-```
-
-There are currently no `#[test]` functions in `native/src/` — coverage comes
-entirely from the oracle binary exercising the library. If line coverage drops
-below 60% CI will fail.
-
----
-
-## Running Dart static checks
-
-```bash
-dart pub get
-
-# Static analysis (fatal on infos)
 dart analyze --fatal-infos
-
-# Format check
 dart format --line-length=80 --set-exit-if-changed lib/ test/ hook/ tool/
+
+cd native
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo deny check
+cargo llvm-cov --summary-only --ignore-filename-regex 'src/bin/'   # ≥60% gate
 ```
 
----
+DCM (code metrics + custom rules) runs in CI only — requires licence keys.
 
-## Running Dart unit tests (JIT + AOT)
-
-There are **no unit tests yet** — only integration tests. Both commands below
-exit 79 (no tests found), which is tolerated by CI until unit tests are added.
+## Demos
 
 ```bash
-# JIT
-dart test --exclude-tags=ffi,wasm,integration,ladder --coverage=coverage
-
-# AOT (kernel)
-dart test --exclude-tags=ffi,wasm,integration,ladder --platform vm --compiler=kernel
+bash tool/serve_demo.sh              # dart2js, opens :8098
+bash tool/serve_demo.sh --dart2wasm
+bash tool/serve_demo.sh --skip-build
 ```
 
----
+GitHub Pages auto-deploys from `main` via `deploy-pages.yml`.
+URL: https://runyaga.github.io/dart_monty_core/
 
-## Running DCM (code metrics + rules)
+There is no in-tree Flutter demo — the previous `dart_monty_flutter`
+sidecar was removed under the Mode A asset refactor. Flutter examples
+belong in `dart_monty`.
 
-DCM requires a licence key; it runs in CI only. For local use install DCM and
-substitute your own credentials:
+## CI
+
+- `ci.yaml` — analyze, format, FFI feature + oracle, WASM (dart2js +
+  dart2wasm), Rust fmt/clippy/deny/coverage, DCM, patch-coverage 70%
+  gate. Runs on PRs and `main`.
+- `publish.yaml` — fires on tag push matching
+  `v[0-9]+.[0-9]+.[0-9]+*`; analyze → dry-run → `pub publish --force`
+  via OIDC.
+- `deploy-pages.yml` — `main` → GitHub Pages.
+
+Artifact hand-offs: `ffigen` → `dart_monty_bindings.dart`; `build-wasm`
+→ `dart_monty_core_native.wasm`; `test` → `lcov.info`.
+
+## Releasing
+
+Versioning: `0.X.0 ↔ monty v0.0.X`. When upstream ships `monty v0.0.18`,
+bump `native/Cargo.toml`'s git tag, verify conformance, then ship
+`dart_monty_core 0.18.0`. Patch releases (`0.X.Y`, Y>0) are reserved
+for our own fixes between upstream bumps. Pre-1.0: consumers pin exact
+(`dart_monty_core: 0.17.0`, not `^0.17.0`).
+
+**First publish of a new package must be manual** — pub.dev rejects
+OIDC for packages that don't yet exist:
 
 ```bash
-dart pub get
-dcm calculate-metrics --ci-key=<KEY> --email=<EMAIL> lib/
-dcm analyze          --ci-key=<KEY> --email=<EMAIL> lib/
+git pull origin main
+dart pub publish --dry-run
+dart pub publish               # browser OAuth, then 'y' to confirm
 ```
 
----
-
-## Running demos
-
-### Web REPL (browser)
+After the first publish, tag pushes auto-publish via `publish.yaml`:
 
 ```bash
-bash tool/serve_demo.sh              # dart2js (default), opens :8098
-bash tool/serve_demo.sh --dart2wasm  # dart2wasm variant
-bash tool/serve_demo.sh --skip-build # reuse existing assets
+# Bump pubspec.yaml version + CHANGELOG, commit, push, then:
+git tag v0.18.0 && git push origin v0.18.0
 ```
-
-**What it does**: cargo build → npm install --force → node build.js →
-copy assets + WASI runtime → dart compile js → Python COOP/COEP server → open browser.
-
-### Flutter REPL (mobile/desktop)
-
-```bash
-# Prerequisite: build FFI dylib (build step 1)
-bash tool/run_flutter_demo.sh [--device macos]
-```
-
-### GitHub Pages demo
-
-Deployed automatically on every push to `main` via `.github/workflows/deploy-pages.yml`.
-
-URL: **https://runyaga.github.io/dart_monty_core/**
-
-- `/` — cover page with links to both demos
-- `/repl/` — Web REPL (dart2js, no COOP/COEP headers on Pages)
-- `/flutter/` — Flutter web REPL
-
----
-
-## CI pipeline
-
-```
-changes (path filter)
-  │
-  ├─► rust ──────────────────────────────────────► build-wasm ──► test-wasm
-  │   (fmt + clippy + deny + llvm-cov ≥60%)       (wasm32-wasip1)  (dart2js + dart2wasm
-  │                                                                  464 fixtures each)
-  ├─► ffigen ─► test     (analyze + fmt + unit JIT + coverage + patch-coverage gate 70%)
-  │          ├─ test-aot (unit AOT/kernel — exit 79 tolerated until unit tests exist)
-  │          ├─ test-ffi (464 FFI fixtures)
-  │          └─ dcm      (calculate-metrics + analyze rules)
-  │
-  └─► deploy-pages (on main push)
-      (cargo + npm + dart compile → GitHub Pages)
-```
-
-**Artifact hand-offs**:
-- `ffigen` uploads `dart_monty_bindings.dart` → consumed by `test`, `test-ffi`, `dcm`
-- `build-wasm` uploads `dart_monty_core_native.wasm` → consumed by `test-wasm`
-- `test` uploads `lcov.info` → consumed by `patch-coverage`
-
-**Key CI flags**:
-- `npm install --force` — required in `test-wasm` and `deploy-pages` (EBADPLATFORM)
-- `--no-source-maps` on `dart compile js` — reduces output size in CI
-- `timeout-minutes: 15` on `ffigen` — `libclang-dev` install is slow on Ubuntu
-
----
-
-## File provenance table
-
-| File | Built by | Destination(s) |
-|---|---|---|
-| `libdart_monty_core_native.{dylib,so,dll}` | `cargo build --release` | (loaded by dart:ffi at runtime) |
-| `native/target/debug/oracle` | `cargo build --bin oracle` | (spawned as subprocess by dart test) |
-| `dart_monty_core_native.wasm` | `cargo build --target wasm32-wasip1` | `assets/` → `test/integration/web/`, `packages/dart_monty_web/web/` |
-| `dart_monty_core_bridge.js` | `node js/build.js` | `assets/` → same as above |
-| `dart_monty_core_worker.js` | `node js/build.js` | `assets/` → same as above |
-| `wasi-worker-browser.mjs` | npm (pre-built) | `test/integration/web/@pydantic/...`, `packages/dart_monty_web/web/@pydantic/...` |
-| `wasm_runner.dart.js` | `dart compile js` | `test/integration/web/` |
-| `wasm_runner.wasm` + `.mjs` | `dart compile wasm` | `test/integration/web/` |
-| `repl_demo.dart.js` | `dart compile js` | `packages/dart_monty_web/web/` |
-| `dart_monty_bindings.dart` | `dart run ffigen` | `lib/src/ffi/generated/` |
-| `_fixture_corpus.dart` | `dart tool/generate_fixture_corpus.dart` | `test/integration/` |
-
----
-
-## What NOT to commit
-
-```
-# lib/assets/dart_monty_core_*.{js,wasm} ARE committed (Mode A).
-# Everything below is a downstream copy — always git-ignored.
-test/integration/web/dart_monty_core_*.js   # git-ignored; copied before test run
-test/integration/web/dart_monty_core_*.wasm # git-ignored; copied before test run
-test/integration/web/wasm_runner.dart.js*  # git-ignored; dart compile js output
-test/integration/web/@pydantic/        # git-ignored; WASI runtime copy
-packages/dart_monty_web/web/repl_demo.dart.js   # git-ignored (see web/.gitignore)
-packages/dart_monty_web/web/*.wasm     # git-ignored
-packages/dart_monty_web/web/dart_monty_core_*.js     # git-ignored
-packages/dart_monty_web/web/@pydantic/ # git-ignored
-```
-
-**Exception**: `test/integration/web/wasm_runner.mjs`, `wasm_runner.wasm`,
-`wasm_runner.support.js`, `wasm_runner.wasm.map` are committed so the
-`wasm_runner_wasm.html` page works in CI without a full dart2wasm build step.
-
----
-
-## Stale artifact rebuild matrix
-
-If you modify any source file, rebuild the corresponding artifact before testing.
-
-| Source changed | Rebuild required |
-|---|---|
-| `native/src/**` | Steps 1 + 1b + 2 + 3, then copy assets |
-| `js/src/**` | Step 3 (npm/node), then copy assets |
-| `test/integration/wasm_runner.dart` | Step 4 (dart compile js) |
-| `test/integration/wasm_runner_wasm.dart` | Step 5 (dart compile wasm) |
-| `packages/dart_monty_web/web/repl_demo.dart` | `dart compile js` in dart_monty_web |
-| `lib/**` (library source) | Steps 4 + 5 (re-compile dart runners) |
-| `native/include/dart_monty.h` | Run `bash tool/generate_bindings.sh` |
-
----
 
 ## Common failure modes
 
-| Symptom | Cause | Fix |
-|---|---|---|
-| `EBADPLATFORM` on `npm install` | `@pydantic/monty-wasm32-wasi` declares `cpu:wasm32` | `npm install --force` |
-| Chrome `TypeError: Cannot read ... 'init'` | `wasi-worker-browser.mjs` not copied | Run step 3b (WASI runtime copy) |
-| dart2wasm 0/464 all fail | Bridge assets missing from `test/integration/web/` | Copy from `assets/` |
-| FFI `DynamicLibraryLoadError` | Native dylib not built | `cd native && cargo build --release` |
-| FFI tests: `ProcessException` on oracle | Oracle binary not built | `cd native && cargo build --bin oracle` |
-| Bindings stale check fails in CI | C header changed, ffigen not re-run | `bash tool/generate_bindings.sh` |
-| `assets/` stale after editing `native/` or `js/` | Forgot to regenerate | `bash tool/prebuild.sh && git add assets/` |
-| GitHub Pages REPL broken (SharedArrayBuffer) | Pages can't set COOP/COEP headers | Expected — dart2js works; dart2wasm needs local serve |
+| Symptom | Fix |
+|---|---|
+| `EBADPLATFORM` on `npm install` | `npm install --force` |
+| `no default linker (cc)` on `pub get` | Install C linker (see prereqs) |
+| Chrome `TypeError: … 'init'` | Copy `wasi-worker-browser.mjs` (see Build) |
+| FFI `DynamicLibraryLoadError` | `cd native && cargo build --release` |
+| FFI `ProcessException` on oracle | `cd native && cargo build --bin oracle` |
+| `Unknown experiment: native-assets` | Update Dart SDK to ≥ 3.10 |
+| `Only users are allowed to upload new packages` | First pub.dev publish must be interactive |
+| `lib/assets/` stale after editing `native/` or `js/` | `bash tool/prebuild.sh && git add lib/assets/` |
+| Bindings stale check fails in CI | `bash tool/generate_bindings.sh` |
+
+`AGENTS.md` is excluded from pub.dev publish via `.pubignore`.


### PR DESCRIPTION
Tidies AGENTS.md before the v0.17.0 publish. 547 → 213 lines.

## Why

AGENTS.md was drifting — claimed \"no unit tests yet\" (we shipped 128 in #79), still referenced the deleted Flutter demo, didn't mention the C-linker prerequisite that the Docker cold-start surfaced, had no Releasing section, and didn't document the test categories cleanly.

## What changed

Restructured to make four things obvious, per the maintainer brief:

1. **Toolchain prerequisites** — its own up-front section. Per-OS C-linker install commands (xcode-select / build-essential / MSVC). Cross-compilation targets for iOS/Android/WASM. Explicit note that this package does not ship pre-built dylibs.
2. **Flutter** — stale references removed. \`dart_monty_flutter\` was deleted under Mode A; Pages site only hosts the Web REPL now. Pointer to \`dart_monty\` for the Flutter integration.
3. **Tests as three named categories**:
   - **Functional** (\`test/unit/\`) — pure Dart, no interpreter
   - **Integration** (\`test/integration/{ffi,wasm}_*_test.dart\`) — real interpreter through each backend
   - **Oracle conformance** (\`test/integration/oracle_ffi_*_test.dart\`) — 464 fixtures × Rust oracle binary as source of truth
   - Plus repros (\`test/integration/repros/\`) for upstream-blocked bugs via the new \`xfail()\` helper
4. **Releasing** — new section. Versioning convention (\`0.X.0 ↔ monty v0.0.X\`), pubspec description guidance, the manual first-publish-must-be-user step on pub.dev, OIDC \`publish.yaml\` for subsequent versions.

Other fixes:
- Native crate is 5 source files (lib + convert + error + handle + repl_handle), not just lib.rs.
- Repository layout includes \`test/unit/\`, \`test/fixtures/repros/\`, \`test/integration/repros/\`, \`hook/build.dart\`.
- Stale \`assets/\` paths corrected to \`lib/assets/\`.
- Common failure modes adds: missing C linker, \"native-assets\" experiment-flag rejection, pub.dev first-publish error.

\`AGENTS.md\` is in \`.pubignore\` — does not ship to consumers.