### PR TITLE
feat(repl): parallel-map dispatch, drop useFutures from feedRun/run/exec

### DIFF
--- a/lib/src/monty.dart
+++ b/lib/src/monty.dart
@@ -61,20 +61,20 @@ class Monty {
   Future<MontyResult> run({
     Map<String, Object?>? inputs,
     Map<String, MontyCallback> externalFunctions = const {},
+    Map<String, MontyCallback> externalAsyncFunctions = const {},
     MontyLimits? limits,
     OsCallHandler? osHandler,
     void Function(String stream, String text)? printCallback,
-    bool useFutures = false,
   }) async {
     final repl = MontyRepl(scriptName: _scriptName);
     try {
       return await repl.feedRun(
         _code,
         externalFunctions: externalFunctions,
+        externalAsyncFunctions: externalAsyncFunctions,
         osHandler: osHandler,
         inputs: inputs,
         printCallback: printCallback,
-        useFutures: useFutures,
       );
     } finally {
       await repl.dispose();
@@ -159,17 +159,17 @@ class Monty {
     String code, {
     Map<String, Object?>? inputs,
     Map<String, MontyCallback> externalFunctions = const {},
+    Map<String, MontyCallback> externalAsyncFunctions = const {},
     MontyLimits? limits,
     String scriptName = 'main.py',
     OsCallHandler? osHandler,
     void Function(String stream, String text)? printCallback,
-    bool useFutures = false,
   }) => Monty(code, scriptName: scriptName).run(
     inputs: inputs,
     externalFunctions: externalFunctions,
+    externalAsyncFunctions: externalAsyncFunctions,
     limits: limits,
     osHandler: osHandler,
     printCallback: printCallback,
-    useFutures: useFutures,
   );
 }

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -175,13 +175,22 @@ class MontyRepl {
   Future<MontyResult> feedRun(
     String code, {
     Map<String, MontyCallback> externalFunctions = const {},
+    Map<String, MontyCallback> externalAsyncFunctions = const {},
     OsCallHandler? osHandler,
     Map<String, Object?>? inputs,
     void Function(String stream, String text)? printCallback,
-    bool useFutures = false,
   }) async {
     _checkNotDisposed();
     await _ensureCreated();
+    final overlap = externalFunctions.keys.toSet().intersection(
+      externalAsyncFunctions.keys.toSet(),
+    );
+    if (overlap.isNotEmpty) {
+      throw ArgumentError(
+        'externalFunctions and externalAsyncFunctions must be disjoint; '
+        'overlapping keys: $overlap',
+      );
+    }
     final effectiveCode = inputs != null && inputs.isNotEmpty
         ? '${inputs_encoder.inputsToCode(inputs)}\n$code'
         : code;
@@ -191,10 +200,15 @@ class MontyRepl {
     // this, names registered in a previous feed leak into the next
     // feed's NameLookup auto-resolve and surface as a confusing
     // "no handler registered" error instead of NameError.
-    await _bindings.setExtFns(externalFunctions.keys.toList());
+    await _bindings.setExtFns([
+      ...externalFunctions.keys,
+      ...externalAsyncFunctions.keys,
+    ]);
 
     try {
-      if (externalFunctions.isEmpty && osHandler == null) {
+      if (externalFunctions.isEmpty &&
+          externalAsyncFunctions.isEmpty &&
+          osHandler == null) {
         // Fast path: no externalFunctions, use simple feedRun.
         final r = await _bindings.feedRun(effectiveCode);
         _pending = false;
@@ -223,8 +237,8 @@ class MontyRepl {
       final result = await _driveLoop(
         initial,
         externalFunctions,
+        externalAsyncFunctions,
         osHandler,
-        useFutures: useFutures,
       );
       _emitPrintOutput(printCallback, result.printOutput);
 
@@ -420,12 +434,12 @@ class MontyRepl {
   Future<MontyResult> _driveLoop(
     MontyProgress initial,
     Map<String, MontyCallback> externalFunctions,
-    OsCallHandler? osHandler, {
-    bool useFutures = false,
-  }) async {
-    // Per-call map of pending callback futures keyed by callId. Only
-    // populated when [useFutures] is true; cleaned up by the
-    // [MontyResolveFutures] branch as it drains them.
+    Map<String, MontyCallback> externalAsyncFunctions,
+    OsCallHandler? osHandler,
+  ) async {
+    // Per-call map of pending futures keyed by callId. Populated only for
+    // callbacks registered in externalAsyncFunctions; drained by the
+    // MontyResolveFutures branch.
     final pendingFutures = <int, Future<Object?>>{};
 
     var progress = initial;
@@ -435,14 +449,16 @@ class MontyRepl {
           case MontyComplete(:final result):
             return result;
           case MontyPending(:final functionName, :final callId):
-            final cb = externalFunctions[functionName];
+            final asyncCb = externalAsyncFunctions[functionName];
+            final syncCb = externalFunctions[functionName];
+            final cb = asyncCb ?? syncCb;
             if (cb == null) {
               progress = _translateProgress(
                 await _bindings.resumeWithError(
                   'No handler registered for: $functionName',
                 ),
               );
-            } else if (useFutures) {
+            } else if (asyncCb != null) {
               // Futures path: launch the callback unawaited, register the
               // future, and tell the engine to keep running until it hits an
               // `await`. The engine will surface MontyResolveFutures with
@@ -451,7 +467,7 @@ class MontyRepl {
                 progress.arguments,
                 progress.kwargs,
               );
-              final fut = Future<Object?>(() => cb(args));
+              final fut = Future<Object?>(() => asyncCb(args));
               pendingFutures[callId] = fut;
               // Suppress "unhandled async error" — errors are caught and
               // surfaced via the errors map during resolveFutures.
@@ -463,7 +479,7 @@ class MontyRepl {
                   progress.arguments,
                   progress.kwargs,
                 );
-                final res = await cb(args);
+                final res = await syncCb!(args);
                 progress = _translateProgress(
                   await _bindings.resume(jsonEncode(res)),
                 );
@@ -476,9 +492,9 @@ class MontyRepl {
           case MontyOsCall():
             progress = await _handleOsCall(progress, osHandler);
           case MontyResolveFutures(:final pendingCallIds):
-            if (!useFutures) {
-              // Sync dispatch path was used — there's nothing to resolve
-              // batch-wise. Resume with null so the engine can advance.
+            if (pendingFutures.isEmpty) {
+              // No async callbacks were registered — nothing to resolve.
+              // Resume with null so the engine can advance.
               progress = _translateProgress(await _bindings.resume('null'));
               break;
             }

--- a/test/integration/_feedrun_async_matrix_body.dart
+++ b/test/integration/_feedrun_async_matrix_body.dart
@@ -108,67 +108,71 @@ await doubled(3)
       expect(calls, 1);
     });
 
-    // matrix-cell: (async Dart) × (Python `await ext()`) — the key cell
-    // requires `useFutures: true`.
-    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
-      var calls = 0;
-      final r = await repl.feedRun(
-        'await fetch("token")',
-        externalFunctions: {
-          'fetch': (args) async {
-            calls++;
-            await Future<void>.delayed(Duration.zero);
+    // matrix-cell: (async Dart) × (Python `await ext()`) — register the
+    // callback in externalAsyncFunctions so _driveLoop uses resumeAsFuture.
+    test(
+      'cell 5a: externalAsyncFunctions wires Python `await fetch(x)`',
+      () async {
+        var calls = 0;
+        final r = await repl.feedRun(
+          'await fetch("token")',
+          externalAsyncFunctions: {
+            'fetch': (args) async {
+              calls++;
+              await Future<void>.delayed(Duration.zero);
 
-            return 'value-for-${args['_0']}';
+              return 'value-for-${args['_0']}';
+            },
           },
-        },
-        useFutures: true,
-      );
+        );
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, 'value-for-token');
-      expect(calls, 1);
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'value-for-token');
+        expect(calls, 1);
+      },
+    );
 
     // matrix-cell: same as 5a, but `asyncio.gather` to confirm concurrent
     // dispatch (all callbacks fire before the first MontyResolveFutures).
-    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
-      final fired = <int>[];
-      final r = await repl.feedRun(
-        '''
+    test(
+      'cell 5b: externalAsyncFunctions + asyncio.gather over externals',
+      () async {
+        final fired = <int>[];
+        final r = await repl.feedRun(
+          '''
 import asyncio
 results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
 results
 ''',
-        externalFunctions: {
-          'fetch': (args) async {
-            final n = args['_0']! as int;
-            fired.add(n);
-            await Future<void>.delayed(Duration.zero);
+          externalAsyncFunctions: {
+            'fetch': (args) async {
+              final n = args['_0']! as int;
+              fired.add(n);
+              await Future<void>.delayed(Duration.zero);
 
-            return n * 10;
+              return n * 10;
+            },
           },
-        },
-        useFutures: true,
-      );
+        );
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, [10, 20, 30]);
-      // All three dispatched (in some order) before gather yielded — that's
-      // the whole point of futures-mode.
-      expect(fired.toSet(), {1, 2, 3});
-      expect(fired, hasLength(3));
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, [10, 20, 30]);
+        // All three dispatched (in some order) before gather yielded — that's
+        // the whole point of async dispatch.
+        expect(fired.toSet(), {1, 2, 3});
+        expect(fired, hasLength(3));
+      },
+    );
 
-    // Default (useFutures=false): Python `await ext()` MUST still raise
-    // TypeError — the legacy contract is preserved for back-compat.
+    // Back-compat: handler in externalFunctions (sync dispatch) → Python
+    // `await ext()` still raises TypeError.
     test(
-      'useFutures=false: Python `await ext()` still raises TypeError',
+      'externalFunctions (sync): Python `await ext()` still raises TypeError',
       () async {
         final r = await repl.feedRun(
           'await fetch(1)',
           externalFunctions: {
-            'fetch': (args) async => args['_0'],
+            'fetch': (args) => Future.value(args['_0']),
           },
         );
 

--- a/test/integration/_monty_async_inputs_test_body.dart
+++ b/test/integration/_monty_async_inputs_test_body.dart
@@ -6,7 +6,7 @@
 //   - pure-Python async (no Dart externals — works on every release)
 //   - external calls without await (the long-standing sync path —
 //     callback resolves Dart-side, Python sees the plain value)
-//   - external async with `useFutures: true` (the futures path that
+//   - external async via externalAsyncFunctions (the futures path that
 //     `_driveLoop` wires through `resumeAsFuture`/`resolveFutures` —
 //     enables Python `await ext()` and `asyncio.gather` over externals)
 //
@@ -95,14 +95,14 @@ result
       );
     });
 
-    // ----- External async via `useFutures: true` -------------------------
+    // ----- External async via externalAsyncFunctions --------------------
     // When Python uses `await fetch(...)` against a Dart external, the
     // engine needs the host to surface the call as an awaitable so Python's
-    // event loop can suspend on it. With `useFutures: true`, `_driveLoop`
-    // launches each callback as an unawaited Future, replies with
-    // `resumeAsFuture`, and batches the results back via `resolveFutures`
-    // when MontyResolveFutures fires.
-    group('external async with useFutures: true', () {
+    // event loop can suspend on it. Registering the callback in
+    // externalAsyncFunctions causes _driveLoop to launch each callback as
+    // an unawaited Future, reply with resumeAsFuture, and batch the results
+    // back via resolveFutures when MontyResolveFutures fires.
+    group('external async with externalAsyncFunctions', () {
       test('await of a Dart external returns the resolved value', () async {
         var fetchCallCount = 0;
         final r =
@@ -111,7 +111,7 @@ result = await fetch(key)
 result
 ''').run(
               inputs: {'key': 'token'},
-              externalFunctions: {
+              externalAsyncFunctions: {
                 'fetch': (args) async {
                   fetchCallCount++;
                   await Future<void>.delayed(Duration.zero);
@@ -119,7 +119,6 @@ result
                   return 'value-for-${args['_0']}';
                 },
               },
-              useFutures: true,
             );
 
         expect(r.error, isNull);
@@ -142,7 +141,7 @@ results = await asyncio.gather(
 results
 ''').run(
                 inputs: {'a': 1, 'b': 2, 'c': 3},
-                externalFunctions: {
+                externalAsyncFunctions: {
                   'fetch': (args) async {
                     final n = args['_0']! as int;
                     calls.add(n);
@@ -151,7 +150,6 @@ results
                     return n * 10;
                   },
                 },
-                useFutures: true,
               );
 
           expect(r.error, isNull);

--- a/test/integration/_run_async_matrix_body.dart
+++ b/test/integration/_run_async_matrix_body.dart
@@ -3,7 +3,7 @@
 // `Monty.run` wraps `MontyRepl.feedRun` in a one-shot REPL lifecycle. The
 // matrix here mirrors the Layer 2 cells but exercises the public one-shot
 // surface — proves the wrapper preserves the contract (no leakage,
-// no extra serialisation steps, useFutures threads through).
+// no extra serialisation steps, externalAsyncFunctions threads through).
 //
 // Both `ffi_run_async_matrix_test.dart` and
 // `wasm_run_async_matrix_test.dart` call [runRunAsyncMatrixTests].
@@ -99,58 +99,63 @@ await doubled(3)
       expect(calls, 1);
     });
 
-    // matrix-cell: (async Dart) × (Python `await ext()`) — useFutures: true
-    test('cell 5a: useFutures=true wires Python `await fetch(x)`', () async {
-      var calls = 0;
-      final r = await Monty('await fetch("token")').run(
-        externalFunctions: {
-          'fetch': (args) async {
-            calls++;
-            await Future<void>.delayed(Duration.zero);
+    // matrix-cell: (async Dart) × (Python `await ext()`) — register the
+    // callback in externalAsyncFunctions so _driveLoop uses resumeAsFuture.
+    test(
+      'cell 5a: externalAsyncFunctions wires Python `await fetch(x)`',
+      () async {
+        var calls = 0;
+        final r = await Monty('await fetch("token")').run(
+          externalAsyncFunctions: {
+            'fetch': (args) async {
+              calls++;
+              await Future<void>.delayed(Duration.zero);
 
-            return 'value-for-${args['_0']}';
+              return 'value-for-${args['_0']}';
+            },
           },
-        },
-        useFutures: true,
-      );
+        );
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, 'value-for-token');
-      expect(calls, 1);
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, 'value-for-token');
+        expect(calls, 1);
+      },
+    );
 
-    test('cell 5b: useFutures=true + asyncio.gather over externals', () async {
-      final fired = <int>[];
-      final r =
-          await Monty('''
+    test(
+      'cell 5b: externalAsyncFunctions + asyncio.gather over externals',
+      () async {
+        final fired = <int>[];
+        final r =
+            await Monty('''
 import asyncio
 results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
 results
 ''').run(
-            externalFunctions: {
-              'fetch': (args) async {
-                final n = args['_0']! as int;
-                fired.add(n);
-                await Future<void>.delayed(Duration.zero);
+              externalAsyncFunctions: {
+                'fetch': (args) async {
+                  final n = args['_0']! as int;
+                  fired.add(n);
+                  await Future<void>.delayed(Duration.zero);
 
-                return n * 10;
+                  return n * 10;
+                },
               },
-            },
-            useFutures: true,
-          );
+            );
 
-      expect(r.error, isNull);
-      expect(r.value.dartValue, [10, 20, 30]);
-      expect(fired.toSet(), {1, 2, 3});
-    });
+        expect(r.error, isNull);
+        expect(r.value.dartValue, [10, 20, 30]);
+        expect(fired.toSet(), {1, 2, 3});
+      },
+    );
 
-    // Default-off back-compat: Python `await ext()` raises TypeError when
-    // useFutures is not opted in.
+    // Back-compat: handler in externalFunctions (sync) → Python `await ext()`
+    // still raises TypeError.
     test(
-      'useFutures=false: Python `await ext()` still raises TypeError',
+      'externalFunctions (sync): Python `await ext()` still raises TypeError',
       () async {
         final r = await Monty('await fetch(1)').run(
-          externalFunctions: {'fetch': (args) async => args['_0']},
+          externalFunctions: {'fetch': (args) => Future.value(args['_0'])},
         );
 
         expect(r.error, isNotNull);
@@ -158,10 +163,10 @@ results
       },
     );
 
-    // Inputs + useFutures interplay — the new flag must not break the
-    // existing inputs: parameter.
+    // externalAsyncFunctions + inputs interplay — confirm the two parameters
+    // compose correctly.
     test(
-      'useFutures + inputs: inputs visible inside awaited external script',
+      'externalAsyncFunctions + inputs: inputs visible inside awaited external',
       () async {
         final r =
             await Monty('''
@@ -169,14 +174,13 @@ result = await fetch(seed)
 result
 ''').run(
               inputs: {'seed': 'alice'},
-              externalFunctions: {
+              externalAsyncFunctions: {
                 'fetch': (args) async {
                   await Future<void>.delayed(Duration.zero);
 
                   return 'hello, ${args['_0']}';
                 },
               },
-              useFutures: true,
             );
 
         expect(r.error, isNull);


### PR DESCRIPTION
## Summary

Removes the `useFutures: bool` parameter from `MontyRepl.feedRun`, `Monty.run`, and `Monty.exec`. Callers now declare intent through two separate maps:

- `externalFunctions` — sync dispatch (Dart Future resolved before Python resumes; same behaviour as before)
- `externalAsyncFunctions` — async dispatch (enables Python `await ext()` and `asyncio.gather` over Dart externals)

Key changes:

- `feedRun` accepts `externalAsyncFunctions`, enforces disjointness with `externalFunctions` (`ArgumentError` on overlap), calls `setExtFns` with the union of both key sets
- `_driveLoop` dispatches on which map the function name appears in; `MontyResolveFutures` branch guarded by `pendingFutures.isEmpty` (replaces `!useFutures` guard)
- Fast path (both maps empty + no osHandler) preserved
- `Monty.run` and `Monty.exec` forwarded identically
- Matrix tests (`_feedrun_async_matrix_body.dart`, `_run_async_matrix_body.dart`, `_monty_async_inputs_test_body.dart`): cells 5a/5b moved to `externalAsyncFunctions:`; back-compat cells stay in `externalFunctions:`

Closes #103 tracks the follow-up rename `externalFunctions` → `externalSyncFunctions`.

## Test plan

- [ ] `dart test` passes on FFI and WASM targets
- [ ] `dcm analyze lib` clean
- [ ] `dart format --set-exit-if-changed .` clean