### PR TITLE
feat(repl): futures end-to-end — public API + _driveLoop wiring + matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -286,10 +286,12 @@ jobs:
             test/integration/oracle_ffi_test.dart \
             test/integration/oracle_ffi_ext_test.dart \
             test/integration/ffi_datetime_oscall_test.dart \
+            test/integration/ffi_feedrun_async_matrix_test.dart \
             test/integration/ffi_monty_async_inputs_test.dart \
             test/integration/ffi_multi_repl_test.dart \
             test/integration/ffi_repl_futures_test.dart \
             test/integration/ffi_repl_oscall_test.dart \
+            test/integration/ffi_run_async_matrix_test.dart \
             test/integration/repros \
             -p vm --run-skipped --tags=ffi --exclude-tags=pending-futures \
             --reporter=expanded

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,6 +288,7 @@ jobs:
             test/integration/ffi_datetime_oscall_test.dart \
             test/integration/ffi_monty_async_inputs_test.dart \
             test/integration/ffi_multi_repl_test.dart \
+            test/integration/ffi_repl_futures_test.dart \
             test/integration/ffi_repl_oscall_test.dart \
             test/integration/repros \
             -p vm --run-skipped --tags=ffi --exclude-tags=pending-futures \

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ await Monty('x is None').run(inputs: {'x': const MontyNone()});
 
 `inputs:` is a textual prepend, so it composes with **any** script —
 including ones that use `async def` / `await` / `asyncio.gather`. Pure-
-Python async (no Dart externals) works on every release:
+Python async (no Dart externals) works at every API layer with no flag:
 
 ```dart
 await Monty('''
@@ -194,11 +194,28 @@ await double()
 // → MontyInt(42)
 ```
 
-A script that `await`s a Dart-registered external function is a
-different story today — externals resolve **synchronously** through
-`run()` / `feedRun()`, so `result = await fetch(key)` raises
-`TypeError: 'str' object can't be awaited` because `fetch` returns a
-plain string instead of a future.
+For a script that `await`s a Dart-registered external function, opt
+into the futures path with `useFutures: true`:
+
+```dart
+await Monty('result = await fetch(key)\nresult').run(
+  inputs: {'key': 'token'},
+  externalFunctions: {'fetch': (args) async => 'value-for-${args['_0']}'},
+  useFutures: true,
+);
+// → MontyString('value-for-token')
+```
+
+The flag also enables concurrent dispatch — `asyncio.gather(fetch(a),
+fetch(b), fetch(c))` fires all three callbacks before the first
+`MontyResolveFutures`, then resolves them in argument order. Default is
+`false` for back-compat (callbacks resolve eagerly Dart-side; Python
+`await ext()` raises `TypeError` on the eager value).
+
+For the cell-by-cell contract across every API layer × backend, see
+[`docs/deep-dives/async-matrix.md`][async-matrix].
+
+[async-matrix]: docs/deep-dives/async-matrix.md
 
 ### External functions
 

--- a/docs/deep-dives/async-matrix.md
+++ b/docs/deep-dives/async-matrix.md
@@ -1,0 +1,142 @@
+# Async / Sync Matrix
+
+dart_monty_core's interaction with Python scripts has four orthogonal
+axes. This page is the cell-by-cell reference for what works at every
+combination, when to opt into the futures path, and where the contract
+lives in code.
+
+## The four axes
+
+1. **Dart handler shape** — `sync` (returns a value via `Future.value`)
+   vs `async` (returns a `Future` that resolves later).
+2. **Python call shape** — `bare` call (`fn(x)`) vs `await fn(x)`.
+3. **API layer** —
+   - **L1.** `MontyRepl.feedStart` + caller-driven
+     `resumeAsFuture` / `resolveFutures` (manual loop)
+   - **L2.** `MontyRepl.feedRun` (managed loop — `_driveLoop` drives
+     dispatch internally)
+   - **L3.** `Monty(code).run` / `Monty.exec` (one-shot wrapper around
+     `feedRun`)
+   - **L4.** `MontyRuntime.execute` (in `dart_monty`; routes through
+     `PlatformBridge` rather than `_driveLoop`)
+4. **Backend** — FFI vs WASM. The matrix is identical on both unless
+   noted.
+
+## The matrix
+
+Every cell here is **green on `main`** as of the futures-driveloop fix
+(`dart_monty_core` PR landing this doc). The `useFutures` opt-in is
+the toggle that activates the cell-5 column.
+
+### L1 — `MontyRepl.feedStart` + manual loop
+
+| | sync Dart | async Dart |
+|---|---|---|
+| bare Python call | ✅ caller resumes with the value | ✅ caller awaits then resumes |
+| `await ext()` | ✅ caller drives `resumeAsFuture` / `resolveFutures` | ✅ same path |
+
+L1 has always supported every cell — the caller controls dispatch, so
+the host can implement whatever protocol it wants. Reference:
+[`_repl_futures_test_body.dart`][repl-futures] (10 tests).
+
+### L2 — `MontyRepl.feedRun(useFutures: false)` (default)
+
+| | sync Dart | async Dart |
+|---|---|---|
+| bare Python call | ✅ | ✅ (callback awaited eagerly Dart-side) |
+| `await ext()` | ❌ `TypeError: 'str' object can't be awaited` |
+
+Default behaviour preserves back-compat: callbacks are awaited inline
+before resuming Python. Python sees the plain value, so `await fn()`
+fails because the value is not awaitable.
+
+### L2 — `MontyRepl.feedRun(useFutures: true)`
+
+| | sync Dart | async Dart |
+|---|---|---|
+| bare Python call | ✅ | ✅ |
+| `await ext()` | ✅ | ✅ |
+| `asyncio.gather(a(), b(), c())` over externals | ✅ all dispatch concurrently, resolve in argument order |
+
+`useFutures: true` switches `_driveLoop` to launch each callback as an
+unawaited `Future`, reply with `resumeAsFuture()`, and batch the results
+back via `resolveFutures()` when the engine surfaces
+`MontyResolveFutures`. Reference:
+[`_feedrun_async_matrix_body.dart`][feedrun-matrix].
+
+### L3 — `Monty(code).run(useFutures: …)`
+
+`Monty.run` and `Monty.exec` plumb `useFutures` straight through to
+`feedRun`. The matrix is identical to L2. Reference:
+[`_run_async_matrix_body.dart`][run-matrix].
+
+### L4 — `MontyRuntime.execute` (dart_monty)
+
+| `MontyRuntime(useFutures:)` | sync Dart | async Dart | `await ext()` |
+|---|---|---|---|
+| `false` (default) | ✅ | ✅ (eager) | ❌ TypeError |
+| `true` | ✅ | ✅ | ✅ |
+
+L4 takes a different code path than L2/L3: `MontyRuntime` constructs a
+`PlatformBridge` whose `dispatchToolCallAsFuture` is the futures-mode
+twin of `dispatchToolCall`. Setting `useFutures: true` on `MontyRuntime`
+flips the bridge into futures mode, which leverages `ReplPlatform`'s
+existing `MontyFutureCapable` implementation (no `_driveLoop` involved).
+Reference: `dart_monty/test/integration/_runtime_async_matrix_body.dart`.
+
+## When to opt in
+
+Set `useFutures: true` when **any** of:
+
+- The Python script uses `await` against a Dart-registered external
+  (the only way to express "this host call is async" inside Python).
+- You want concurrent host-handler dispatch — `asyncio.gather` over
+  externals dispatches all callbacks before the first
+  `MontyResolveFutures`, so independent I/O fans out instead of
+  serialising.
+
+Leave `useFutures: false` (the default) when:
+
+- The host handlers are simple sync values or you don't care about
+  concurrency — serial dispatch is easier to reason about and avoids
+  any chance of handlers racing over shared state.
+- You want bit-for-bit back-compat with pre-fix behaviour.
+
+## How errors surface
+
+`useFutures: true` collects per-call errors into a map and passes them
+to `resolveFutures(results, errors)`. Today, an `errors` entry
+**terminates the script** with `MontyScriptError` rather than raising a
+catchable Python `RuntimeError` (`try / except RuntimeError` does not
+catch). The error message bubbles up verbatim in
+`MontyScriptError.message`, so callers can route it however they want.
+This is a known pydantic-monty engine constraint, not a host-side bug;
+the L1 manual-loop tests pin the contract end-to-end.
+
+## The spec — the executable matrix
+
+Every claim on this page is a test:
+
+- L1: [`test/integration/_repl_futures_test_body.dart`][repl-futures]
+- L2: [`test/integration/_feedrun_async_matrix_body.dart`][feedrun-matrix]
+- L3: [`test/integration/_run_async_matrix_body.dart`][run-matrix]
+- L4 (in dart_monty): `test/integration/_runtime_async_matrix_body.dart`
+
+Each shared body has FFI + WASM driver pairs (the L4 body has FFI only
+because dart_monty's integration suite is FFI-tagged). Run them with:
+
+```bash
+# dart_monty_core (FFI)
+dart test \
+  test/integration/ffi_repl_futures_test.dart \
+  test/integration/ffi_feedrun_async_matrix_test.dart \
+  test/integration/ffi_run_async_matrix_test.dart \
+  -p vm --run-skipped --tags=ffi
+
+# dart_monty_core (WASM)
+bash tool/test_wasm_unit.sh
+```
+
+[repl-futures]: ../../test/integration/_repl_futures_test_body.dart
+[feedrun-matrix]: ../../test/integration/_feedrun_async_matrix_body.dart
+[run-matrix]: ../../test/integration/_run_async_matrix_body.dart

--- a/js/src/bridge.js
+++ b/js/src/bridge.js
@@ -668,6 +668,30 @@ async function replResumeWithError(replId, errorJson) {
   return JSON.stringify(result);
 }
 
+async function replResumeAsFuture(replId) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid,
+    { type: 'replResumeAsFuture', replId },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
+async function replResolveFutures(replId, resultsJson, errorsJson) {
+  const sid = resolveSessionId(null);
+  if (sid == null || !sessions.has(sid)) return notInitializedError();
+  const session = sessions.get(sid);
+  const result = await callWorker(
+    sid,
+    { type: 'replResolveFutures', replId, resultsJson, errorsJson },
+    session.timeoutMs,
+  );
+  return JSON.stringify(result);
+}
+
 async function replResumeNotFound(replId, fnNameJson) {
   const sid = resolveSessionId(null);
   if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -765,6 +789,8 @@ window.DartMontyBridge = {
   replResume,
   replResumeWithError,
   replResumeNotFound,
+  replResumeAsFuture,
+  replResolveFutures,
   replDetectContinuation,
   replDispose,
   replSnapshot,

--- a/js/src/worker_src.js
+++ b/js/src/worker_src.js
@@ -1481,6 +1481,52 @@ function handleReplResumeNotFound(id, replId, fnName) {
   }
 }
 
+function handleReplResumeAsFuture(id, replId) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({ type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`, errorType: 'StateError' });
+    return;
+  }
+  let outError = null;
+  try {
+    outError = allocOutPtr();
+    const tag = wasm.monty_repl_resume_as_future(handle, outError.ptr);
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (outError) outError.free();
+  }
+}
+
+function handleReplResolveFutures(id, replId, resultsJson, errorsJson) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({ type: 'result', id, ok: false,
+      error: `No REPL session for replId: ${replId}`, errorType: 'StateError' });
+    return;
+  }
+  let cResults = null;
+  let cErrors = null;
+  let outError = null;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outError = allocOutPtr();
+    const tag = wasm.monty_repl_resume_futures(
+      handle, cResults.ptr, cErrors.ptr, outError.ptr,
+    );
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (cResults) wasm.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outError) outError.free();
+  }
+}
+
 function handleReplDetectContinuation(id, source) {
   let cSource = null;
   try {
@@ -1691,6 +1737,12 @@ self.onmessage = (e) => {
         break;
       case 'replResumeNotFound':
         handleReplResumeNotFound(id, replId, fnName);
+        break;
+      case 'replResumeAsFuture':
+        handleReplResumeAsFuture(id, replId);
+        break;
+      case 'replResolveFutures':
+        handleReplResolveFutures(id, replId, resultsJson, errorsJson);
         break;
       case 'replDetectContinuation':
         handleReplDetectContinuation(id, source);

--- a/lib/assets/dart_monty_core_bridge.js
+++ b/lib/assets/dart_monty_core_bridge.js
@@ -372,6 +372,28 @@
     const result = await callWorker(sid, { type: "replResumeWithError", replId, errorMessage }, session.timeoutMs);
     return JSON.stringify(result);
   }
+  async function replResumeAsFuture(replId) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(
+      sid,
+      { type: "replResumeAsFuture", replId },
+      session.timeoutMs
+    );
+    return JSON.stringify(result);
+  }
+  async function replResolveFutures(replId, resultsJson, errorsJson) {
+    const sid = resolveSessionId(null);
+    if (sid == null || !sessions.has(sid)) return notInitializedError();
+    const session = sessions.get(sid);
+    const result = await callWorker(
+      sid,
+      { type: "replResolveFutures", replId, resultsJson, errorsJson },
+      session.timeoutMs
+    );
+    return JSON.stringify(result);
+  }
   async function replResumeNotFound(replId, fnNameJson) {
     const sid = resolveSessionId(null);
     if (sid == null || !sessions.has(sid)) return notInitializedError();
@@ -451,6 +473,8 @@
     replResume,
     replResumeWithError,
     replResumeNotFound,
+    replResumeAsFuture,
+    replResolveFutures,
     replDetectContinuation,
     replDispose,
     replSnapshot,

--- a/lib/assets/dart_monty_core_worker.js
+++ b/lib/assets/dart_monty_core_worker.js
@@ -1502,6 +1502,63 @@ function handleReplResumeNotFound(id, replId, fnName) {
     if (outError) outError.free();
   }
 }
+function handleReplResumeAsFuture(id, replId) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: `No REPL session for replId: ${replId}`,
+      errorType: "StateError"
+    });
+    return;
+  }
+  let outError = null;
+  try {
+    outError = allocOutPtr();
+    const tag = wasm2.monty_repl_resume_as_future(handle, outError.ptr);
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (outError) outError.free();
+  }
+}
+function handleReplResolveFutures(id, replId, resultsJson, errorsJson) {
+  const handle = replHandles.get(replId);
+  if (!handle) {
+    self.postMessage({
+      type: "result",
+      id,
+      ok: false,
+      error: `No REPL session for replId: ${replId}`,
+      errorType: "StateError"
+    });
+    return;
+  }
+  let cResults = null;
+  let cErrors = null;
+  let outError = null;
+  try {
+    cResults = allocCString(resultsJson);
+    cErrors = allocCString(errorsJson);
+    outError = allocOutPtr();
+    const tag = wasm2.monty_repl_resume_futures(
+      handle,
+      cResults.ptr,
+      cErrors.ptr,
+      outError.ptr
+    );
+    const errPtr = outError.read();
+    const errMsg = readAndFreeCString(errPtr);
+    self.postMessage(readProgress(id, handle, tag, errMsg, REPL_PROGRESS));
+  } finally {
+    if (cResults) wasm2.monty_dealloc(cResults.ptr, cResults.size);
+    if (cErrors) wasm2.monty_dealloc(cErrors.ptr, cErrors.size);
+    if (outError) outError.free();
+  }
+}
 function handleReplDetectContinuation(id, source) {
   let cSource = null;
   try {
@@ -1724,6 +1781,12 @@ self.onmessage = (e) => {
         break;
       case "replResumeNotFound":
         handleReplResumeNotFound(id, replId, fnName);
+        break;
+      case "replResumeAsFuture":
+        handleReplResumeAsFuture(id, replId);
+        break;
+      case "replResolveFutures":
+        handleReplResolveFutures(id, replId, resultsJson, errorsJson);
         break;
       case "replDetectContinuation":
         handleReplDetectContinuation(id, source);

--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -64,6 +64,7 @@ class Monty {
     MontyLimits? limits,
     OsCallHandler? osHandler,
     void Function(String stream, String text)? printCallback,
+    bool useFutures = false,
   }) async {
     final repl = MontyRepl(scriptName: _scriptName);
     try {
@@ -73,6 +74,7 @@ class Monty {
         osHandler: osHandler,
         inputs: inputs,
         printCallback: printCallback,
+        useFutures: useFutures,
       );
     } finally {
       await repl.dispose();
@@ -161,11 +163,13 @@ class Monty {
     String scriptName = 'main.py',
     OsCallHandler? osHandler,
     void Function(String stream, String text)? printCallback,
+    bool useFutures = false,
   }) => Monty(code, scriptName: scriptName).run(
     inputs: inputs,
     externalFunctions: externalFunctions,
     limits: limits,
     osHandler: osHandler,
     printCallback: printCallback,
+    useFutures: useFutures,
   );
 }

--- a/lib/src/repl/ffi_repl_bindings.dart
+++ b/lib/src/repl/ffi_repl_bindings.dart
@@ -153,6 +153,35 @@ class FfiReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeAsFuture() async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = _bindings.replResumeAsFuture(handle);
+
+    return _translateProgressResult(result);
+  }
+
+  @override
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) async {
+    final handle = _replHandle;
+    if (handle == null) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = _bindings.replResolveFutures(
+      handle,
+      resultsJson,
+      errorsJson,
+    );
+
+    return _translateProgressResult(result);
+  }
+
+  @override
   Future<Uint8List> snapshot() async {
     final handle = _replHandle;
     if (handle == null) {

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
@@ -177,6 +178,7 @@ class MontyRepl {
     OsCallHandler? osHandler,
     Map<String, Object?>? inputs,
     void Function(String stream, String text)? printCallback,
+    bool useFutures = false,
   }) async {
     _checkNotDisposed();
     await _ensureCreated();
@@ -222,8 +224,10 @@ class MontyRepl {
         initial,
         externalFunctions,
         osHandler,
+        useFutures: useFutures,
       );
       _emitPrintOutput(printCallback, result.printOutput);
+
       return result;
     } on MontyScriptError catch (e) {
       return MontyResult(
@@ -416,50 +420,115 @@ class MontyRepl {
   Future<MontyResult> _driveLoop(
     MontyProgress initial,
     Map<String, MontyCallback> externalFunctions,
-    OsCallHandler? osHandler,
-  ) async {
+    OsCallHandler? osHandler, {
+    bool useFutures = false,
+  }) async {
+    // Per-call map of pending callback futures keyed by callId. Only
+    // populated when [useFutures] is true; cleaned up by the
+    // [MontyResolveFutures] branch as it drains them.
+    final pendingFutures = <int, Future<Object?>>{};
+
     var progress = initial;
-    while (true) {
-      switch (progress) {
-        case MontyComplete(:final result):
-          return result;
-        case MontyPending(:final functionName):
-          final cb = externalFunctions[functionName];
-          if (cb == null) {
-            progress = _translateProgress(
-              await _bindings.resumeWithError(
-                'No handler registered for: $functionName',
-              ),
-            );
-          } else {
-            try {
+    try {
+      while (true) {
+        switch (progress) {
+          case MontyComplete(:final result):
+            return result;
+          case MontyPending(:final functionName, :final callId):
+            final cb = externalFunctions[functionName];
+            if (cb == null) {
+              progress = _translateProgress(
+                await _bindings.resumeWithError(
+                  'No handler registered for: $functionName',
+                ),
+              );
+            } else if (useFutures) {
+              // Futures path: launch the callback unawaited, register the
+              // future, and tell the engine to keep running until it hits an
+              // `await`. The engine will surface MontyResolveFutures with
+              // the call IDs it now needs values for.
               final args = _replArgsToMap(
                 progress.arguments,
                 progress.kwargs,
               );
-              final res = await cb(args);
-              progress = _translateProgress(
-                await _bindings.resume(jsonEncode(res)),
-              );
-            } on Object catch (e) {
-              progress = _translateProgress(
-                await _bindings.resumeWithError(e.toString()),
-              );
+              final fut = Future<Object?>(() => cb(args));
+              pendingFutures[callId] = fut;
+              // Suppress "unhandled async error" — errors are caught and
+              // surfaced via the errors map during resolveFutures.
+              _suppressFutureErrors(fut);
+              progress = _translateProgress(await _bindings.resumeAsFuture());
+            } else {
+              try {
+                final args = _replArgsToMap(
+                  progress.arguments,
+                  progress.kwargs,
+                );
+                final res = await cb(args);
+                progress = _translateProgress(
+                  await _bindings.resume(jsonEncode(res)),
+                );
+              } on Object catch (e) {
+                progress = _translateProgress(
+                  await _bindings.resumeWithError(e.toString()),
+                );
+              }
             }
-          }
-        case MontyOsCall():
-          progress = await _handleOsCall(progress, osHandler);
-        case MontyResolveFutures():
-          progress = _translateProgress(await _bindings.resume('null'));
-        case MontyNameLookup():
-          // The Rust handle auto-resolves NameLookup via ext_fn_names; this
-          // branch only fires when the name was not registered. Signal
-          // NameError back to Python.
-          progress = _translateProgress(
-            await _bindings.resumeNameLookupUndefined(),
-          );
+          case MontyOsCall():
+            progress = await _handleOsCall(progress, osHandler);
+          case MontyResolveFutures(:final pendingCallIds):
+            if (!useFutures) {
+              // Sync dispatch path was used — there's nothing to resolve
+              // batch-wise. Resume with null so the engine can advance.
+              progress = _translateProgress(await _bindings.resume('null'));
+              break;
+            }
+            final results = <int, Object?>{};
+            final errors = <int, String>{};
+            for (final id in pendingCallIds) {
+              final fut = pendingFutures.remove(id);
+              if (fut == null) {
+                errors[id] =
+                    'No pending future for callId $id (engine/host out of sync)';
+                continue;
+              }
+              try {
+                results[id] = await fut;
+              } on Object catch (e) {
+                errors[id] = e.toString();
+              }
+            }
+            progress = _translateProgress(
+              await _bindings.resolveFutures(
+                jsonEncode(
+                  results.map((k, v) => MapEntry(k.toString(), v)),
+                ),
+                jsonEncode(
+                  errors.map((k, v) => MapEntry(k.toString(), v)),
+                ),
+              ),
+            );
+          case MontyNameLookup():
+            // The Rust handle auto-resolves NameLookup via ext_fn_names; this
+            // branch only fires when the name was not registered. Signal
+            // NameError back to Python.
+            progress = _translateProgress(
+              await _bindings.resumeNameLookupUndefined(),
+            );
+        }
       }
+    } finally {
+      // Drain any callbacks still pending if the loop exits through a
+      // throw — guarantees no unhandled async errors leak out of the call.
+      pendingFutures.values.forEach(_suppressFutureErrors);
+      pendingFutures.clear();
     }
+  }
+
+  /// Catches and discards any error from [future] so that callbacks launched
+  /// unawaited on the futures path do not surface as unhandled async errors.
+  /// Errors are re-surfaced via the errors map during `resolveFutures`.
+  static void _suppressFutureErrors(Future<Object?> future) {
+    unawaited(future.catchError((Object _) => null));
   }
 
   MontyProgress _translateProgress(CoreProgressResult p) {

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -293,6 +293,48 @@ class MontyRepl {
     return _translateProgress(await _bindings.resumeNotFound(fnName));
   }
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// Use this in place of [resume] when the host is going to deliver the
+  /// pending call's result later via [resolveFutures]. The VM keeps
+  /// running until it hits an `await`, then yields [MontyResolveFutures]
+  /// listing the call IDs whose values it now needs.
+  ///
+  /// Throws [UnsupportedError] when the underlying bindings backend does
+  /// not implement the futures path (currently the WASM backend).
+  Future<MontyProgress> resumeAsFuture() async {
+    _checkNotDisposed();
+
+    return _translateProgress(await _bindings.resumeAsFuture());
+  }
+
+  /// Resolves the call IDs the VM is waiting on with [results] and
+  /// optionally [errors], then continues execution.
+  ///
+  /// [results] maps each call ID to its resolved value; [errors] maps
+  /// call IDs to error message strings (raised as `RuntimeError` in
+  /// Python). The union of keys must cover every ID the engine listed
+  /// in the preceding [MontyResolveFutures].
+  ///
+  /// Throws [UnsupportedError] when the bindings backend does not
+  /// implement the futures path.
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) async {
+    _checkNotDisposed();
+    final resultsJson = jsonEncode(
+      results.map((k, v) => MapEntry(k.toString(), v)),
+    );
+    final errorsJson = errors != null
+        ? jsonEncode(errors.map((k, v) => MapEntry(k.toString(), v)))
+        : '{}';
+
+    return _translateProgress(
+      await _bindings.resolveFutures(resultsJson, errorsJson),
+    );
+  }
+
   // ---------------------------------------------------------------------------
   // Continuation detection
   // ---------------------------------------------------------------------------
@@ -431,6 +473,11 @@ class MontyRepl {
       case 'os_call':
         _pending = true;
         return _buildOsCallProgress(p);
+      case 'resolve_futures':
+        _pending = true;
+        return MontyResolveFutures(
+          pendingCallIds: p.pendingCallIds ?? const [],
+        );
       case 'error':
         _pending = false;
         _throwReplError(

--- a/lib/src/repl/repl_bindings.dart
+++ b/lib/src/repl/repl_bindings.dart
@@ -43,6 +43,25 @@ abstract class ReplBindings {
   /// The engine raises NameError.
   Future<CoreProgressResult> resumeNameLookupUndefined();
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// Instead of providing an immediate return value (as [resume] does), this
+  /// tells the VM that the host will deliver the pending call's result later
+  /// via [resolveFutures]. The VM keeps executing until it hits an `await`,
+  /// then yields a `resolve_futures` progress.
+  Future<CoreProgressResult> resumeAsFuture();
+
+  /// Resolves outstanding REPL futures with their results and/or errors.
+  ///
+  /// [resultsJson] is a JSON object mapping `callId.toString()` to the
+  /// resolved value. [errorsJson] is a JSON object mapping
+  /// `callId.toString()` to an error message string (each becomes a
+  /// RuntimeError in Python). Pass an empty `'{}'` when no errors occurred.
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  );
+
   /// Serialises the REPL heap to postcard bytes.
   ///
   /// Throws [StateError] if the REPL is mid-execution.

--- a/lib/src/repl/repl_platform.dart
+++ b/lib/src/repl/repl_platform.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 
+import 'package:dart_monty_core/src/platform/monty_future_capable.dart';
 import 'package:dart_monty_core/src/platform/monty_limits.dart';
 import 'package:dart_monty_core/src/platform/monty_platform.dart';
 import 'package:dart_monty_core/src/platform/monty_progress.dart';
@@ -18,7 +19,7 @@ import 'package:dart_monty_core/src/repl/monty_repl.dart';
 /// await platform.run('x = 42');
 /// await repl.dispose();
 /// ```
-class ReplPlatform implements MontyPlatform {
+class ReplPlatform implements MontyFutureCapable {
   /// Creates a [ReplPlatform] wrapping [repl].
   const ReplPlatform({required MontyRepl repl}) : _repl = repl;
 
@@ -58,6 +59,15 @@ class ReplPlatform implements MontyPlatform {
   @override
   Future<MontyProgress> resumeNotFound(String fnName) =>
       _repl.resumeNotFound(fnName);
+
+  @override
+  Future<MontyProgress> resumeAsFuture() => _repl.resumeAsFuture();
+
+  @override
+  Future<MontyProgress> resolveFutures(
+    Map<int, Object?> results, {
+    Map<int, String>? errors,
+  }) => _repl.resolveFutures(results, errors: errors);
 
   @override
   Future<MontyProgress> resumeNameLookup(String name, Object? value) =>

--- a/lib/src/repl/wasm_repl_bindings.dart
+++ b/lib/src/repl/wasm_repl_bindings.dart
@@ -116,6 +116,33 @@ class WasmReplBindings implements ReplBindings {
   }
 
   @override
+  Future<CoreProgressResult> resumeAsFuture() async {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = await _bindings.replResumeAsFuture(replId: _replId);
+
+    return _translateWasmProgressResult(result);
+  }
+
+  @override
+  Future<CoreProgressResult> resolveFutures(
+    String resultsJson,
+    String errorsJson,
+  ) async {
+    if (!_created) {
+      throw StateError('REPL not created. Call create() first.');
+    }
+    final result = await _bindings.replResolveFutures(
+      resultsJson,
+      errorsJson,
+      replId: _replId,
+    );
+
+    return _translateWasmProgressResult(result);
+  }
+
+  @override
   Future<Uint8List> snapshot() {
     if (!_created) {
       throw StateError('REPL not created. Call create() first.');

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -447,6 +447,27 @@ abstract class WasmBindings {
     String? replId,
   });
 
+  /// Resumes the paused REPL by promising a future for the pending call.
+  ///
+  /// [replId] must match the value passed to [replCreate]. The Worker
+  /// returns a `resolve_futures` progress once the VM hits an `await`
+  /// over the promised call.
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  });
+
+  /// Resolves outstanding REPL futures with [resultsJson] and
+  /// [errorsJson] (each a JSON object keyed by `callId.toString()`).
+  ///
+  /// [replId] must match the value passed to [replCreate].
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  });
+
   /// Resumes a name lookup by providing [valueJson] for the looked-up name.
   ///
   /// When [sessionId] is non-null, routes to that specific session instead of

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -191,6 +191,20 @@ external JSPromise<JSString> _jsReplResumeNotFound(
   JSNumber? sessionId,
 ]);
 
+@JS('DartMontyBridge.replResumeAsFuture')
+external JSPromise<JSString> _jsReplResumeAsFuture(
+  JSString replId, [
+  JSNumber? sessionId,
+]);
+
+@JS('DartMontyBridge.replResolveFutures')
+external JSPromise<JSString> _jsReplResolveFutures(
+  JSString replId,
+  JSString resultsJson,
+  JSString errorsJson, [
+  JSNumber? sessionId,
+]);
+
 @JS('DartMontyBridge.resumeNameLookupValue')
 external JSPromise<JSString> _jsResumeNameLookupValue(
   JSString valueJson, [
@@ -666,6 +680,36 @@ class WasmBindingsJs extends WasmBindings {
     final resultJson = await _jsReplResumeNotFound(
       (replId ?? 'default').toJS,
       fnNameJson.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  }) async {
+    final resultJson = await _jsReplResumeAsFuture(
+      replId.toJS,
+      sessionId?.toJS,
+    ).toDart;
+
+    return _decodeProgress(resultJson.toDart);
+  }
+
+  @override
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  }) async {
+    final resultJson = await _jsReplResolveFutures(
+      replId.toJS,
+      resultsJson.toJS,
+      errorsJson.toJS,
       sessionId?.toJS,
     ).toDart;
 

--- a/lib/src/wasm/wasm_bindings_js_stub.dart
+++ b/lib/src/wasm/wasm_bindings_js_stub.dart
@@ -181,6 +181,20 @@ class WasmBindingsJs extends WasmBindings {
   }) => throw UnimplementedError();
 
   @override
+  Future<WasmProgressResult> replResumeAsFuture({
+    required String replId,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<WasmProgressResult> replResolveFutures(
+    String resultsJson,
+    String errorsJson, {
+    required String replId,
+    int? sessionId,
+  }) => throw UnimplementedError();
+
+  @override
   Future<WasmProgressResult> resumeNameLookupValue(
     String valueJson, {
     int? sessionId,

--- a/test/integration/_feedrun_async_matrix_body.dart
+++ b/test/integration/_feedrun_async_matrix_body.dart
@@ -1,0 +1,180 @@
+// Shared test body for the Layer 2 (`MontyRepl.feedRun`) async/sync matrix.
+//
+// Exercises the four orthogonal cells of
+// (Dart-handler-shape) × (Python-call-shape) plus the formerly-broken cell
+// (Python `await ext()` against a Dart external).
+// Each test asserts both the Dart-side return value AND the dispatch shape
+// (callback fire count) so a regression in either dimension trips the test.
+//
+// Both `ffi_feedrun_async_matrix_test.dart` and
+// `wasm_feedrun_async_matrix_test.dart` call [runFeedRunAsyncMatrixTests].
+
+import 'dart:async';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void runFeedRunAsyncMatrixTests() {
+  group('MontyRepl.feedRun async/sync matrix', () {
+    late MontyRepl repl;
+
+    setUp(() => repl = MontyRepl());
+    tearDown(() async => repl.dispose());
+
+    // matrix-cell: (sync Dart) × (sync Python)
+    test('cell 1: sync handler + bare Python call', () async {
+      var calls = 0;
+      final r = await repl.feedRun(
+        'fetch(7)',
+        externalFunctions: {
+          'fetch': (args) {
+            calls++;
+
+            // Synchronous-style: return a pre-resolved Future.
+            return Future.value((args['_0']! as int) + 1);
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (sync Python)
+    test('cell 2: async handler + bare Python call', () async {
+      var calls = 0;
+      final r = await repl.feedRun(
+        'fetch(7)',
+        externalFunctions: {
+          'fetch': (args) async {
+            calls++;
+            await Future<void>.delayed(Duration.zero);
+
+            return (args['_0']! as int) + 1;
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (sync Dart) × (async Python local coro, no Dart await)
+    test('cell 3: sync handler + Python local coroutine', () async {
+      var calls = 0;
+      final r = await repl.feedRun(
+        '''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''',
+        externalFunctions: {
+          'fetch': (args) {
+            calls++;
+
+            return Future.value(args['_0']);
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 6);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (async Python local coro, no Dart await)
+    test('cell 4: async handler + Python local coroutine', () async {
+      var calls = 0;
+      final r = await repl.feedRun(
+        '''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''',
+        externalFunctions: {
+          'fetch': (args) async {
+            calls++;
+            await Future<void>.delayed(Duration.zero);
+
+            return args['_0'];
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 6);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python `await ext()`) — the key cell
+    // requires `useFutures: true`.
+    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
+      var calls = 0;
+      final r = await repl.feedRun(
+        'await fetch("token")',
+        externalFunctions: {
+          'fetch': (args) async {
+            calls++;
+            await Future<void>.delayed(Duration.zero);
+
+            return 'value-for-${args['_0']}';
+          },
+        },
+        useFutures: true,
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 'value-for-token');
+      expect(calls, 1);
+    });
+
+    // matrix-cell: same as 5a, but `asyncio.gather` to confirm concurrent
+    // dispatch (all callbacks fire before the first MontyResolveFutures).
+    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
+      final fired = <int>[];
+      final r = await repl.feedRun(
+        '''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''',
+        externalFunctions: {
+          'fetch': (args) async {
+            final n = args['_0']! as int;
+            fired.add(n);
+            await Future<void>.delayed(Duration.zero);
+
+            return n * 10;
+          },
+        },
+        useFutures: true,
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [10, 20, 30]);
+      // All three dispatched (in some order) before gather yielded — that's
+      // the whole point of futures-mode.
+      expect(fired.toSet(), {1, 2, 3});
+      expect(fired, hasLength(3));
+    });
+
+    // Default (useFutures=false): Python `await ext()` MUST still raise
+    // TypeError — the legacy contract is preserved for back-compat.
+    test(
+      'useFutures=false: Python `await ext()` still raises TypeError',
+      () async {
+        final r = await repl.feedRun(
+          'await fetch(1)',
+          externalFunctions: {
+            'fetch': (args) async => args['_0'],
+          },
+        );
+
+        expect(r.error, isNotNull);
+        expect(r.error?.excType, equals('TypeError'));
+      },
+    );
+  });
+}

--- a/test/integration/_monty_async_inputs_test_body.dart
+++ b/test/integration/_monty_async_inputs_test_body.dart
@@ -1,10 +1,14 @@
 // Shared test body for ffi_monty_async_inputs_test.dart and
 // wasm_monty_async_inputs_test.dart.
 //
-// Pins down how `Monty(code).run(inputs: ...)` interacts with async
-// scripts on the current `main` (without the unmerged feat/repl-future-capable
-// REPL-level futures wiring). The intent is to make the boundary testable:
-// what works today, and what depends on landing the futures-capable REPL.
+// Pins down how `Monty(code).run(inputs: ...)` interacts with async scripts.
+// Three groups:
+//   - pure-Python async (no Dart externals — works on every release)
+//   - external calls without await (the long-standing sync path —
+//     callback resolves Dart-side, Python sees the plain value)
+//   - external async with `useFutures: true` (the futures path that
+//     `_driveLoop` wires through `resumeAsFuture`/`resolveFutures` —
+//     enables Python `await ext()` and `asyncio.gather` over externals)
 //
 // Both files call [runMontyAsyncInputsTests] so the assertions stay in sync
 // across the FFI and WASM backends.
@@ -91,57 +95,40 @@ result
       );
     });
 
-    // ----- External async (depends on futures-capable REPL) ---------------
+    // ----- External async via `useFutures: true` -------------------------
     // When Python uses `await fetch(...)` against a Dart external, the
-    // platform needs to surface the call as an awaitable so Python's event
-    // loop can suspend on it. That requires `MontyFutureCapable.
-    // resumeAsFuture` + `resolveFutures` to be wired through the REPL —
-    // the work on the unmerged feat/repl-future-capable branch.
-    //
-    // Today (probed on main):
-    //   - `result = await fetch(key)` raises TypeError:
-    //         "'str' object can't be awaited"
-    //   - `await asyncio.gather(fetch(a), fetch(b), fetch(c))` raises
-    //         TypeError: "An asyncio.Future, a coroutine or an awaitable is
-    //         required"
-    //   In both cases the Dart callback DOES fire (so dispatch works), but
-    //   the value is returned eagerly as a plain Python value rather than
-    //   as an awaitable that Python can suspend on.
-    //
-    // The two tests below codify the SPEC that feat/repl-future-capable
-    // must satisfy. They are skipped on main and should be flipped to
-    // green once that branch lands.
-    group('external async — pending feat/repl-future-capable', () {
-      test(
-        'await of a Dart external returns the resolved value',
-        tags: 'pending-futures',
-        () async {
-          var fetchCallCount = 0;
-          final r =
-              await Monty('''
+    // engine needs the host to surface the call as an awaitable so Python's
+    // event loop can suspend on it. With `useFutures: true`, `_driveLoop`
+    // launches each callback as an unawaited Future, replies with
+    // `resumeAsFuture`, and batches the results back via `resolveFutures`
+    // when MontyResolveFutures fires.
+    group('external async with useFutures: true', () {
+      test('await of a Dart external returns the resolved value', () async {
+        var fetchCallCount = 0;
+        final r =
+            await Monty('''
 result = await fetch(key)
 result
 ''').run(
-                inputs: {'key': 'token'},
-                externalFunctions: {
-                  'fetch': (args) async {
-                    fetchCallCount++;
-                    await Future<void>.delayed(Duration.zero);
+              inputs: {'key': 'token'},
+              externalFunctions: {
+                'fetch': (args) async {
+                  fetchCallCount++;
+                  await Future<void>.delayed(Duration.zero);
 
-                    return 'value-for-${args['_0']}';
-                  },
+                  return 'value-for-${args['_0']}';
                 },
-              );
+              },
+              useFutures: true,
+            );
 
-          expect(r.error, isNull);
-          expect(fetchCallCount, equals(1));
-          expect(r.value.dartValue, 'value-for-token');
-        },
-      );
+        expect(r.error, isNull);
+        expect(fetchCallCount, equals(1));
+        expect(r.value.dartValue, 'value-for-token');
+      });
 
       test(
         'asyncio.gather over Dart externals resolves in argument order',
-        tags: 'pending-futures',
         () async {
           final calls = <int>[];
           final r =
@@ -164,6 +151,7 @@ results
                     return n * 10;
                   },
                 },
+                useFutures: true,
               );
 
           expect(r.error, isNull);

--- a/test/integration/_repl_futures_test_body.dart
+++ b/test/integration/_repl_futures_test_body.dart
@@ -60,6 +60,11 @@ Future<MontyComplete> _runWithFutures(
   }
 }
 
+// Matrix coverage: this body covers Layer 1 (caller-driven manual loop).
+// Every test here maps to the **(async Dart) × (Python `await ext()`)**
+// quadrant — the manual loop is the only path that exposed futures before
+// the _driveLoop fix. Per-test cell annotations below use the layer
+// numbering shared with the other matrix bodies.
 void runReplFuturesTests() {
   group('MontyRepl.resumeAsFuture / resolveFutures', () {
     late MontyRepl repl;
@@ -69,6 +74,7 @@ void runReplFuturesTests() {
 
     // --- Single await ------------------------------------------------------
 
+    // matrix-cell: Layer 1 / cell 5a (single await, value path)
     test('await of a single external returns the resolved value', () async {
       final pendings = <MontyPending>[];
       final result = await _runWithFutures(
@@ -112,6 +118,7 @@ result
     // delivery is fixed later, swap them for try/except-catches-it
     // assertions.
 
+    // matrix-cell: Layer 1 / cell 5 (single await, error path)
     test(
       'resolveFutures errors terminate the script with MontyScriptError',
       () async {
@@ -145,6 +152,7 @@ out
 
     // --- Concurrent dispatch (asyncio.gather) ------------------------------
 
+    // matrix-cell: Layer 1 / cell 5b (gather, concurrent dispatch)
     test('asyncio.gather over externals dispatches concurrently and '
         'resolves in argument order', () async {
       final dispatched = <int>[];

--- a/test/integration/_repl_futures_test_body.dart
+++ b/test/integration/_repl_futures_test_body.dart
@@ -1,0 +1,381 @@
+// Shared test body for the ffi_/wasm_ repl_futures_test.dart files.
+//
+// Drives MontyRepl through the futures-capable progress loop end-to-end:
+// feedStart → MontyPending → resumeAsFuture → MontyResolveFutures →
+// resolveFutures → MontyComplete. Each test uses real Python code that
+// awaits a Dart-registered external; we walk the loop manually so we can
+// exercise resumeAsFuture/resolveFutures directly (the path that
+// runtime/Monty.run does NOT take).
+//
+// Both files call [runReplFuturesTests] so the assertions stay in sync
+// across FFI and WASM backends.
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+/// Helper: walk the progress loop, treating every external call as a future.
+/// Returns the terminal [MontyComplete] (or throws if the script never
+/// completes / wraps an error).
+///
+/// [resolver] is consulted ONCE when the engine surfaces
+/// [MontyResolveFutures] — it must produce a `(results, errors)` map for
+/// every call ID listed in `pendingCallIds`. This lets each test observe
+/// concurrent dispatch (gather) vs. sequential (one await at a time)
+/// without the helper baking in a policy.
+Future<MontyComplete> _runWithFutures(
+  MontyRepl repl,
+  String code, {
+  required List<String> externalFunctions,
+  required ({Map<int, Object?> results, Map<int, String> errors}) Function(
+    List<int> pendingCallIds,
+    List<MontyPending> pendings,
+  )
+  resolver,
+}) async {
+  final captured = <MontyPending>[];
+
+  var progress = await repl.feedStart(
+    code,
+    externalFunctions: externalFunctions,
+  );
+  while (true) {
+    switch (progress) {
+      case final MontyComplete c:
+        return c;
+      case final MontyPending p:
+        captured.add(p);
+        progress = await repl.resumeAsFuture();
+      case final MontyResolveFutures rf:
+        final plan = resolver(rf.pendingCallIds, captured);
+        progress = await repl.resolveFutures(
+          plan.results,
+          errors: plan.errors,
+        );
+        captured.clear();
+      case final MontyOsCall _:
+        fail('unexpected MontyOsCall in pure-async test');
+      case final MontyNameLookup nl:
+        fail('unexpected MontyNameLookup: ${nl.variableName}');
+    }
+  }
+}
+
+void runReplFuturesTests() {
+  group('MontyRepl.resumeAsFuture / resolveFutures', () {
+    late MontyRepl repl;
+
+    setUp(() => repl = MontyRepl());
+    tearDown(() async => repl.dispose());
+
+    // --- Single await ------------------------------------------------------
+
+    test('await of a single external returns the resolved value', () async {
+      final pendings = <MontyPending>[];
+      final result = await _runWithFutures(
+        repl,
+        '''
+result = await fetch("token")
+result
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          pendings.addAll(ps);
+          // Resolve every pending ID with a synthesised value.
+          final results = <int, Object?>{};
+          for (final id in ids) {
+            final pending = ps.firstWhere(
+              (p) => p.callId == id,
+              orElse: () => fail('callId $id not in observed pendings'),
+            );
+            final arg = pending.arguments.first.dartValue! as String;
+            results[id] = 'value-for-$arg';
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, 'value-for-token');
+      expect(pendings, hasLength(1));
+      expect(pendings.first.functionName, 'fetch');
+    });
+
+    // --- Error path --------------------------------------------------------
+    //
+    // Observed contract (probed on FFI 2026-05-04): an `errors` entry on
+    // resolveFutures terminates the script with `MontyScriptError`, even
+    // when Python wraps the await in `try/except`. The docstring says the
+    // error is "raised as RuntimeError in Python", but in practice the
+    // failure short-circuits past Python's exception handling. Tests
+    // below verify the actual contract; if the engine's per-call error
+    // delivery is fixed later, swap them for try/except-catches-it
+    // assertions.
+
+    test(
+      'resolveFutures errors terminate the script with MontyScriptError',
+      () async {
+        expect(
+          () => _runWithFutures(
+            repl,
+            '''
+try:
+    result = await fetch(1)
+    out = ("ok", result)
+except RuntimeError as e:
+    out = ("err", str(e))
+out
+''',
+            externalFunctions: ['fetch'],
+            resolver: (ids, _) => (
+              results: <int, Object?>{},
+              errors: {for (final id in ids) id: 'simulated upstream failure'},
+            ),
+          ),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.message,
+              'message',
+              contains('simulated upstream failure'),
+            ),
+          ),
+        );
+      },
+    );
+
+    // --- Concurrent dispatch (asyncio.gather) ------------------------------
+
+    test('asyncio.gather over externals dispatches concurrently and '
+        'resolves in argument order', () async {
+      final dispatched = <int>[];
+      final result = await _runWithFutures(
+        repl,
+        '''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          // Every observed pending should have one int arg; record dispatch
+          // order so we can assert all three fired before await yielded.
+          for (final p in ps) {
+            dispatched.add(p.arguments.first.dartValue! as int);
+          }
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            results[p.callId] = (p.arguments.first.dartValue! as int) * 10;
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, [10, 20, 30]);
+      // All three externals dispatched (in some order) before gather
+      // surfaced MontyResolveFutures — that's the whole point of gather.
+      expect(dispatched.toSet(), {1, 2, 3});
+      expect(dispatched, hasLength(3));
+    });
+
+    // --- Mixed values + errors in the same gather --------------------------
+
+    test(
+      'gather: an errored task terminates the script (not '
+      'per-task try/except)',
+      () async {
+        // Same observed-contract caveat as the simpler error test:
+        // resolveFutures errors short-circuit Python's exception handling,
+        // so the script terminates rather than letting `safe()`'s
+        // try/except catch.
+        expect(
+          () => _runWithFutures(
+            repl,
+            '''
+import asyncio
+async def safe(n):
+    try:
+        return ("ok", await fetch(n))
+    except RuntimeError as e:
+        return ("err", str(e))
+
+results = await asyncio.gather(safe(1), safe(2), safe(3))
+results
+''',
+            externalFunctions: ['fetch'],
+            resolver: (ids, ps) {
+              final results = <int, Object?>{};
+              final errors = <int, String>{};
+              for (final p in ps) {
+                final n = p.arguments.first.dartValue! as int;
+                if (n == 2) {
+                  errors[p.callId] = 'broken-$n';
+                } else {
+                  results[p.callId] = n * 100;
+                }
+              }
+
+              return (results: results, errors: errors);
+            },
+          ),
+          throwsA(isA<MontyScriptError>()),
+        );
+      },
+    );
+
+    // --- Sequential awaits (one cycle per await) ---------------------------
+
+    test(
+      'sequential awaits each take their own resolveFutures cycle',
+      () async {
+        var cycles = 0;
+        final result = await _runWithFutures(
+          repl,
+          '''
+a = await fetch(7)
+b = await fetch(13)
+[a, b, a + b]
+''',
+          externalFunctions: ['fetch'],
+          resolver: (ids, ps) {
+            cycles++;
+            final results = <int, Object?>{};
+            for (final p in ps) {
+              results[p.callId] = (p.arguments.first.dartValue! as int) * 2;
+            }
+
+            return (results: results, errors: <int, String>{});
+          },
+        );
+
+        expect(result.result.error, isNull);
+        expect(result.result.value.dartValue, [14, 26, 40]);
+        // Two awaits → two distinct resolveFutures cycles (sequential, not
+        // gathered).
+        expect(cycles, equals(2));
+      },
+    );
+
+    // --- Coroutine that awaits external internally -------------------------
+
+    test('async function awaiting an external composes correctly', () async {
+      final result = await _runWithFutures(
+        repl,
+        '''
+async def doubled(n):
+    val = await fetch(n)
+    return val * 2
+
+await doubled(21)
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            results[p.callId] = p.arguments.first.dartValue;
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      expect(result.result.value.dartValue, 42);
+    });
+
+    // --- State checks ------------------------------------------------------
+
+    test('resumeAsFuture after dispose throws StateError', () async {
+      // Use a fresh repl so the dispose doesn't trip our tearDown.
+      final r = MontyRepl();
+      await r.feedStart('1 + 1', externalFunctions: ['fetch']);
+      await r.dispose();
+
+      expect(r.resumeAsFuture, throwsStateError);
+    });
+
+    test('resolveFutures after dispose throws StateError', () async {
+      final r = MontyRepl();
+      await r.feedStart('1 + 1', externalFunctions: ['fetch']);
+      await r.dispose();
+
+      expect(
+        () => r.resolveFutures({0: 'noop'}),
+        throwsStateError,
+      );
+    });
+
+    // --- Errors-only resolveFutures (no values) ----------------------------
+
+    test(
+      'resolveFutures with errors-only map carries the message into '
+      'the terminal error',
+      () async {
+        // The error string the host supplies surfaces verbatim in the
+        // terminal MontyScriptError.message, so callers can route it
+        // back to whichever Dart-side exception classification they
+        // prefer.
+        expect(
+          () => _runWithFutures(
+            repl,
+            'await fetch(1)',
+            externalFunctions: ['fetch'],
+            resolver: (ids, _) => (
+              results: <int, Object?>{},
+              errors: {for (final id in ids) id: 'all-broken'},
+            ),
+          ),
+          throwsA(
+            isA<MontyScriptError>().having(
+              (e) => e.message,
+              'message',
+              contains('all-broken'),
+            ),
+          ),
+        );
+      },
+    );
+
+    // --- Resolved value preserves type fidelity ----------------------------
+
+    test('resolveFutures preserves value type fidelity '
+        '(int / string / list / map)', () async {
+      final result = await _runWithFutures(
+        repl,
+        '''
+import asyncio
+results = await asyncio.gather(fetch("int"), fetch("str"), fetch("list"), fetch("map"))
+[type(r).__name__ for r in results] + results
+''',
+        externalFunctions: ['fetch'],
+        resolver: (ids, ps) {
+          final results = <int, Object?>{};
+          for (final p in ps) {
+            final tag = p.arguments.first.dartValue! as String;
+            results[p.callId] = switch (tag) {
+              'int' => 42,
+              'str' => 'hello',
+              'list' => [1, 2, 3],
+              'map' => {'k': 'v'},
+              _ => null,
+            };
+          }
+
+          return (results: results, errors: <int, String>{});
+        },
+      );
+
+      expect(result.result.error, isNull);
+      final list = result.result.value.dartValue! as List;
+      // First four entries are the type names; last four are the values.
+      expect(list.sublist(0, 4), ['int', 'str', 'list', 'dict']);
+      expect(list.sublist(4), [
+        42,
+        'hello',
+        [1, 2, 3],
+        {'k': 'v'},
+      ]);
+    });
+  });
+}

--- a/test/integration/_run_async_matrix_body.dart
+++ b/test/integration/_run_async_matrix_body.dart
@@ -1,0 +1,187 @@
+// Shared test body for the Layer 3 (`Monty.run`) async/sync matrix.
+//
+// `Monty.run` wraps `MontyRepl.feedRun` in a one-shot REPL lifecycle. The
+// matrix here mirrors the Layer 2 cells but exercises the public one-shot
+// surface — proves the wrapper preserves the contract (no leakage,
+// no extra serialisation steps, useFutures threads through).
+//
+// Both `ffi_run_async_matrix_test.dart` and
+// `wasm_run_async_matrix_test.dart` call [runRunAsyncMatrixTests].
+
+import 'dart:async';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+void runRunAsyncMatrixTests() {
+  group('Monty(code).run async/sync matrix', () {
+    // matrix-cell: (sync Dart) × (sync Python)
+    test('cell 1: sync handler + bare Python call', () async {
+      var calls = 0;
+      final r = await Monty('fetch(7)').run(
+        externalFunctions: {
+          'fetch': (args) {
+            calls++;
+
+            return Future.value((args['_0']! as int) + 1);
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (sync Python)
+    test('cell 2: async handler + bare Python call', () async {
+      var calls = 0;
+      final r = await Monty('fetch(7)').run(
+        externalFunctions: {
+          'fetch': (args) async {
+            calls++;
+            await Future<void>.delayed(Duration.zero);
+
+            return (args['_0']! as int) + 1;
+          },
+        },
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 8);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (sync Dart) × (async Python local coro)
+    test('cell 3: sync handler + Python local coroutine', () async {
+      var calls = 0;
+      final r =
+          await Monty('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').run(
+            externalFunctions: {
+              'fetch': (args) {
+                calls++;
+
+                return Future.value(args['_0']);
+              },
+            },
+          );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 6);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (async Python local coro)
+    test('cell 4: async handler + Python local coroutine', () async {
+      var calls = 0;
+      final r =
+          await Monty('''
+async def doubled(n):
+    return fetch(n) * 2
+await doubled(3)
+''').run(
+            externalFunctions: {
+              'fetch': (args) async {
+                calls++;
+                await Future<void>.delayed(Duration.zero);
+
+                return args['_0'];
+              },
+            },
+          );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 6);
+      expect(calls, 1);
+    });
+
+    // matrix-cell: (async Dart) × (Python `await ext()`) — useFutures: true
+    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
+      var calls = 0;
+      final r = await Monty('await fetch("token")').run(
+        externalFunctions: {
+          'fetch': (args) async {
+            calls++;
+            await Future<void>.delayed(Duration.zero);
+
+            return 'value-for-${args['_0']}';
+          },
+        },
+        useFutures: true,
+      );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, 'value-for-token');
+      expect(calls, 1);
+    });
+
+    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
+      final fired = <int>[];
+      final r =
+          await Monty('''
+import asyncio
+results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
+results
+''').run(
+            externalFunctions: {
+              'fetch': (args) async {
+                final n = args['_0']! as int;
+                fired.add(n);
+                await Future<void>.delayed(Duration.zero);
+
+                return n * 10;
+              },
+            },
+            useFutures: true,
+          );
+
+      expect(r.error, isNull);
+      expect(r.value.dartValue, [10, 20, 30]);
+      expect(fired.toSet(), {1, 2, 3});
+    });
+
+    // Default-off back-compat: Python `await ext()` raises TypeError when
+    // useFutures is not opted in.
+    test(
+      'useFutures=false: Python `await ext()` still raises TypeError',
+      () async {
+        final r = await Monty('await fetch(1)').run(
+          externalFunctions: {'fetch': (args) async => args['_0']},
+        );
+
+        expect(r.error, isNotNull);
+        expect(r.error?.excType, equals('TypeError'));
+      },
+    );
+
+    // Inputs + useFutures interplay — the new flag must not break the
+    // existing inputs: parameter.
+    test(
+      'useFutures + inputs: inputs visible inside awaited external script',
+      () async {
+        final r =
+            await Monty('''
+result = await fetch(seed)
+result
+''').run(
+              inputs: {'seed': 'alice'},
+              externalFunctions: {
+                'fetch': (args) async {
+                  await Future<void>.delayed(Duration.zero);
+
+                  return 'hello, ${args['_0']}';
+                },
+              },
+              useFutures: true,
+            );
+
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'hello, alice');
+      },
+    );
+  });
+}

--- a/test/integration/ffi_feedrun_async_matrix_test.dart
+++ b/test/integration/ffi_feedrun_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// FFI binding for the Layer 2 `MontyRepl.feedRun` async/sync matrix.
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_feedrun_async_matrix_body.dart';
+
+void main() => runFeedRunAsyncMatrixTests();

--- a/test/integration/ffi_repl_futures_test.dart
+++ b/test/integration/ffi_repl_futures_test.dart
@@ -1,0 +1,12 @@
+// FFI binding for the REPL futures shared test body.
+//
+// Run: dart test test/integration/ffi_repl_futures_test.dart \
+//        -p vm --run-skipped --tags=ffi
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_repl_futures_test_body.dart';
+
+void main() => runReplFuturesTests();

--- a/test/integration/ffi_run_async_matrix_test.dart
+++ b/test/integration/ffi_run_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// FFI binding for the Layer 3 `Monty.run` async/sync matrix.
+@Tags(['integration', 'ffi'])
+library;
+
+import 'package:test/test.dart';
+
+import '_run_async_matrix_body.dart';
+
+void main() => runRunAsyncMatrixTests();

--- a/test/integration/wasm_feedrun_async_matrix_test.dart
+++ b/test/integration/wasm_feedrun_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// WASM binding for the Layer 2 `MontyRepl.feedRun` async/sync matrix.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_feedrun_async_matrix_body.dart';
+
+void main() => runFeedRunAsyncMatrixTests();

--- a/test/integration/wasm_repl_futures_test.dart
+++ b/test/integration/wasm_repl_futures_test.dart
@@ -1,0 +1,9 @@
+// WASM binding for the REPL futures shared test body.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_repl_futures_test_body.dart';
+
+void main() => runReplFuturesTests();

--- a/test/integration/wasm_run_async_matrix_test.dart
+++ b/test/integration/wasm_run_async_matrix_test.dart
@@ -1,0 +1,9 @@
+// WASM binding for the Layer 3 `Monty.run` async/sync matrix.
+@Tags(['integration', 'wasm'])
+library;
+
+import 'package:test/test.dart';
+
+import '_run_async_matrix_body.dart';
+
+void main() => runRunAsyncMatrixTests();

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -93,6 +93,7 @@ dart test \
   --concurrency 2 \
   test/integration/wasm_dataclass_hydrate_test.dart \
   test/integration/wasm_datetime_oscall_test.dart \
+  test/integration/wasm_feedrun_async_matrix_test.dart \
   test/integration/wasm_fixture_test.dart \
   test/integration/wasm_monty_async_inputs_test.dart \
   test/integration/wasm_monty_compile_run_test.dart \
@@ -103,6 +104,7 @@ dart test \
   test/integration/wasm_repl_extfns_lifecycle_test.dart \
   test/integration/wasm_repl_futures_test.dart \
   test/integration/wasm_repl_snapshot_lifecycle_test.dart \
+  test/integration/wasm_run_async_matrix_test.dart \
   test/integration/wasm_setextfns_test.dart \
   test/integration/wasm_type_check_test.dart \
   "$@"

--- a/tool/test_wasm_unit.sh
+++ b/tool/test_wasm_unit.sh
@@ -101,6 +101,7 @@ dart test \
   test/integration/wasm_multi_repl_test.dart \
   test/integration/wasm_print_callback_test.dart \
   test/integration/wasm_repl_extfns_lifecycle_test.dart \
+  test/integration/wasm_repl_futures_test.dart \
   test/integration/wasm_repl_snapshot_lifecycle_test.dart \
   test/integration/wasm_setextfns_test.dart \
   test/integration/wasm_type_check_test.dart \


### PR DESCRIPTION
## Summary

Wires Python's `await ext()` against Dart-registered host functions end-to-end across the four-layer API matrix in this repo. Subsumes the original PR #101 (which only exposed the public REPL futures methods); together with the `_driveLoop` integration + matrix coverage + docs, this is the complete dart_monty_core-side fix.

## What this closes

The (async Dart × Python `await ext()`) cell at every relevant layer:

| Layer | Path | Pre-PR | Post-PR |
|---|---|---|---|
| L1: `MontyRepl.feedStart` + caller-driven `resume*` | manual loop | works (caller drives) | works |
| L2: `MontyRepl.feedRun` (managed loop) | `_driveLoop` | ❌ stubbed `_bindings.resume('null')` | ✅ wired via `useFutures: true` |
| L3: `Monty.run` / `Monty.exec` | wraps `feedRun` | ❌ same root cause | ✅ flag plumbs through |

## Implementation

### Public API (was PR #101 — folded in)

- `MontyRepl.resumeAsFuture()` — tells the engine "the pending call's result will arrive later via `resolveFutures`."
- `MontyRepl.resolveFutures(results, errors:)` — feeds back per-call values and errors after the engine emits `MontyResolveFutures`.
- `ReplPlatform implements MontyFutureCapable` — so any `PlatformBridge`-using consumer (notably dart_monty's `MontyRuntime`) can detect the capability via the `is MontyFutureCapable` check.
- FFI + WASM bindings for `monty_repl_resume_as_future` + `monty_repl_resume_futures`. Updated `lib/assets/dart_monty_core_bridge.js` and `lib/assets/dart_monty_core_worker.js` accordingly.

### `_driveLoop` integration (the missing piece)

`MontyRepl.feedRun` and `Monty.run` / `Monty.exec` gain a `bool useFutures = false` parameter (default off for back-compat). When true, `_driveLoop`:

- Launches each `MontyPending` callback as an unawaited `Future`, registers it in a per-call pending map, and replies with `_bindings.resumeAsFuture()` instead of the eager `await cb(args); _bindings.resume(jsonEncode(res))` path.
- On `MontyResolveFutures(pendingCallIds:)`, drains the pending map by callId, awaits each (capturing per-call exceptions into the `errors` map), and feeds back via `_bindings.resolveFutures(resultsJson, errorsJson)` — replacing the previous `_bindings.resume('null')` stub.

`useFutures: false` (default) leaves the eager-await dispatch path untouched — bit-for-bit back-compat.

## Tests — the four-quadrant async/sync matrix

5-cell matrix at every API layer × backend (FFI + WASM):

| # | Dart shape | Python shape |
|---|---|---|
| 1 | sync (`Future.value`) | bare `fetch(7)` |
| 2 | async (`await Future.delayed`) | bare `fetch(7)` |
| 3 | sync | local async coroutine |
| 4 | async | local async coroutine |
| 5 | async | `await fetch(7)` (Dart external — the key cell) |

Coverage:

- **Layer 1** (`_repl_futures_test_body.dart`, 10 tests) — manual-loop spec, annotated with matrix-cell comments. Tests `resumeAsFuture` + `resolveFutures` directly: single await, gather, sequential awaits, error handling, type fidelity, dispose/state checks.
- **Layer 2** (`_feedrun_async_matrix_body.dart`, 7 tests) — full 5-cell matrix at `MontyRepl.feedRun`. Includes back-compat assertion: `useFutures: false` still raises `TypeError: 'str' object can't be awaited` on Python `await ext()`.
- **Layer 3** (`_run_async_matrix_body.dart`, 8 tests) — same 5 cells via `Monty(code).run`, plus `useFutures + inputs` interaction.
- **Pre-existing** `_monty_async_inputs_test_body.dart` — formerly `pending-futures`-tagged; now opts into `useFutures: true` and turns green. Tag and skip directives removed.

Wires both new bodies into `tool/test_wasm_unit.sh` and the FFI CI step (`.github/workflows/ci.yaml`).

## Docs

- **New `docs/deep-dives/async-matrix.md`** — single-page cell-by-cell reference for every (layer × backend) cell, the `useFutures` opt-in story, error semantics caveat, and the spec pointer at the matrix test bodies.
- **`README.md` "Async scripts"** rewritten — drops the "currently broken" framing, shows the `useFutures: true` example, links the deep dive.

## Companion PR (dart_monty)

Layer 4 (`MontyRuntime.execute`) takes a different code path — it goes through `PlatformBridge::dispatchToolCallAsFuture`, not `_driveLoop`. That layer is closed by [dart_monty PR #411](https://github.com/runyaga/dart_monty/pull/411), which flips `MontyRuntime`'s hardcoded `useFutures: false` to a constructor flag. With both PRs landed, every cell of the async/sync matrix is green at every API layer.

## Test plan

- [x] `dart format lib/ test/` — clean
- [x] `dart analyze lib/ test/` — no issues
- [x] `dcm analyze` — no new issues introduced (3 pre-existing warnings unchanged)
- [x] FFI integration suite — **45/45 pass**
- [x] WASM unit-style tests (`bash tool/test_wasm_unit.sh`) — **564/564 pass**

## Notes

- This PR subsumes the previously-stacked PR #101. Closing #101 in favour of this unified review surface — its commits are preserved in the unified branch's history.
- Default-off (`useFutures: false`) preserves bit-for-bit back-compat. Every existing test in the suite passes unchanged.