### PR TITLE
docs: drop unannounced 0.17.1 binary-release plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,8 @@
 # AGENTS.md — dart_monty_core build & test guide
 
 Reference for two audiences: **(1) consumers compiling `dart_monty_core`
-0.17.0 from source** (the only path on 0.17.0 — see Toolchain
-prerequisites below), and **(2) maintainers** building, testing, and
-releasing this package. Once 0.17.1 ships prebuilt binaries (see
-"Native binary release pipeline (0.17.1+)" near the end), audience (1)
-can skip the Rust toolchain entirely.
+from source** (see Toolchain prerequisites below), and **(2) maintainers**
+building, testing, and releasing this package.
 
 ## Toolchain prerequisites
 
@@ -217,57 +214,3 @@ git tag v0.18.0 && git push origin v0.18.0
 | `lib/assets/` stale after editing `native/` or `js/` | `bash tool/prebuild.sh && git add lib/assets/` |
 | Bindings stale check fails in CI | `bash tool/generate_bindings.sh` |
 
-## Native binary release pipeline (0.17.1+)
-
-Starting at 0.17.1, prebuilt FFI binaries are published as GitHub
-Release assets and downloaded by `hook/build.dart` on consumer
-machines. Compile-from-source is preserved as a fallback when a network
-download fails or when a contributor is iterating on the Rust crate
-(presence of `native/Cargo.toml` in the package root is the signal —
-see `hook/build.dart`).
-
-### Artefacts shipped per release
-
-| Platform | Triple | File | Approx. size |
-|---|---|---|---|
-| macOS arm64 | `aarch64-apple-darwin` | `libdart_monty_core_native-aarch64-apple-darwin.dylib` | ~6 MB |
-| macOS x86_64 | `x86_64-apple-darwin` | `libdart_monty_core_native-x86_64-apple-darwin.dylib` | ~6 MB |
-| Linux x86_64 | `x86_64-unknown-linux-gnu` | `libdart_monty_core_native-x86_64-unknown-linux-gnu.so` | ~6 MB |
-| Linux aarch64 | `aarch64-unknown-linux-gnu` | `libdart_monty_core_native-aarch64-unknown-linux-gnu.so` | ~6 MB |
-| Windows x86_64 | `x86_64-pc-windows-msvc` | `dart_monty_core_native-x86_64-pc-windows-msvc.dll` | ~6 MB |
-| Android (4 ABIs) | `aarch64-linux-android` etc. | `libdart_monty_core_native-<abi>.so` | ~6 MB each |
-| iOS xcframework | (universal) | `dart_monty_core_native.xcframework.zip` | 70 MB zipped, 171 MB unzipped |
-
-WASM stays committed in `lib/assets/` — there is no FFI hook for the
-web target.
-
-### Why download instead of commit
-
-iOS xcframework size (170 MB unzipped) rules out committing binaries
-to the package: the resulting tarball would exceed pub.dev's 100 MB
-hard cap. Download-on-demand from GitHub Releases keeps the published
-package small (~6 MB tarball, just the WASM trio + Dart sources).
-
-### Release workflow (new in 0.17.1)
-
-1. Bump `pubspec.yaml` version to `0.17.1`.
-2. `tool/build_release_artefacts.sh` (forthcoming) cross-compiles all
-   triples and uploads them to a draft GitHub Release.
-3. `hook/build.dart` (extended) probes platform at `pub get` time,
-   downloads the matching artefact via HTTPS, verifies SHA-256 against
-   a manifest committed alongside the hook, caches under
-   `${PUB_CACHE}/dart_monty_core/native/<version>/<triple>/`, and
-   wires it as the `CodeAsset`.
-4. CI matrix-builds the artefacts on macOS, Ubuntu, Windows runners
-   and asserts manifest checksums. Promote draft → published when the
-   matrix is green.
-5. Tag `v0.17.1` triggers `publish.yaml`; OIDC handles the upload.
-
-### Outstanding design decisions for 0.17.1
-
-- Manifest format (JSON next to `hook/build.dart` vs embedded const map).
-- Behaviour when offline — fall back to source build silently or hard
-  fail with an actionable error?
-- Cache location (`PUB_CACHE` vs system temp).
-- Code-signing for macOS dylib (Developer ID + notarization) — defer
-  to 0.17.x when Apple Developer cert is provisioned.

--- a/README.md
+++ b/README.md
@@ -190,13 +190,6 @@ maxRecursionDepth:)`.
 > **0.17.0 builds the native FFI binary from source on `dart pub get`.**
 > Every FFI consumer needs a Rust toolchain, including Flutter consumers
 > coming in via [`dart_monty`](https://github.com/runyaga/dart_monty).
->
-> **Prebuilt binaries arrive in 0.17.1** for macOS (arm64+x86_64), Linux
-> (x86_64-gnu+aarch64-gnu), Windows (x86_64), iOS (xcframework), and
-> Android (4 ABIs). The build hook will download the matching artefact
-> from this repo's GitHub Releases on first `pub get` — no Rust
-> toolchain required. See `AGENTS.md` "Native binary release pipeline
-> (0.17.1+)".
 
 ### Install (from GitHub)
 


### PR DESCRIPTION
## Summary

README's call-out and AGENTS.md's "Native binary release pipeline (0.17.1+)" section promised prebuilt FFI binaries via GitHub Releases in a future 0.17.1 — that work is not committed to. Remove the forward references so the docs match reality (0.17.0 builds from source; nothing further promised).

## Changes

- `README.md`: drop the second paragraph of the install-warning block.
- `AGENTS.md`: drop the forward reference in the intro and the entire "Native binary release pipeline (0.17.1+)" section (artefacts table, why-download rationale, release workflow, design decisions).

## Test plan

- [x] `grep -rln "0.17.1\|Prebuilt binaries\|Native binary release pipeline"` across both repos → zero matches