### PR TITLE
fix(tooling): point test_wasm.sh at lib/assets/

### DIFF
--- a/tool/test_wasm.sh
+++ b/tool/test_wasm.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 
 PKG="$(cd "$(dirname "$0")/.." && pwd)"
 JS_DIR="$PKG/js"
-ASSETS_DIR="$PKG/assets"
+ASSETS_DIR="$PKG/lib/assets"
 INTEG_WEB="$PKG/test/integration/web"
 SERVE_PORT=8097
 SKIP_BUILD=false


### PR DESCRIPTION
## Summary

`js/build.js` writes the bridge JS and worker JS to `lib/assets/` (the canonical pub package asset location), but `tool/test_wasm.sh` still pointed at the legacy top-level `assets/` path. Existence checks at lines 87-92 short-circuited before the headless-Chrome fixture phase could run.

One-line fix in line 28.

## Test plan

- [x] `bash tool/test_wasm.sh --skip-build` → **474/474 fixtures passing** in headless Chrome
- [x] Full `bash tool/test_wasm.sh` (cargo wasm32-wasip1 + npm + chrome) — verified end-to-end