### PR TITLE
ci: upload Dart coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,6 +124,11 @@ jobs:
             mkdir -p coverage
             touch coverage/lcov.info
           fi
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload lcov artifact
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Adds the [`codecov/codecov-action@v5`](https://github.com/codecov/codecov-action) step right after LCOV generation in the **Dart test (JIT)** job. Uses the `CODECOV_TOKEN` repo secret.

## Why

The codecov badge added in #94 currently reads "unknown" because no coverage reports are being pushed. This wires the upload so the badge starts reflecting reality.

## Prerequisites

- `CODECOV_TOKEN` secret must be configured at https://github.com/runyaga/dart_monty_core/settings/secrets/actions (token from https://app.codecov.io/gh/runyaga/dart_monty_core after enabling the project there).

## Notes

- Currently the `test` job's coverage tracefile is **empty** (no unit tests yet — comment on line ~110 says "exit 79 = no tests found"). The upload step won't fail on empty data, but the badge will read 0% until unit tests are added.
- Rust coverage (`cargo llvm-cov` in the `rust` job) is NOT uploaded — separate output format, separate decision. Add later if you want full-stack coverage.