### PR TITLE
docs: align dart_monty pointer — no binary distribution yet

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,20 +11,22 @@ Maintainer reference for building, testing, and releasing this package.
 | Dart SDK ≥ 3.10 | `brew install dart` | dart.dev/get-dart | dart.dev/get-dart |
 | Web tests | Node 20+ + Chrome | Node 20+ + Chrome | Node 20+ + Chrome |
 
-Cross-compilation targets:
+Maintainers also need the WASM target for rebuilding `lib/assets/`:
 
 ```bash
 rustup target add wasm32-wasip1
-rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios   # iOS
-rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi  # Android (also needs NDK + cargo-ndk)
 ```
 
 `dart_monty_core` does **not** ship pre-built FFI dylibs — they're built
-from source on every consumer's machine via `hook/build.dart`. WASM
-consumers get pre-built artefacts from `lib/assets/` (Mode A). Flutter
-consumers should depend on
-[`dart_monty`](https://github.com/runyaga/dart_monty), which bundles
-per-arch binaries.
+from source on every consumer's machine via `hook/build.dart`. The hook
+supports desktop triples only (macOS / Linux / Windows × arm64 + x64);
+iOS and Android fall through with no asset emitted. WASM consumers get
+pre-built artefacts from `lib/assets/` (Mode A). When using
+`dart_monty_core` directly, mobile (iOS / Android) compilation is the
+consumer's responsibility — they compile the native crate and wire it
+into their Flutter plugin themselves.
+[`dart_monty`](https://github.com/runyaga/dart_monty) is the higher-level
+Flutter wrapper for consumers who want the integration layer instead.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -186,33 +186,34 @@ maxRecursionDepth:)`.
 ## Installation
 
 > **This package builds the native FFI binary from source on `dart pub get`.**
-> If you don't want a Rust toolchain on consumer machines, depend on
-> [`dart_monty`](https://github.com/runyaga/dart_monty) instead — it
-> bundles per-platform binaries and is the right call for almost every
-> Flutter consumer.
+> Every FFI consumer needs a Rust toolchain, including Flutter consumers
+> coming in via [`dart_monty`](https://github.com/runyaga/dart_monty).
 
 ```yaml
 dependencies:
   dart_monty_core: 0.17.0   # exact pin until 1.0
 ```
 
-### Prerequisites for FFI (native targets — desktop, server, CLI, mobile)
+### Prerequisites for FFI (desktop only)
 
-The `hook/build.dart` native-assets hook runs `cargo build --release` on
-the consumer's machine during `pub get`. Required toolchain:
+`hook/build.dart` runs `cargo build --release --target <host-triple>`
+on the consumer's machine during `pub get`. Required toolchain:
 
 - **Rust** — install via [rustup](https://rustup.rs)
-- **System toolchain for the link step**:
+- **C linker** for the cdylib link step:
   - **macOS**: `xcode-select --install` (provides `clang`)
   - **Linux**: `sudo apt install build-essential` / `dnf install gcc` / equivalent
   - **Windows**: [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) with the C++ workload
-  - **iOS**: Xcode + `rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios`
-  - **Android**: [Android NDK](https://developer.android.com/ndk/downloads) + [`cargo-ndk`](https://crates.io/crates/cargo-ndk) + `rustup target add aarch64-linux-android x86_64-linux-android armv7-linux-androideabi`
 
-For Flutter mobile apps, using
-[`dart_monty`](https://github.com/runyaga/dart_monty) (which ships
-pre-built per-ABI binaries) is almost always the right call instead of
-setting up Rust + NDK on every developer's machine.
+Supported FFI host triples in v0.17.0: `aarch64-apple-darwin`,
+`x86_64-apple-darwin`, `aarch64-unknown-linux-gnu`,
+`x86_64-unknown-linux-gnu`, `aarch64-pc-windows-msvc`,
+`x86_64-pc-windows-msvc`. **Mobile (iOS, Android) is not handled by this
+package's hook** — the hook returns no native asset for those targets.
+If you're using `dart_monty_core` directly and need Monty on mobile,
+compiling and wiring the native crate into your Flutter project's iOS /
+Android plugin is your responsibility. For a higher-level Flutter
+integration, use [`dart_monty`](https://github.com/runyaga/dart_monty).
 
 First `pub get` takes 1–3 minutes (compiling the native crate); subsequent
 runs reuse cargo's cache.
@@ -236,7 +237,7 @@ cp $(dart pub cache dir)/hosted/pub.dev/dart_monty_core-*/lib/assets/dart_monty_
 
 ### Other ecosystems
 
-- **Flutter** — [`dart_monty`](https://github.com/runyaga/dart_monty) bundles per-arch binaries; no Rust required.
+- **Flutter** — [`dart_monty`](https://github.com/runyaga/dart_monty) wraps this package with the Flutter integration layer (asset loading, plugin scaffolding). When using `dart_monty_core` directly, mobile (iOS / Android) compilation is your responsibility; `dart_monty` is the alternative.
 - **JS / TS** — use [`@pydantic/monty`](https://www.npmjs.com/package/@pydantic/monty); the canonical npm package.
 
 ## Known upstream limitations


### PR DESCRIPTION
Follow-up to #84 (README) and #85 (AGENTS.md). Both now overstated dart_monty's role — earlier copy said it bundles binaries / removes the Rust requirement. That's aspirational, not present-tense; v0.17.0 ships build-from-source, period.

## What changed

Four sites, all factual corrections (no new content):

**README.md**
- \`## Installation\` callout: was \"depend on dart_monty instead — it bundles per-platform binaries.\" Now: \"every FFI consumer needs a Rust toolchain, including Flutter consumers coming in via dart_monty. Pre-built binary distribution is on the roadmap but not in v0.17.0.\"
- FFI prereqs mobile note: was \"using dart_monty (which ships pre-built per-ABI binaries) is almost always the right call.\" Now: explicit that Flutter mobile devs also need Rust + NDK today; dart_monty is the wrapper for the Flutter API surface, not for binary distribution.
- Other ecosystems → Flutter: was \"dart_monty bundles per-arch binaries; no Rust required.\" Now: \"wraps this package with the Flutter integration layer (asset loading, plugin scaffolding). Binary distribution is on its roadmap but not yet shipped — Rust toolchain still required today.\"

**AGENTS.md**
- Toolchain prerequisites paragraph: matches the README's framing.

## Why this matters before publish

v0.17.0 is the first time anyone outside this repo will see the install instructions. Saying dart_monty solves the binary problem when it doesn't would set people up for a confusing experience the moment they try it. Honest framing: build-from-source on every platform except web; binary distribution is future work.

## Test plan

- [x] \`dart analyze --fatal-infos lib/\` — clean (no code changes)