### PR TITLE
docs(readme): switch consumer story to git-only distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ interpreter from Pydantic, written in Rust.
 [`dart_monty`](https://github.com/runyaga/dart_monty), which depends
 on this package.
 
-> **Pre-1.0** — pin exact (`dart_monty_core: 0.17.0`); minor version mirrors the upstream `monty` patch (`0.X.0 ↔ monty v0.0.X`).
+> **Pre-1.0, git-only** — `dart_monty_core` is not published to pub.dev. Consume it via a `git:` dependency pinned to a tag. Minor version mirrors the upstream `monty` patch (`0.X.0 ↔ monty v0.0.X`).
 
 ## Why
 
@@ -191,7 +191,10 @@ maxRecursionDepth:)`.
 
 ```yaml
 dependencies:
-  dart_monty_core: 0.17.0   # exact pin until 1.0
+  dart_monty_core:
+    git:
+      url: https://github.com/runyaga/dart_monty_core
+      ref: v0.17.0   # pin to a tag; do not float on main
 ```
 
 ### Prerequisites for FFI (desktop only)
@@ -224,9 +227,11 @@ WASM ships pre-built — no toolchain required. Copy the three assets into
 your `web/` and add a script tag:
 
 ```bash
-cp $(dart pub cache dir)/hosted/pub.dev/dart_monty_core-*/lib/assets/dart_monty_core_bridge.js web/
-cp $(dart pub cache dir)/hosted/pub.dev/dart_monty_core-*/lib/assets/dart_monty_core_worker.js web/
-cp $(dart pub cache dir)/hosted/pub.dev/dart_monty_core-*/lib/assets/dart_monty_core_native.wasm web/
+# Git-deps cache the cloned repo here (path encodes the resolved sha):
+SRC=$(find ~/.pub-cache/git -maxdepth 2 -type d -name 'dart_monty_core-*' | head -1)
+cp "$SRC/lib/assets/dart_monty_core_bridge.js" web/
+cp "$SRC/lib/assets/dart_monty_core_worker.js" web/
+cp "$SRC/lib/assets/dart_monty_core_native.wasm" web/
 ```
 
 ```html


### PR DESCRIPTION
\`dart_monty_core\` is no longer being published to pub.dev. Consumers pull from this GitHub repo via a \`git:\` dependency pinned to a tag.

## What changed

Three sites in README.md:

- **Pre-1.0 callout**: now reads \"Pre-1.0, git-only — dart_monty_core is not published to pub.dev. Consume it via a \`git:\` dependency pinned to a tag. Minor version mirrors the upstream monty patch (0.X.0 ↔ monty v0.0.X).\"
- **Installation snippet**: replaced \`dart_monty_core: 0.17.0\` (pub.dev pin) with a \`git:\` dep block pointing at this repo with \`ref: v0.17.0\`.
- **Web (WASM) asset copy commands**: was sourcing from the pub-cache \`hosted/pub.dev/dart_monty_core-*\` path. Replaced with a \`find ~/.pub-cache/git\` one-liner that resolves the git-deps cache directory.

## Open follow-ups (if we go full-git-only)

- **PR #87** (drop \"restricted\" from pubspec description) — moot if we're not publishing to pub.dev. The description still shows in some Dart tooling output (\`dart pub deps\`, etc.) so the cleanup is still nice; or close.
- **\`.github/workflows/publish.yaml\`** — dead code with git-only distribution. Either delete or leave dormant.
- **\`v0.17.0\` git tag** — keep as a stable version marker for git deps to pin against.