### PR TITLE
test(core-async): pin Monty.run(inputs:) + async behaviour on main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,10 +286,12 @@ jobs:
             test/integration/oracle_ffi_test.dart \
             test/integration/oracle_ffi_ext_test.dart \
             test/integration/ffi_datetime_oscall_test.dart \
+            test/integration/ffi_monty_async_inputs_test.dart \
             test/integration/ffi_multi_repl_test.dart \
             test/integration/ffi_repl_oscall_test.dart \
             test/integration/repros \
-            -p vm --run-skipped --tags=ffi --reporter=expanded
+            -p vm --run-skipped --tags=ffi --exclude-tags=pending-futures \
+            --reporter=expanded
 
   # ---------------------------------------------------------------------------
   # Example smoke tests — every example/*.dart must compile and exit 0.

--- a/README.md
+++ b/README.md
@@ -198,17 +198,7 @@ A script that `await`s a Dart-registered external function is a
 different story today — externals resolve **synchronously** through
 `run()` / `feedRun()`, so `result = await fetch(key)` raises
 `TypeError: 'str' object can't be awaited` because `fetch` returns a
-plain string instead of a future. True awaitable externals are tracked
-on the unmerged [`feat/repl-future-capable`][async-branch] branch
-which exposes `resumeAsFuture` / `resolveFutures` on `MontyRepl`.
-The matching test pair —
-[`ffi_monty_async_inputs_test.dart`][async-test-ffi] /
-[`wasm_monty_async_inputs_test.dart`][async-test-wasm] — pins both
-behaviours so the boundary is unambiguous.
-
-[async-branch]: https://github.com/runyaga/dart_monty_core/tree/feat/repl-future-capable
-[async-test-ffi]: test/integration/ffi_monty_async_inputs_test.dart
-[async-test-wasm]: test/integration/wasm_monty_async_inputs_test.dart
+plain string instead of a future.
 
 ### External functions
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -12,3 +12,5 @@ tags:
     skip: "Example smoke tests. Run: dart test -p vm --run-skipped --tags=example"
   ladder:
     skip: "Skipped by default (slow). Run: dart test --run-skipped --tags=ladder"
+  pending-futures:
+    skip: "Pending feat/repl-future-capable. Run with --run-skipped --tags=pending-futures to confirm the spec is still failing."

--- a/test/integration/_monty_async_inputs_test_body.dart
+++ b/test/integration/_monty_async_inputs_test_body.dart
@@ -1,0 +1,176 @@
+// Shared test body for ffi_monty_async_inputs_test.dart and
+// wasm_monty_async_inputs_test.dart.
+//
+// Pins down how `Monty(code).run(inputs: ...)` interacts with async
+// scripts on the current `main` (without the unmerged feat/repl-future-capable
+// REPL-level futures wiring). The intent is to make the boundary testable:
+// what works today, and what depends on landing the futures-capable REPL.
+//
+// Both files call [runMontyAsyncInputsTests] so the assertions stay in sync
+// across the FFI and WASM backends.
+
+import 'dart:async';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void runMontyAsyncInputsTests() {
+  group('Monty(code).run(inputs:) + async', () {
+    // ----- Pure-Python async (no external futures) -------------------------
+    // `async def` + `await coro()` runs entirely inside the interpreter — no
+    // MontyResolveFutures event fires, so it does not depend on the
+    // futures-capable REPL wiring.
+    group('pure-Python async', () {
+      test('await of a local coroutine returns the awaited value', () async {
+        final r = await Monty('''
+async def foo():
+    return n * 2
+result = await foo()
+result
+''').run(inputs: {'n': 21});
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 42);
+      });
+
+      test('inputs visible inside async closure', () async {
+        final r = await Monty('''
+async def greet():
+    return f"hello, {name}!"
+await greet()
+''').run(inputs: {'name': 'alice'});
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'hello, alice!');
+      });
+
+      test('asyncio.gather over local coroutines', () async {
+        final r = await Monty('''
+import asyncio
+async def add(a, b):
+    return a + b
+await asyncio.gather(add(x, 1), add(x, 2), add(x, 3))
+''').run(inputs: {'x': 10});
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, [11, 12, 13]);
+      });
+    });
+
+    // ----- External calls: synchronous resolution -------------------------
+    // On `main`, externalFunctions resolve *synchronously* from Python's
+    // perspective: the callback's awaited Dart Future is unwrapped before
+    // resume(), so Python sees the plain value. That means externals work
+    // fine when called like a normal function but break when Python tries
+    // to `await` them.
+    group('external calls — synchronous on main', () {
+      test(
+        'plain (non-await) external call returns the resolved value',
+        () async {
+          var fetchCallCount = 0;
+          final r =
+              await Monty('''
+result = fetch(key)
+result
+''').run(
+                inputs: {'key': 'token'},
+                externalFunctions: {
+                  'fetch': (args) async {
+                    fetchCallCount++;
+                    await Future<void>.delayed(Duration.zero);
+
+                    return 'value-for-${args['_0']}';
+                  },
+                },
+              );
+
+          expect(r.error, isNull);
+          expect(r.value.dartValue, 'value-for-token');
+          expect(fetchCallCount, equals(1));
+        },
+      );
+    });
+
+    // ----- External async (depends on futures-capable REPL) ---------------
+    // When Python uses `await fetch(...)` against a Dart external, the
+    // platform needs to surface the call as an awaitable so Python's event
+    // loop can suspend on it. That requires `MontyFutureCapable.
+    // resumeAsFuture` + `resolveFutures` to be wired through the REPL —
+    // the work on the unmerged feat/repl-future-capable branch.
+    //
+    // Today (probed on main):
+    //   - `result = await fetch(key)` raises TypeError:
+    //         "'str' object can't be awaited"
+    //   - `await asyncio.gather(fetch(a), fetch(b), fetch(c))` raises
+    //         TypeError: "An asyncio.Future, a coroutine or an awaitable is
+    //         required"
+    //   In both cases the Dart callback DOES fire (so dispatch works), but
+    //   the value is returned eagerly as a plain Python value rather than
+    //   as an awaitable that Python can suspend on.
+    //
+    // The two tests below codify the SPEC that feat/repl-future-capable
+    // must satisfy. They are skipped on main and should be flipped to
+    // green once that branch lands.
+    group('external async — pending feat/repl-future-capable', () {
+      test(
+        'await of a Dart external returns the resolved value',
+        tags: 'pending-futures',
+        () async {
+          var fetchCallCount = 0;
+          final r =
+              await Monty('''
+result = await fetch(key)
+result
+''').run(
+                inputs: {'key': 'token'},
+                externalFunctions: {
+                  'fetch': (args) async {
+                    fetchCallCount++;
+                    await Future<void>.delayed(Duration.zero);
+
+                    return 'value-for-${args['_0']}';
+                  },
+                },
+              );
+
+          expect(r.error, isNull);
+          expect(fetchCallCount, equals(1));
+          expect(r.value.dartValue, 'value-for-token');
+        },
+      );
+
+      test(
+        'asyncio.gather over Dart externals resolves in argument order',
+        tags: 'pending-futures',
+        () async {
+          final calls = <int>[];
+          final r =
+              await Monty('''
+import asyncio
+results = await asyncio.gather(
+    fetch(a),
+    fetch(b),
+    fetch(c),
+)
+results
+''').run(
+                inputs: {'a': 1, 'b': 2, 'c': 3},
+                externalFunctions: {
+                  'fetch': (args) async {
+                    final n = args['_0']! as int;
+                    calls.add(n);
+                    await Future<void>.delayed(Duration.zero);
+
+                    return n * 10;
+                  },
+                },
+              );
+
+          expect(r.error, isNull);
+          expect(calls.toSet(), equals({1, 2, 3}));
+          expect(r.value.dartValue, equals([10, 20, 30]));
+        },
+      );
+    });
+  });
+}

--- a/test/integration/ffi_monty_async_inputs_test.dart
+++ b/test/integration/ffi_monty_async_inputs_test.dart
@@ -1,0 +1,12 @@
+// FFI binding for the async-inputs shared test body.
+//
+// Run: dart test test/integration/ffi_monty_async_inputs_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_monty_async_inputs_test_body.dart';
+
+void main() => runMontyAsyncInputsTests();

--- a/test/integration/wasm_monty_async_inputs_test.dart
+++ b/test/integration/wasm_monty_async_inputs_test.dart
@@ -1,0 +1,12 @@
+// WASM binding for the async-inputs shared test body.
+//
+// Run with dart2js:  dart test test/integration/wasm_monty_async_inputs_test.dart -p chrome --run-skipped
+// Run with dart2wasm: dart test test/integration/wasm_monty_async_inputs_test.dart -p chrome --compiler dart2wasm --run-skipped
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_monty_async_inputs_test_body.dart';
+
+void main() => runMontyAsyncInputsTests();

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -88,6 +88,7 @@ dart test \
   -p chrome \
   --run-skipped \
   --tags=wasm \
+  --exclude-tags=pending-futures \
   --reporter expanded \
   --concurrency 2 \
   test/integration/wasm_dataclass_hydrate_test.dart \

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -93,6 +93,7 @@ dart test \
   test/integration/wasm_dataclass_hydrate_test.dart \
   test/integration/wasm_datetime_oscall_test.dart \
   test/integration/wasm_fixture_test.dart \
+  test/integration/wasm_monty_async_inputs_test.dart \
   test/integration/wasm_monty_compile_run_test.dart \
   test/integration/wasm_monty_exec_externals_test.dart \
   test/integration/wasm_mount_dir_test.dart \


### PR DESCRIPTION
## Summary

Pins down what `Monty(code).run(inputs: ...)` does on `main` for async scripts, so the boundary between "works today" and "depends on `feat/repl-future-capable`" is testable.

| Group | Status |
|---|---|
| Pure-Python async (`async def` + `await coro()` + `asyncio.gather` over coroutines) | ✅ passes on main |
| External calls — synchronous (`fetch(key)`, no `await`) | ✅ passes on main |
| External async (`await fetch(...)`, `asyncio.gather(fetch(a), fetch(b))`) | ⏳ tagged `pending-futures`; spec for `feat/repl-future-capable` |

The pending tests fail today on main with:
- `TypeError: 'str' object can't be awaited`
- `TypeError: An asyncio.Future, a coroutine or an awaitable is required`

…because Dart externals resolve eagerly through `_bindings.resume(jsonEncode(res))`. `feat/repl-future-capable` wires `resumeAsFuture` / `resolveFutures`; flipping these tests green will be the regression check that branch needs.

## Test plan

- [x] `dart test test/integration/ffi_monty_async_inputs_test.dart -p vm --run-skipped --tags=ffi --exclude-tags=pending-futures` — 4 pass
- [x] `bash tool/test_wasm_unit.sh --exclude-tags=pending-futures` — 530 pass
- [x] To validate the pending spec when it lands: drop `--exclude-tags=pending-futures`

## Notes

- Adds `pending-futures` tag to `dart_test.yaml` with a skip directive so default test runs stay green.
- Adds `wasm_monty_async_inputs_test.dart` to the explicit file list in `tool/test_wasm_unit.sh`.
- Branched off `main`, independent of #99 (`feat/inputs-run-script`).