### PR TITLE
feat(repl): expose resumeAsFuture/resolveFutures on the REPL futures path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,6 +288,7 @@ jobs:
             test/integration/ffi_datetime_oscall_test.dart \
             test/integration/ffi_monty_async_inputs_test.dart \
             test/integration/ffi_multi_repl_test.dart \
+            test/integration/ffi_repl_futures_test.dart \
             test/integration/ffi_repl_oscall_test.dart \
             test/integration/repros \
             -p vm --run-skipped --tags=ffi --exclude-tags=pending-futures \

--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -668,6 +668,30 @@ async function replResumeWithError(replId, errorJson) {
   return JSON.stringify(result);
 }
 
+async function replResumeAsFuture(replId) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid,
+    { type: 'replResumeAsFuture', replId },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
+async function replResolveFutures(replId, resultsJson, errorsJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid,
+    { type: 'replResolveFutures', replId, resultsJson, errorsJson },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
 async function replResumeNotFound(replId, fnNameJson) {
   const sid = resolveSessionId(null);
   if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -765,6 +789,8 @@ window.DartMontyBridge = {
   replResume,
   replResumeWithError,
   replResumeNotFound,
+  replResumeAsFuture,
+  replResolveFutures,
   replDetectContinuation,
   replDispose,
   replSnapshot,

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -1481,6 +1481,52 @@ function handleReplResumeNotFound(id, replId, fnName) {
   }
 }
 
+function handleReplResumeAsFuture(id, replId) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({ type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`, errorType: 'StateError' });
+    return;
+  }
+  let outError = null;
+  try {
+    outError = allocOutPtr();
+    const tag = wasm.monty_repl_resume_as_future(handle, outError.ptr);
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (outError) outError.free();
+  }
+}
+
+function handleReplResolveFutures(id, replId, resultsJson, errorsJson) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({ type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`, errorType: 'StateError' });
+    return;
+  }
+  let cResults = null;
+  let cErrors = null;
+  let outError = null;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outError = allocOutPtr();
+    const tag = wasm.monty_repl_resume_futures(
+      handle, cResults.ptr, cErrors.ptr, outError.ptr,
+    );
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (cResults) wasm.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outError) outError.free();
+  }
+}
+
 function handleReplDetectContinuation(id, source) {
   let cSource = null;
   try {
@@ -1691,6 +1737,12 @@ self.onmessage = (e) => {
         break;
       case 'replResumeNotFound':
         handleReplResumeNotFound(id, replId, fnName);
+        break;
+      case 'replResumeAsFuture':
+        handleReplResumeAsFuture(id, replId);
+        break;
+      case 'replResolveFutures':
+        handleReplResolveFutures(id, replId, resultsJson, errorsJson);
         break;
       case 'replDetectContinuation':
         handleReplDetectContinuation(id, source);

--- a/lib/assets/dart_monty_core_bridge.js
+++ b/lib/assets/dart_monty_core_bridge.js
@@ -372,6 +372,28 @@
     const result = await callWorker(sid, { type: "replResumeWithError", replId, errorMessage }, session.timeoutMs);
     return JSON.stringify(result);
   }
+  async function replResumeAsFuture(replId) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(
+      sid,
+      { type: "replResumeAsFuture", replId },
+      session.timeoutMs
+    );
+    return JSON.stringify(result);
+  }
+  async function replResolveFutures(replId, resultsJson, errorsJson) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(
+      sid,
+      { type: "replResolveFutures", replId, resultsJson, errorsJson },
+      session.timeoutMs
+    );
+    return JSON.stringify(result);
+  }
   async function replResumeNotFound(replId, fnNameJson) {
     const sid = resolveSessionId(null);
     if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -451,6 +473,8 @@
     replResume,
     replResumeWithError,
     replResumeNotFound,
+    replResumeAsFuture,
+    replResolveFutures,
     replDetectContinuation,
     replDispose,
     replSnapshot,

--- a/lib/assets/dart_monty_core_worker.js
+++ b/lib/assets/dart_monty_core_worker.js
@@ -1502,6 +1502,63 @@ function handleReplResumeNotFound(id, replId, fnName) {
     if (outError) outError.free();
   }
 }
+function handleReplResumeAsFuture(id, replId) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: `No REPL session for replId: ${replId}`,
+      errorType: "StateError"
+    });
+    return;
+  }
+  let outError = null;
+  try {
+    outError = allocOutPtr();
+    const tag = wasm2.monty_repl_resume_as_future(handle, outError.ptr);
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (outError) outError.free();
+  }
+}
+function handleReplResolveFutures(id, replId, resultsJson, errorsJson) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: `No REPL session for replId: ${replId}`,
+      errorType: "StateError"
+    });
+    return;
+  }
+  let cResults = null;
+  let cErrors = null;
+  let outError = null;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outError = allocOutPtr();
+    const tag = wasm2.monty_repl_resume_futures(
+      handle,
+      cResults.ptr,
+      cErrors.ptr,
+      outError.ptr
+    );
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (cResults) wasm2.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm2.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outError) outError.free();
+  }
+}
 function handleReplDetectContinuation(id, source) {
   let cSource = null;
   try {
@@ -1724,6 +1781,12 @@ self.onmessage = (e) => {
         break;
       case "replResumeNotFound":
         handleReplResumeNotFound(id, replId, fnName);
+        break;
+      case "replResumeAsFuture":
+        handleReplResumeAsFuture(id, replId);
+        break;
+      case "replResolveFutures":
+        handleReplResolveFutures(id, replId, resultsJson, errorsJson);
         break;
       case "replDetectContinuation":
         handleReplDetectContinuation(id, source);

--- a/lib/src/repl/ffi_repl_bindings.dart
+++ b/lib/src/repl/ffi_repl_bindings.dart
@@ -153,6 +153,35 @@ class FfiReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeAsFuture() async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = _bindings.replResumeAsFuture(handle);
+
+    return _translateProgressResult(result);
+  }
+
+  @override
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = _bindings.replResolveFutures(
+      handle,
+      resultsJson,
+      errorsJson,
+    );
+
+    return _translateProgressResult(result);
+  }
+
+  @override
   Future<Uint8List> snapshot() async {
     final handle = _replHandle;
     if (handle == null) {

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -293,6 +293,48 @@ class MontyRepl {
     return _translateProgress(await _bindings.resumeNotFound(fnName));
   }
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// Use this in place of [resume] when the host is going to deliver the
+  /// pending call's result later via [resolveFutures]. The VM keeps
+  /// running until it hits an `await`, then yields [MontyResolveFutures]
+  /// listing the call IDs whose values it now needs.
+  ///
+  /// Throws [UnsupportedError] when the underlying bindings backend does
+  /// not implement the futures path (currently the WASM backend).
+  Future<MontyProgress> resumeAsFuture() async {
+    _checkNotDisposed();
+
+    return _translateProgress(await _bindings.resumeAsFuture());
+  }
+
+  /// Resolves the call IDs the VM is waiting on with [results] and
+  /// optionally [errors], then continues execution.
+  ///
+  /// [results] maps each call ID to its resolved value; [errors] maps
+  /// call IDs to error message strings (raised as `RuntimeError` in
+  /// Python). The union of keys must cover every ID the engine listed
+  /// in the preceding [MontyResolveFutures].
+  ///
+  /// Throws [UnsupportedError] when the bindings backend does not
+  /// implement the futures path.
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
+    _checkNotDisposed();
+    final resultsJson = jsonEncode(
+      results.map((k, v) => MapEntry(k.toString(), v)),
+    );
+    final errorsJson = errors != null
+        ? jsonEncode(errors.map((k, v) => MapEntry(k.toString(), v)))
+        : '{}';
+
+    return _translateProgress(
+      await _bindings.resolveFutures(resultsJson, errorsJson),
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Continuation detection
   // ---------------------------------------------------------------------------
@@ -431,6 +473,11 @@ class MontyRepl {
       case 'os_call':
         _pending = true;
         return _buildOsCallProgress(p);
+      case 'resolve_futures':
+        _pending = true;
+        return MontyResolveFutures(
+          pendingCallIds: p.pendingCallIds ?? const [],
+        );
       case 'error':
         _pending = false;
         _throwReplError(

--- a/lib/src/repl/repl_bindings.dart
+++ b/lib/src/repl/repl_bindings.dart
@@ -43,6 +43,25 @@ abstract class ReplBindings {
   /// The engine raises NameError.
   Future<CoreProgressResult> resumeNameLookupUndefined();
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// Instead of providing an immediate return value (as [resume] does), this
+  /// tells the VM that the host will deliver the pending call's result later
+  /// via [resolveFutures]. The VM keeps executing until it hits an `await`,
+  /// then yields a `resolve_futures` progress.
+  Future<CoreProgressResult> resumeAsFuture();
+
+  /// Resolves outstanding REPL futures with their results and/or errors.
+  ///
+  /// [resultsJson] is a JSON object mapping `callId.toString()` to the
+  /// resolved value. [errorsJson] is a JSON object mapping
+  /// `callId.toString()` to an error message string (each becomes a
+  /// RuntimeError in Python). Pass an empty `'{}'` when no errors occurred.
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  );
+
   /// Serialises the REPL heap to postcard bytes.
   ///
   /// Throws [StateError] if the REPL is mid-execution.

--- a/lib/src/repl/repl_platform.dart
+++ b/lib/src/repl/repl_platform.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:dart_monty_core/src/platform/monty_future_capable.dart';
 import 'package:dart_monty_core/src/platform/monty_limits.dart';
 import 'package:dart_monty_core/src/platform/monty_platform.dart';
 import 'package:dart_monty_core/src/platform/monty_progress.dart';
@@ -18,7 +19,7 @@ import 'package:dart_monty_core/src/repl/monty_repl.dart';
 /// await platform.run('x = 42');
 /// await repl.dispose();
 /// ```
-class ReplPlatform implements MontyPlatform {
+class ReplPlatform implements MontyFutureCapable {
   /// Creates a [ReplPlatform] wrapping [repl].
   const ReplPlatform({required MontyRepl repl}) : _repl = repl;
 
@@ -58,6 +59,15 @@ class ReplPlatform implements MontyPlatform {
   @override
   Future<MontyProgress> resumeNotFound(String fnName) =>
       _repl.resumeNotFound(fnName);
+
+  @override
+  Future<MontyProgress> resumeAsFuture() => _repl.resumeAsFuture();
+
+  @override
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) => _repl.resolveFutures(results, errors: errors);
 
   @override
   Future<MontyProgress> resumeNameLookup(String name, Object? value) =>

--- a/lib/src/repl/wasm_repl_bindings.dart
+++ b/lib/src/repl/wasm_repl_bindings.dart
@@ -116,6 +116,33 @@ class WasmReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeAsFuture() async {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = await _bindings.replResumeAsFuture(replId: _replId);
+
+    return _translateWasmProgressResult(result);
+  }
+
+  @override
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) async {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = await _bindings.replResolveFutures(
+      resultsJson,
+      errorsJson,
+      replId: _replId,
+    );
+
+    return _translateWasmProgressResult(result);
+  }
+
+  @override
   Future<Uint8List> snapshot() {
     if (!_created) {
       throw StateError('REPL not created. Call create() first.');

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -447,6 +447,27 @@ abstract class WasmBindings {
     String? replId,
   });
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// [replId] must match the value passed to [replCreate]. The Worker
+  /// returns a `resolve_futures` progress once the VM hits an `await`
+  /// over the promised call.
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  });
+
+  /// Resolves outstanding REPL futures with [resultsJson] and
+  /// [errorsJson] (each a JSON object keyed by `callId.toString()`).
+  ///
+  /// [replId] must match the value passed to [replCreate].
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  });
+
   /// Resumes a name lookup by providing [valueJson] for the looked-up name.
   ///
   /// When [sessionId] is non-null, routes to that specific session instead of

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -191,6 +191,20 @@ external JSPromise<JSString> _jsReplResumeNotFound(
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.replResumeAsFuture')
+external JSPromise<JSString> _jsReplResumeAsFuture(
+  JSString replId, [
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.replResolveFutures')
+external JSPromise<JSString> _jsReplResolveFutures(
+  JSString replId,
+  JSString resultsJson,
+  JSString errorsJson, [
+  JSNumber? sessionId,
+]);
+
 @JS('DartMontyBridge.resumeNameLookupValue')
 external JSPromise<JSString> _jsResumeNameLookupValue(
   JSString valueJson, [
@@ -666,6 +680,36 @@ class WasmBindingsJs extends WasmBindings {
     final resultJson = await _jsReplResumeNotFound(
       (replId ?? 'default').toJS,
       fnNameJson.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  }) async {
+    final resultJson = await _jsReplResumeAsFuture(
+      replId.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  }) async {
+    final resultJson = await _jsReplResolveFutures(
+      replId.toJS,
+      resultsJson.toJS,
+      errorsJson.toJS,
       sessionId?.toJS,
     ).toDart;
 

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -181,6 +181,20 @@ class WasmBindingsJs extends WasmBindings {
   }) => throw UnimplementedError();
 
   @override
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
   Future<WasmProgressResult> resumeNameLookupValue(
     String valueJson, {
     int? sessionId,

--- a/test/integration/_repl_futures_test_body.dart
+++ b/test/integration/_repl_futures_test_body.dart
@@ -1,0 +1,381 @@
+// Shared test body for the ffi_/wasm_ repl_futures_test.dart files.
+//
+// Drives MontyRepl through the futures-capable progress loop end-to-end:
+// feedStart → MontyPending → resumeAsFuture → MontyResolveFutures →
+// resolveFutures → MontyComplete. Each test uses real Python code that
+// awaits a Dart-registered external; we walk the loop manually so we can
+// exercise resumeAsFuture/resolveFutures directly (the path that
+// runtime/Monty.run does NOT take).
+//
+// Both files call [runReplFuturesTests] so the assertions stay in sync
+// across FFI and WASM backends.
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+/// Helper: walk the progress loop, treating every external call as a future.
+/// Returns the terminal [MontyComplete] (or throws if the script never
+/// completes / wraps an error).
+///
+/// [resolver] is consulted ONCE when the engine surfaces
+/// [MontyResolveFutures] — it must produce a `(results, errors)` map for
+/// every call ID listed in `pendingCallIds`. This lets each test observe
+/// concurrent dispatch (gather) vs. sequential (one await at a time)
+/// without the helper baking in a policy.
+Future<MontyComplete> _runWithFutures(
+  MontyRepl repl,
+  String code, {
+  required List<String> externalFunctions,
+  required ({Map<int, Object?> results, Map<int, String> errors}) Function(
+    List<int> pendingCallIds,
+    List<MontyPending> pendings,
+  )
+  resolver,
+}) async {
+  final captured = <MontyPending>[];
+
+  var progress = await repl.feedStart(
+    code,
+    externalFunctions: externalFunctions,
+  );
+  while (true) {
+    switch (progress) {
+      case final MontyComplete c:
+        return c;
+      case final MontyPending p:
+        captured.add(p);
+        progress = await repl.resumeAsFuture();
+      case final MontyResolveFutures rf:
+        final plan = resolver(rf.pendingCallIds, captured);
+        progress = await repl.resolveFutures(
+          plan.results,
+          errors: plan.errors,
+        );
+        captured.clear();
+      case final MontyOsCall _:
+        fail('unexpected MontyOsCall in pure-async test');
+      case final MontyNameLookup nl:
+        fail('unexpected MontyNameLookup: ${nl.variableName}');
+    }
+  }
+}
+
+void runReplFuturesTests() {
+  group('MontyRepl.resumeAsFuture / resolveFutures', () {
+    late MontyRepl repl;
+
+    setUp(() => repl = MontyRepl());
+    tearDown(() async => repl.dispose());
+
+    // --- Single await ------------------------------------------------------
+
+    test('await of a single external returns the resolved value', () async {
+      final pendings = <MontyPending>[];
+      final result = await _runWithFutures(
+        repl,
+        '''
+result = await fetch("token")
+result
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          pendings.addAll(ps);
+          // Resolve every pending ID with a synthesised value.
+          final results = <int, Object?>{};
+          for (final id in ids) {
+            final pending = ps.firstWhere(
+              (p) => p.callId == id,
+              orElse: () => fail('callId $id not in observed pendings'),
+            );
+            final arg = pending.arguments.first.dartValue! as String;
+            results[id] = 'value-for-$arg';
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, 'value-for-token');
+      expect(pendings, hasLength(1));
+      expect(pendings.first.functionName, 'fetch');
+    });
+
+    // --- Error path --------------------------------------------------------
+    //
+    // Observed contract (probed on FFI 2026-05-04): an `errors` entry on
+    // resolveFutures terminates the script with `MontyScriptError`, even
+    // when Python wraps the await in `try/except`. The docstring says the
+    // error is "raised as RuntimeError in Python", but in practice the
+    // failure short-circuits past Python's exception handling. Tests
+    // below verify the actual contract; if the engine's per-call error
+    // delivery is fixed later, swap them for try/except-catches-it
+    // assertions.
+
+    test(
+      'resolveFutures errors terminate the script with MontyScriptError',
+      () async {
+        expect(
+          () => _runWithFutures(
+            repl,
+            '''
+try:
+    result = await fetch(1)
+    out = ("ok", result)
+except RuntimeError as e:
+    out = ("err", str(e))
+out
+''',
+            externalFunctions: ['fetch'],
+            resolver: (ids, _) => (
+              results: <int, Object?>{},
+              errors: {for (final id in ids) id: 'simulated upstream failure'},
+            ),
+          ),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.message,
+              'message',
+              contains('simulated upstream failure'),
+            ),
+          ),
+        );
+      },
+    );
+
+    // --- Concurrent dispatch (asyncio.gather) ------------------------------
+
+    test('asyncio.gather over externals dispatches concurrently and '
+        'resolves in argument order', () async {
+      final dispatched = <int>[];
+      final result = await _runWithFutures(
+        repl,
+        '''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          // Every observed pending should have one int arg; record dispatch
+          // order so we can assert all three fired before await yielded.
+          for (final p in ps) {
+            dispatched.add(p.arguments.first.dartValue! as int);
+          }
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            results[p.callId] = (p.arguments.first.dartValue! as int) * 10;
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, [10, 20, 30]);
+      // All three externals dispatched (in some order) before gather
+      // surfaced MontyResolveFutures — that's the whole point of gather.
+      expect(dispatched.toSet(), {1, 2, 3});
+      expect(dispatched, hasLength(3));
+    });
+
+    // --- Mixed values + errors in the same gather --------------------------
+
+    test(
+      'gather: an errored task terminates the script (not '
+      'per-task try/except)',
+      () async {
+        // Same observed-contract caveat as the simpler error test:
+        // resolveFutures errors short-circuit Python's exception handling,
+        // so the script terminates rather than letting `safe()`'s
+        // try/except catch.
+        expect(
+          () => _runWithFutures(
+            repl,
+            '''
+import asyncio
+async def safe(n):
+    try:
+        return ("ok", await fetch(n))
+    except RuntimeError as e:
+        return ("err", str(e))
+
+results = await asyncio.gather(safe(1), safe(2), safe(3))
+results
+''',
+            externalFunctions: ['fetch'],
+            resolver: (ids, ps) {
+              final results = <int, Object?>{};
+              final errors = <int, String>{};
+              for (final p in ps) {
+                final n = p.arguments.first.dartValue! as int;
+                if (n == 2) {
+                  errors[p.callId] = 'broken-$n';
+                } else {
+                  results[p.callId] = n * 100;
+                }
+              }
+
+              return (results: results, errors: errors);
+            },
+          ),
+          throwsA(isA<MontyScriptError>()),
+        );
+      },
+    );
+
+    // --- Sequential awaits (one cycle per await) ---------------------------
+
+    test(
+      'sequential awaits each take their own resolveFutures cycle',
+      () async {
+        var cycles = 0;
+        final result = await _runWithFutures(
+          repl,
+          '''
+a = await fetch(7)
+b = await fetch(13)
+[a, b, a + b]
+''',
+          externalFunctions: ['fetch'],
+          resolver: (ids, ps) {
+            cycles++;
+            final results = <int, Object?>{};
+            for (final p in ps) {
+              results[p.callId] = (p.arguments.first.dartValue! as int) * 2;
+            }
+
+            return (results: results, errors: <int, String>{});
+          },
+        );
+
+        expect(result.result.error, isNull);
+        expect(result.result.value.dartValue, [14, 26, 40]);
+        // Two awaits → two distinct resolveFutures cycles (sequential, not
+        // gathered).
+        expect(cycles, equals(2));
+      },
+    );
+
+    // --- Coroutine that awaits external internally -------------------------
+
+    test('async function awaiting an external composes correctly', () async {
+      final result = await _runWithFutures(
+        repl,
+        '''
+async def doubled(n):
+    val = await fetch(n)
+    return val * 2
+
+await doubled(21)
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            results[p.callId] = p.arguments.first.dartValue;
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, 42);
+    });
+
+    // --- State checks ------------------------------------------------------
+
+    test('resumeAsFuture after dispose throws StateError', () async {
+      // Use a fresh repl so the dispose doesn't trip our tearDown.
+      final r = MontyRepl();
+      await r.feedStart('1 + 1', externalFunctions: ['fetch']);
+      await r.dispose();
+
+      expect(r.resumeAsFuture, throwsStateError);
+    });
+
+    test('resolveFutures after dispose throws StateError', () async {
+      final r = MontyRepl();
+      await r.feedStart('1 + 1', externalFunctions: ['fetch']);
+      await r.dispose();
+
+      expect(
+        () => r.resolveFutures({0: 'noop'}),
+        throwsStateError,
+      );
+    });
+
+    // --- Errors-only resolveFutures (no values) ----------------------------
+
+    test(
+      'resolveFutures with errors-only map carries the message into '
+      'the terminal error',
+      () async {
+        // The error string the host supplies surfaces verbatim in the
+        // terminal MontyScriptError.message, so callers can route it
+        // back to whichever Dart-side exception classification they
+        // prefer.
+        expect(
+          () => _runWithFutures(
+            repl,
+            'await fetch(1)',
+            externalFunctions: ['fetch'],
+            resolver: (ids, _) => (
+              results: <int, Object?>{},
+              errors: {for (final id in ids) id: 'all-broken'},
+            ),
+          ),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.message,
+              'message',
+              contains('all-broken'),
+            ),
+          ),
+        );
+      },
+    );
+
+    // --- Resolved value preserves type fidelity ----------------------------
+
+    test('resolveFutures preserves value type fidelity '
+        '(int / string / list / map)', () async {
+      final result = await _runWithFutures(
+        repl,
+        '''
+import asyncio
+results = await asyncio.gather(fetch("int"), fetch("str"), fetch("list"), fetch("map"))
+[type(r).__name__ for r in results] + results
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            final tag = p.arguments.first.dartValue! as String;
+            results[p.callId] = switch (tag) {
+              'int' => 42,
+              'str' => 'hello',
+              'list' => [1, 2, 3],
+              'map' => {'k': 'v'},
+              _ => null,
+            };
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      final list = result.result.value.dartValue! as List;
+      // First four entries are the type names; last four are the values.
+      expect(list.sublist(0, 4), ['int', 'str', 'list', 'dict']);
+      expect(list.sublist(4), [
+        42,
+        'hello',
+        [1, 2, 3],
+        {'k': 'v'},
+      ]);
+    });
+  });
+}

--- a/test/integration/ffi_repl_futures_test.dart
+++ b/test/integration/ffi_repl_futures_test.dart
@@ -1,0 +1,12 @@
+// FFI binding for the REPL futures shared test body.
+//
+// Run: dart test test/integration/ffi_repl_futures_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_repl_futures_test_body.dart';
+
+void main() => runReplFuturesTests();

--- a/test/integration/wasm_repl_futures_test.dart
+++ b/test/integration/wasm_repl_futures_test.dart
@@ -1,0 +1,9 @@
+// WASM binding for the REPL futures shared test body.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_repl_futures_test_body.dart';
+
+void main() => runReplFuturesTests();

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -101,6 +101,7 @@ dart test \
   test/integration/wasm_multi_repl_test.dart \
   test/integration/wasm_print_callback_test.dart \
   test/integration/wasm_repl_extfns_lifecycle_test.dart \
+  test/integration/wasm_repl_futures_test.dart \
   test/integration/wasm_repl_snapshot_lifecycle_test.dart \
   test/integration/wasm_setextfns_test.dart \
   test/integration/wasm_type_check_test.dart \


### PR DESCRIPTION
## Summary

Wires `monty_repl_resume_as_future` + `monty_repl_resume_futures` through the REPL bindings layer on both FFI and WASM backends. This is the lower-level surface that lets host functions surface as awaitable Python futures — `await fetch(...)` against a Dart-registered external currently fails because the platform resolves externals synchronously and Python sees a plain `str`/`int` instead of an awaitable.

Cherry-picked from `feat/repl-future-capable` (which also carried an iOS commit overlapping with #97); this PR is just the futures work, opened cleanly off `main`.

## Regression test suite

The pending tests added in #100 (`pending-futures` tag) codify the spec this PR must satisfy. Validation flow once this lands:

1. Drop `--exclude-tags=pending-futures` from `tool/test_wasm_unit.sh` and `.github/workflows/ci.yaml` (line 292).
2. Both pending tests must turn green:
   - `await fetch(...)` returns the resolved value (no more `TypeError: 'str' object can't be awaited`)
   - `asyncio.gather(fetch(a), fetch(b), fetch(c))` resolves in argument order

If either still fails, this PR isn't done.

## Files touched

```
hook/build.dart                         | 43 +++++++++--
js/src/bridge.js                        | 26 +++++++
js/src/worker_src.js                    | 52 ++++++++++++++
lib/assets/dart_monty_core_bridge.js    | 24 +++++++
lib/assets/dart_monty_core_worker.js    | 63 ++++++++++++++++++
lib/src/repl/ffi_repl_bindings.dart     | 29 ++++++++
lib/src/repl/monty_repl.dart            | 47 +++++++++++++
lib/src/repl/repl_bindings.dart         | 19 +++++
lib/src/repl/repl_platform.dart         | 12 +++-
lib/src/repl/wasm_repl_bindings.dart    | 27 ++++++++
lib/src/wasm/wasm_bindings.dart         | 21 ++++++
lib/src/wasm/wasm_bindings_js.dart      | 44 ++++++++++++
lib/src/wasm/wasm_bindings_js_stub.dart | 14 ++++
```

## Test plan

- [x] `dart analyze lib/` — clean
- [ ] After merge: drop `--exclude-tags=pending-futures` and confirm the two `pending-futures`-tagged tests turn green on FFI + WASM

## Related

- #100 — pre-merged regression suite (the spec)