### PR TITLE
fix(pubspec): drop "restricted" from description

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_monty_core
-description: Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's restricted interpreter.
+description: Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's interpreter.
 version: 0.17.0
 homepage: https://github.com/runyaga/dart_monty_core
 repository: https://github.com/runyaga/dart_monty_core


### PR DESCRIPTION
The description on main reads:

> Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's restricted interpreter.

The intended text, confirmed twice during the v0.17.0 prep, is:

> Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's interpreter.

PR #84 was force-pushed with this amend after the initial review pass, but the squash-merge captured an earlier version of the commit. Fixing before the first pub.dev publish so the registry shows what was actually agreed.

One-line diff. 95 → 87 chars; both well inside pub.dev's 60–180 sweet spot.