### PR TITLE
release: 0.17.0 (re-cut from broken 0.0.17)

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -8,7 +8,6 @@ js/
 native/target/
 native/.dart_tool/
 native/tests/
-native/src/bin/
 native/lcov.info
 native/Cargo.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.17.0
+
+Re-cut release: align versioning with `dart_monty`. Supersedes the
+retracted `0.0.17` (which omitted `native/src/bin/oracle.rs` from
+the published archive, breaking the build hook for consumers).
+
 ## 0.0.17
 
 Initial release.

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -38,6 +38,7 @@ void main(List<String> args) async {
       final result = await Process.run('cargo', [
         'build',
         '--release',
+        '--lib',
         ...targetArgs,
       ], workingDirectory: Directory.fromUri(nativeDir).path);
       if (result.exitCode != 0) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_core
 description: Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's interpreter.
-version: 0.0.17
+version: 0.17.0
 homepage: https://github.com/runyaga/dart_monty_core
 repository: https://github.com/runyaga/dart_monty_core
 


### PR DESCRIPTION
## Summary

- Bump version to **0.17.0** to align with `dart_monty`'s versioning. Supersedes the retracted `0.0.17`, which shipped a `Cargo.toml` referencing `native/src/bin/oracle.rs` while `.pubignore` excluded the file — cargo refused the manifest and the build hook crashed for every native consumer.
- Fix the packaging bug: drop `native/src/bin/` from `.pubignore` so `oracle.rs` ships (4 KB), and pass `--lib` to the cargo invocation in `hook/build.dart` so consumer installs only build the cdylib/staticlib (oracle is a dev-only test binary, not needed at consumer build time).

## Test plan

- [x] `cargo build --release --lib` from `native/` succeeds standalone
- [x] `dart pub publish --dry-run` ships `oracle.rs` (archive: 4 MB, 1 expected hint about version jump)
- [x] Used as a `path:` override from `dart_monty` — full test suite passes (465/465)
- [ ] After merge: tag `v0.17.0` and publish to pub.dev
- [ ] Verify a fresh `dart pub add dart_monty_core` resolves and builds cleanly on macOS