### PR TITLE
docs(readme): switch install instructions to pub.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ interpreter from Pydantic, written in Rust.
 [`dart_monty`](https://github.com/runyaga/dart_monty), which depends
 on this package.
 
-**Pre-1.0** — install via `git:` from GitHub (see Installation
-below). Versioning convention: minor version mirrors the upstream
-`monty` patch (`0.X.0 ↔ monty v0.0.X`).
+**Pre-1.0** — published on pub.dev (see Installation below).
+Versioning convention: minor version mirrors the upstream `monty`
+patch (`0.X.0 ↔ monty v0.0.X`).
 
 ## Why
 
@@ -198,12 +198,21 @@ maxRecursionDepth:)`.
 > toolchain required. See `AGENTS.md` "Native binary release pipeline
 > (0.17.1+)".
 
-### Install (from GitHub)
+### Install (from pub.dev)
 
-`dart_monty_core` is distributed via GitHub. **Do not use
-`dart pub add dart_monty_core`** — pub.dev does not yet have
-0.17.0; the historical `dart_monty` 0.11.0 there is a different,
-older API.
+```bash
+dart pub add dart_monty_core
+```
+
+Or pin in `pubspec.yaml`:
+
+```yaml
+dependencies:
+  dart_monty_core: ^0.17.0
+```
+
+To track unreleased fixes on `main`, use a `git:` dependency
+instead:
 
 ```yaml
 dependencies:
@@ -211,16 +220,6 @@ dependencies:
     git:
       url: https://github.com/runyaga/dart_monty_core.git
       ref: main
-```
-
-For local development against a worktree, use `path:` instead:
-
-```yaml
-dependencies:
-  dart_monty_core:
-    git:
-      url: https://github.com/runyaga/dart_monty_core
-      ref: v0.17.0   # pin to a tag; do not float on main
 ```
 
 ### Prerequisites for FFI (desktop only)
@@ -253,8 +252,9 @@ WASM ships pre-built — no toolchain required. Copy the three assets into
 your `web/` and add a script tag:
 
 ```bash
-# Git-deps cache the cloned repo here (path encodes the resolved sha):
-SRC=$(find ~/.pub-cache/git -maxdepth 2 -type d -name 'dart_monty_core-*' | head -1)
+# Locate the package cache (pub.dev hosted, or a git: dep):
+SRC=$(find ~/.pub-cache/hosted/pub.dev ~/.pub-cache/git \
+  -maxdepth 2 -type d -name 'dart_monty_core-*' 2>/dev/null | head -1)
 cp "$SRC/lib/assets/dart_monty_core_bridge.js" web/
 cp "$SRC/lib/assets/dart_monty_core_worker.js" web/
 cp "$SRC/lib/assets/dart_monty_core_native.wasm" web/


### PR DESCRIPTION
## Summary

The README still warned **"Do not use `dart pub add
dart_monty_core`"** and routed everyone through a `git:`
dependency. This PR flips the primary install path back to
pub.dev:
