### PR TITLE
docs: add README image, badges, and pub.dev topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # dart_monty_core
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/runyaga/dart_monty/main/docs/assets/dart_monty.jpg" alt="dart_monty_core" width="280">
+</p>
+
+[![CI](https://github.com/runyaga/dart_monty_core/actions/workflows/ci.yaml/badge.svg)](https://github.com/runyaga/dart_monty_core/actions/workflows/ci.yaml)
+[![Pages](https://github.com/runyaga/dart_monty_core/actions/workflows/deploy-pages.yml/badge.svg)](https://runyaga.github.io/dart_monty_core/)
+[![codecov](https://codecov.io/gh/runyaga/dart_monty_core/graph/badge.svg)](https://codecov.io/gh/runyaga/dart_monty_core)
+
 Run Python in Dart. A thin binding for
 [pydantic/monty](https://github.com/pydantic/monty) — the sandboxed Python
 interpreter from Pydantic, written in Rust.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ topics:
   - python
   - sandbox
   - interpreter
-  - dart
+  - scripting
 
 environment:
   sdk: ^3.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,11 @@ description: Sandboxed Python scripting for Dart. Low-level binding for pydantic
 version: 0.17.0
 homepage: https://github.com/runyaga/dart_monty_core
 repository: https://github.com/runyaga/dart_monty_core
+topics:
+  - python
+  - sandbox
+  - interpreter
+  - dart
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary

Mirrors the presentation of the sibling `dart_monty` package's README and surfaces this package on pub.dev's topic search.

## Changes

- `README.md`: centered image at the top + three badges (CI / Pages / codecov), pointing at this repo's workflows and codecov project. Image is sourced from `runyaga/dart_monty`'s `docs/assets` (both repos share the same brand asset).
- `pubspec.yaml`: added `topics: [python, sandbox, interpreter, dart]` so the package shows up under those topics on pub.dev.

## Notes

- The pub.dev image fix only takes effect on the *next* release — pub.dev pins the README to whatever shipped with each version. `dart_monty_core 0.17.0`'s listing won't update; the change lands when `0.17.x` (or later) ships.
- `codecov` badge will render as "unknown" until codecov is wired up to ingest reports for this repo.