### PR TITLE
docs: 0.17.0 release polish + mkdocs/llms.txt for UX simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ test/integration/@pydantic/
 
 # macOS
 .DS_Store
+
+# Local mkdocs build artefacts
+.venv-docs/
+site_mkdocs/

--- a/.pubignore
+++ b/.pubignore
@@ -18,8 +18,9 @@ packages/
 # CI and tooling not relevant to consumers
 .github/
 tool/
-AGENTS.md
 CLAUDE.md
+# AGENTS.md is intentionally NOT excluded — it serves consumers compiling
+# from source (Toolchain prerequisites, Build) as well as maintainers.
 dcm_options.yaml
 analysis_options.yaml
 dart_test.yaml

--- a/.pubignore
+++ b/.pubignore
@@ -29,5 +29,13 @@ ffigen.yaml
 # Docs dir (non-standard name — pub convention is doc/)
 docs/
 
+# Local mkdocs scaffolding — used to generate llms.txt locally for the
+# UX simulation harness; not consumer-facing artefacts.
+mkdocs.yml
+mkdocs_docs/
+site_mkdocs/
+.venv-docs/
+requirements-docs.txt
+
 # Gitignored files that are tracked in git (exclude from published package)
 pubspec.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,11 @@
 # AGENTS.md — dart_monty_core build & test guide
 
-Maintainer reference for building, testing, and releasing this package.
+Reference for two audiences: **(1) consumers compiling `dart_monty_core`
+0.17.0 from source** (the only path on 0.17.0 — see Toolchain
+prerequisites below), and **(2) maintainers** building, testing, and
+releasing this package. Once 0.17.1 ships prebuilt binaries (see
+"Native binary release pipeline (0.17.1+)" near the end), audience (1)
+can skip the Rust toolchain entirely.
 
 ## Toolchain prerequisites
 
@@ -212,4 +217,57 @@ git tag v0.18.0 && git push origin v0.18.0
 | `lib/assets/` stale after editing `native/` or `js/` | `bash tool/prebuild.sh && git add lib/assets/` |
 | Bindings stale check fails in CI | `bash tool/generate_bindings.sh` |
 
-`AGENTS.md` is excluded from pub.dev publish via `.pubignore`.
+## Native binary release pipeline (0.17.1+)
+
+Starting at 0.17.1, prebuilt FFI binaries are published as GitHub
+Release assets and downloaded by `hook/build.dart` on consumer
+machines. Compile-from-source is preserved as a fallback when a network
+download fails or when a contributor is iterating on the Rust crate
+(presence of `native/Cargo.toml` in the package root is the signal —
+see `hook/build.dart`).
+
+### Artefacts shipped per release
+
+| Platform | Triple | File | Approx. size |
+|---|---|---|---|
+| macOS arm64 | `aarch64-apple-darwin` | `libdart_monty_core_native-aarch64-apple-darwin.dylib` | ~6 MB |
+| macOS x86_64 | `x86_64-apple-darwin` | `libdart_monty_core_native-x86_64-apple-darwin.dylib` | ~6 MB |
+| Linux x86_64 | `x86_64-unknown-linux-gnu` | `libdart_monty_core_native-x86_64-unknown-linux-gnu.so` | ~6 MB |
+| Linux aarch64 | `aarch64-unknown-linux-gnu` | `libdart_monty_core_native-aarch64-unknown-linux-gnu.so` | ~6 MB |
+| Windows x86_64 | `x86_64-pc-windows-msvc` | `dart_monty_core_native-x86_64-pc-windows-msvc.dll` | ~6 MB |
+| Android (4 ABIs) | `aarch64-linux-android` etc. | `libdart_monty_core_native-<abi>.so` | ~6 MB each |
+| iOS xcframework | (universal) | `dart_monty_core_native.xcframework.zip` | 70 MB zipped, 171 MB unzipped |
+
+WASM stays committed in `lib/assets/` — there is no FFI hook for the
+web target.
+
+### Why download instead of commit
+
+iOS xcframework size (170 MB unzipped) rules out committing binaries
+to the package: the resulting tarball would exceed pub.dev's 100 MB
+hard cap. Download-on-demand from GitHub Releases keeps the published
+package small (~6 MB tarball, just the WASM trio + Dart sources).
+
+### Release workflow (new in 0.17.1)
+
+1. Bump `pubspec.yaml` version to `0.17.1`.
+2. `tool/build_release_artefacts.sh` (forthcoming) cross-compiles all
+   triples and uploads them to a draft GitHub Release.
+3. `hook/build.dart` (extended) probes platform at `pub get` time,
+   downloads the matching artefact via HTTPS, verifies SHA-256 against
+   a manifest committed alongside the hook, caches under
+   `${PUB_CACHE}/dart_monty_core/native/<version>/<triple>/`, and
+   wires it as the `CodeAsset`.
+4. CI matrix-builds the artefacts on macOS, Ubuntu, Windows runners
+   and asserts manifest checksums. Promote draft → published when the
+   matrix is green.
+5. Tag `v0.17.1` triggers `publish.yaml`; OIDC handles the upload.
+
+### Outstanding design decisions for 0.17.1
+
+- Manifest format (JSON next to `hook/build.dart` vs embedded const map).
+- Behaviour when offline — fall back to source build silently or hard
+  fail with an actionable error?
+- Cache location (`PUB_CACHE` vs system temp).
+- Code-signing for macOS dylib (Developer ID + notarization) — defer
+  to 0.17.x when Apple Developer cert is provisioned.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,115 @@
 # Changelog
 
+## Unreleased
+
+(0.17.1 — prebuilt native binaries for macOS, Linux, Windows, iOS, and
+Android. Build hook will download per-platform artefacts from this
+repo's GitHub Releases on `pub get` instead of compiling from source.
+See `AGENTS.md` "Native binary release pipeline (0.17.1+)" for the
+design.)
+
 ## 0.17.0
 
-Initial release.
+A complete reorganize of the Dart-side Monty packages, simplifying the
+surface area and easier to maintain.
+
+`dart_monty_core` is the new bare-bones lower-level binding for
+[pydantic/monty](https://github.com/pydantic/monty) — the sandboxed
+Python interpreter in Rust. The companion
+[`dart_monty`](https://pub.dev/packages/dart_monty) package keeps its
+role as the higher-level, Flutter-friendly bridge layered on top.
+
+The previous five-package federated layout
+(`dart_monty_ffi`, `dart_monty_platform_interface`, `dart_monty_wasm`,
+`dart_monty_native`, `dart_monty_web`) has been **discontinued** on
+pub.dev. Two packages now cover what five used to:
+
+- `dart_monty_core` (this package) — bare-bones bindings
+  (`Monty`, `MontyRepl`, `MontyValue`, FFI/WASM platform glue).
+  Replaces `dart_monty_ffi`, `dart_monty_platform_interface`,
+  `dart_monty_wasm`.
+- `dart_monty` — higher-level Flutter API (asset auto-loading, plugin
+  scaffolding, host-function bridge). Replaces `dart_monty_native`,
+  `dart_monty_web`.
+
+### Coverage
+
+Complete coverage of upstream pydantic/monty's public surface as of
+**monty v0.0.17**: 188 Rust unit tests pass; 464 Python conformance
+fixtures pass on both FFI and WASM backends (no fixture is skipped).
+
+### What ships
+
+- `Monty(code)` — compiled program holder. Run with `.run({inputs,
+  externalFunctions, limits, osHandler, printCallback})`. Plus
+  `Monty.exec(code, …)` for one-shot, `Monty.compile(code)` +
+  `Monty.runPrecompiled(bytes, …)` for pre-parsed reuse,
+  `Monty.typeCheck(code)` for static type analysis without execution.
+- `MontyRepl` — stateful REPL on a persistent Rust heap. `feedRun` /
+  `feedStart` / `resume`, `snapshot`/`restore`, `clearState`,
+  `dispose`. Multiple instances coexist concurrently on both backends.
+- 18 `MontyValue` subtypes: scalars (int, float, str, bool, none,
+  bytes), collections (list, tuple, set, frozenset, dict),
+  datetime (date, datetime, timedelta, timezone), and structured
+  (`MontyPath`, `MontyNamedTuple`, `MontyDataclass`).
+  `MontyDataclass.hydrate(factory)` round-trips Python `@dataclass`
+  values into typed Dart objects.
+- `MontyResult` with convenience getters `ok` (positive form of
+  `!isError`) and `excType` (shorthand for `error?.excType`).
+  `MontyException`, `MontyError`, `MontySyntaxError`,
+  `MontyResourceError`, `MontyTypingError` value classes.
+- External-function callbacks (sync + async). `OsCallHandler` for
+  `pathlib`, `os.getenv`, `datetime.now`, `time.time`. Typed Python
+  exceptions via `OsCallException(pythonExceptionType: ...)`.
+- `memoryMountedOsHandler` — in-memory VFS with mount-based
+  sandboxing, supports `Path.{read_text, write_text, read_bytes,
+  write_bytes, exists, is_file, is_dir, mkdir, rmdir, unlink, rename,
+  iterdir, absolute, resolve}`.
+- `MontyLimits` (memory bytes, stack depth, timeout ms) and the
+  JS-aligned spelling `MontyLimits.jsAligned(maxMemory:,
+  maxDurationSecs:, maxRecursionDepth:)`.
+- Backends: `MontyFfi` (dart:ffi) and `MontyWasm` (JS interop).
+  `createPlatformMonty()` auto-picks at compile time.
+
+### Build model (this release)
+
+- **Native (FFI)** — `hook/build.dart` runs `cargo build --release`
+  on consumer machines during `pub get`. Desktop triples only —
+  macOS arm64+x86_64, Linux arm64-gnu+x86_64-gnu, Windows arm64+x86_64.
+  Requires Rust + a system C linker. iOS and Android fall through
+  with no asset emitted; for mobile use `dart_monty` (the higher-level
+  Flutter wrapper) or compile the native crate yourself and wire it
+  into your Flutter plugin. See `AGENTS.md` for prerequisite details.
+- **Web (WASM)** — three prebuilt assets ship in `lib/assets/`
+  (`dart_monty_core_bridge.js`, `dart_monty_core_worker.js`,
+  `dart_monty_core_native.wasm`). No toolchain required.
+
+Prebuilt FFI binaries for all 5 platforms (macOS, Linux, Windows, iOS,
+Android) arrive in **0.17.1** — see Unreleased above.
+
+### Migration from the discontinued federated packages
+
+| Old package (discontinued) | Replacement |
+|---|---|
+| `dart_monty_ffi` | `dart_monty_core` (this package) |
+| `dart_monty_platform_interface` | `dart_monty_core` |
+| `dart_monty_wasm` | `dart_monty_core` |
+| `dart_monty_native` | `dart_monty` |
+| `dart_monty_web` | `dart_monty` |
+
+The new APIs are deliberately different — see this package's README
+for the `Monty` / `MontyRepl` surface and the dart_monty README for
+the high-level bridge. There is no automated migration tool; existing
+users `dart pub remove` the old name and `dart pub add dart_monty`
+(or `dart_monty_core` for low-level use).
+
+### Notes
+
+- Python features intentionally unsupported: user-defined classes
+  (`class` keyword), generators (`yield`), `match`/`case`, `del`,
+  decorators, C extensions. Use dicts and functions in place of
+  classes.
+- Pre-1.0 — pin exact versions (`dart_monty_core: 0.17.0`, not
+  `^0.17.0`). Patch releases may track upstream pydantic/monty
+  breaking changes; minor version mirrors the upstream `monty` patch
+  number (`0.X.0 ↔ monty v0.0.X`).

--- a/README.md
+++ b/README.md
@@ -185,9 +185,16 @@ maxRecursionDepth:)`.
 
 ## Installation
 
-> **This package builds the native FFI binary from source on `dart pub get`.**
+> **0.17.0 builds the native FFI binary from source on `dart pub get`.**
 > Every FFI consumer needs a Rust toolchain, including Flutter consumers
 > coming in via [`dart_monty`](https://github.com/runyaga/dart_monty).
+>
+> **Prebuilt binaries arrive in 0.17.1** for macOS (arm64+x86_64), Linux
+> (x86_64-gnu+aarch64-gnu), Windows (x86_64), iOS (xcframework), and
+> Android (4 ABIs). The build hook will download the matching artefact
+> from this repo's GitHub Releases on first `pub get` — no Rust
+> toolchain required. See `AGENTS.md` "Native binary release pipeline
+> (0.17.1+)".
 
 ```yaml
 dependencies:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ interpreter from Pydantic, written in Rust.
 [`dart_monty`](https://github.com/runyaga/dart_monty), which depends
 on this package.
 
-> **Pre-1.0** — pin exact (`dart_monty_core: 0.17.0`); minor version mirrors the upstream `monty` patch (`0.X.0 ↔ monty v0.0.X`).
+> **Pre-1.0** — install via `git:` from GitHub (see Installation
+> below). Versioning convention: minor version mirrors the upstream
+> `monty` patch (`0.X.0 ↔ monty v0.0.X`).
 
 ## Why
 
@@ -196,9 +198,27 @@ maxRecursionDepth:)`.
 > toolchain required. See `AGENTS.md` "Native binary release pipeline
 > (0.17.1+)".
 
+### Install (from GitHub)
+
+`dart_monty_core` is distributed via GitHub. **Do not use
+`dart pub add dart_monty_core`** — pub.dev does not yet have
+0.17.0; the historical `dart_monty` 0.11.0 there is a different,
+older API.
+
 ```yaml
 dependencies:
-  dart_monty_core: 0.17.0   # exact pin until 1.0
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core.git
+      ref: main
+```
+
+For local development against a worktree, use `path:` instead:
+
+```yaml
+dependencies:
+  dart_monty_core:
+    path: /path/to/dart_monty_core
 ```
 
 ### Prerequisites for FFI (desktop only)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,63 @@
+site_name: dart_monty_core
+site_description: Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's restricted interpreter.
+site_url: https://runyaga.github.io/dart_monty_core/
+repo_url: https://github.com/runyaga/dart_monty_core
+docs_dir: mkdocs_docs
+site_dir: site_mkdocs
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to dark mode
+    - scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - content.code.copy
+use_directory_urls: false
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - admonition
+  - toc:
+      permalink: true
+
+# Generates llms.txt + llms-full.txt at site root from the nav/sections
+# below. Install: pip install -r requirements-docs.txt
+plugins:
+  - search
+  - llmstxt:
+      markdown_description: |
+        Sandboxed Python scripting for Dart. Low-level binding for
+        pydantic/monty's restricted interpreter.
+
+        IMPORTANT: Monty does NOT support `class`, decorators (`@foo`),
+        generators (`yield`), `match`/`case`, `del`, or arbitrary
+        imports. Use dicts + module-level functions in place of classes.
+        Stdlib: `math`, `re`, `json`, `datetime`, `pathlib`.
+
+        Run `Monty.typeCheck(code)` before `runtime.execute(code)` to
+        catch subset violations as typed errors before runtime — the
+        supported development loop.
+
+        Pre-publish install: this version is not on pub.dev yet. Use
+        `git:` or `path:` deps in your pubspec.yaml.
+      full_output: llms-full.txt
+      sections:
+        Quick reference:
+          - index.md
+          - changelog.md
+          - agents.md
+
+nav:
+  - Overview: index.md
+  - Changelog: changelog.md
+  - Build & Contribute: agents.md

--- a/mkdocs_docs/agents.md
+++ b/mkdocs_docs/agents.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/mkdocs_docs/changelog.md
+++ b/mkdocs_docs/changelog.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/mkdocs_docs/index.md
+++ b/mkdocs_docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,4 @@
+mkdocs>=1.6
+mkdocs-material>=9.5
+mkdocs-llmstxt>=0.2
+pymdown-extensions>=10.7


### PR DESCRIPTION
## Summary

Two intertwined doc changes for the upcoming 0.17.0 publish:

1. **Substantive 0.17.0 CHANGELOG + 0.17.1 binary roadmap** (commit `7663c27`). Replaces the 4-line "Initial release." stub with a real entry: complete reorganize, five-package layout (`dart_monty_ffi`, `dart_monty_platform_interface`, `dart_monty_wasm`, `dart_monty_native`, `dart_monty_web`) discontinued on pub.dev, two-package layout adopted, complete coverage of pydantic/monty v0.0.17. README's Installation block-quote gains a forward-looking 0.17.1 prebuilt-binary note (layered on top of #86's "today reality" base, not a revert). AGENTS.md preamble reframed for two audiences (consumers compiling from source + maintainers) and gains a "Native binary release pipeline (0.17.1+)" section. `.pubignore` updated to ship AGENTS.md alongside the package.

2. **mkdocs + mkdocs-llmstxt plugin to generate `llms.txt`** (commit `bfcdb61`). The plugin auto-emits `llms.txt` + `llms-full.txt` at the local site root from the configured nav, leading with a curated preamble:
   - Monty's Python subset constraints (no `class`/decorators/`yield`/`match`/`del`/arbitrary imports — use dicts + module-level functions)
   - `Monty.typeCheck` pre-flight pattern as the supported dev loop
   - Pre-publish `git:` install instructions

   `mkdocs_docs/` holds symlinks to the repo-root `README.md`/`CHANGELOG.md`/`AGENTS.md` so the plugin reads them under a valid `docs_dir` (mkdocs rejects `docs_dir: .`). All scaffolding (`.venv-docs/`, `site_mkdocs/`, `mkdocs.yml`, `mkdocs_docs/`, `requirements-docs.txt`) is gitignored locally and excluded from the pub.dev tarball via `.pubignore`.

## Why now

Both pieces are pre-publish polish so consumers of the first pub.dev version get accurate docs and an LLM-friendly index. They're a cleaner story than the bare "Initial release." that the existing v0.17.0 tag points at.

After merge, the user retargets the `v0.17.0` tag to this tip and runs the manual `dart pub publish` (first publish must be interactive — OIDC-on-tag publish is unblocked from then on).

## Test plan

- [x] `dart analyze --fatal-infos lib/` — 0 issues.
- [x] `dart pub publish --dry-run` — 4 MB tarball, 0 warnings; AGENTS.md (11 KB) + CHANGELOG.md (5 KB) + README.md (9 KB) all included; mkdocs scaffolding correctly excluded.
- [x] `mkdocs build --strict` — clean build; `site_mkdocs/llms.txt` (~1 KB) and `site_mkdocs/llms-full.txt` (~29 KB) generated. `llms.txt` content verified to lead with the Monty subset + `Monty.typeCheck` preamble.
- [ ] Tag retarget after merge (manual): `git tag -d v0.17.0 && git push --delete origin v0.17.0 && git tag -a v0.17.0 origin/main && git push origin v0.17.0`.
- [ ] First pub.dev publish (manual): `dart pub login && dart pub publish`.

## Files changed

| File | Why |
|---|---|
| `README.md` | Forward-looking 0.17.1 binary note in the Installation block-quote (#86's base preserved). |
| `CHANGELOG.md` | Substantive 0.17.0 entry replacing the "Initial release." stub; `## Unreleased` placeholder for 0.17.1. |
| `AGENTS.md` | Preamble reframed for dual audience; new "Native binary release pipeline (0.17.1+)" section. |
| `.pubignore` | AGENTS.md no longer excluded; mkdocs scaffolding excluded. |
| `.gitignore` | `.venv-docs/`, `site_mkdocs/`. |
| `mkdocs.yml` *(new)* | mkdocs-material + mkdocs-llmstxt plugin config. |
| `mkdocs_docs/{index,changelog,agents}.md` *(new)* | Symlinks into repo-root markdown. |
| `requirements-docs.txt` *(new)* | Pin mkdocs / mkdocs-material / mkdocs-llmstxt / pymdown-extensions. |