### PR TITLE
feat(api): MontyCallback(args, kwargs) — parity with pydantic-monty *args/**kwargs

### DIFF
--- a/example/03_externals_and_os.dart
+++ b/example/03_externals_and_os.dart
@@ -22,10 +22,10 @@ Future<void> main() async {
 }
 
 // ── External functions ────────────────────────────────────────────────────────
-// MontyCallback = Future<Object?> Function(Map<String, Object?> args)
+// MontyCallback = Future<Object?> Function(List<Object?> args, Map<String, Object?>? kwargs)
 //
-// Positional args arrive as '_0', '_1', ... in the map.
-// Keyword args arrive under their Python names.
+// Positional args arrive in the args list.
+// Keyword args arrive in the kwargs map.
 Future<void> _externalFunctions() async {
   print('\n── externalFunctions ──');
 
@@ -37,11 +37,11 @@ result = add(3, 4)
 greeting = greet(name="World")
 ''',
     externalFunctions: {
-      // Synchronous-style: return the value directly.
-      'add': (args) async => (args['_0'] as int) + (args['_1'] as int),
+      // Positional args arrive in the args list.
+      'add': (args, _) async => (args[0]! as int) + (args[1]! as int),
 
-      // Keyword args land under their Python names.
-      'greet': (args) async => 'Hello, ${args['name']}!',
+      // Keyword args land in the kwargs map.
+      'greet': (_, kwargs) async => 'Hello, ${kwargs!['name']}!',
     },
   );
 
@@ -52,7 +52,7 @@ greeting = greet(name="World")
   await repl.feedRun(
     'data = fetch_data()',
     externalFunctions: {
-      'fetch_data': (_) async => {
+      'fetch_data': (_, _) async => {
         'name': 'alice',
         'scores': [98, 87, 92],
       },

--- a/example/04_session.dart
+++ b/example/04_session.dart
@@ -61,16 +61,16 @@ result = a + b
 
       case MontyPending(
         :final functionName,
-        :final arguments,
+        :final args,
         kwargs: _,
         :final callId,
         :final methodCall,
       ):
         callCount++;
         print(
-          '  call #$callId: $functionName(${arguments.map((a) => a.dartValue)})  method=$methodCall',
+          '  call #$callId: $functionName(${args.map((a) => a.dartValue)})  method=$methodCall',
         );
-        final n = arguments.first.dartValue as int;
+        final n = args.first.dartValue as int;
         // Resume with the computed value. It must be JSON-encodable.
         progress = await repl.resume(n * 2);
 
@@ -140,7 +140,7 @@ content = pathlib.Path("/data/notes.txt").read_text()
         repl.dispose();
         return;
 
-      case MontyOsCall(:final operationName, arguments: _):
+      case MontyOsCall(:final operationName, args: _):
         // Intercept and handle the OS call manually.
         Object? value;
         if (operationName == 'Path.read_text') {

--- a/example/04_session.dart
+++ b/example/04_session.dart
@@ -27,7 +27,7 @@ Future<void> _autoDispatch() async {
 
   await repl.feedRun(
     'greeting = greet("Dart")',
-    externalFunctions: {'greet': (args) async => 'Hi, ${args["_0"]}!'},
+    externalFunctions: {'greet': (args, _) async => 'Hi, ${args[0]}!'},
   );
   print('auto: ${(await repl.feedRun("greeting")).value}');
   repl.dispose();

--- a/example/05_repl.dart
+++ b/example/05_repl.dart
@@ -40,7 +40,7 @@ Future<void> _basicFeed() async {
   // Externals auto-dispatched — no manual loop needed.
   await repl.feedRun(
     'result = double(x)',
-    externalFunctions: {'double': (args) async => (args['_0'] as int) * 2},
+    externalFunctions: {'double': (args, _) async => (args[0]! as int) * 2},
   );
   print('double(42) = ${(await repl.feedRun("result")).value}'); // 84
 

--- a/example/05_repl.dart
+++ b/example/05_repl.dart
@@ -103,9 +103,9 @@ Future<void> _manualFeedLoop() async {
         await repl.dispose();
         return;
 
-      case MontyPending(:final functionName, :final arguments):
+      case MontyPending(:final functionName, :final args):
         step++;
-        final n = arguments.first.dartValue as int;
+        final n = args.first.dartValue as int;
         print('  step $step: $functionName($n) → ${n * 10}');
         progress = await repl.resume(n * 10); // return value
 

--- a/example/06_compile_and_platform.dart
+++ b/example/06_compile_and_platform.dart
@@ -153,7 +153,7 @@ asyncio.run(main())
           final results = <int, Object?>{};
           for (final id in pendingCallIds) {
             final call = pendingCalls[id]!;
-            results[id] = call.arguments.first.dartValue; // echo the name arg
+            results[id] = call.args.first.dartValue; // echo the name arg
           }
           progress = await platform.resolveFutures(results);
 

--- a/example/10_dataclasses.dart
+++ b/example/10_dataclasses.dart
@@ -72,10 +72,10 @@ Future<void> _readingFields() async {
 
   final r = await Monty('make_user("alice", 30)').run(
     externalFunctions: {
-      'make_user': (args) async => _dataclass(
+      'make_user': (args, _) async => _dataclass(
         name: 'User',
         typeId: 1,
-        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+        attrs: {'name': args[0]! as String, 'age': args[1]! as int},
       ),
     },
   );
@@ -97,10 +97,10 @@ Future<void> _hydrateOne() async {
 
   final r = await Monty('make_user("bob", 42)').run(
     externalFunctions: {
-      'make_user': (args) async => _dataclass(
+      'make_user': (args, _) async => _dataclass(
         name: 'User',
         typeId: 1,
-        attrs: {'name': args['_0']! as String, 'age': args['_1']! as int},
+        attrs: {'name': args[0]! as String, 'age': args[1]! as int},
       ),
     },
   );
@@ -130,9 +130,9 @@ Future<void> _hydrateRegistry() async {
   }
 
   final externalFunctions = <String, MontyCallback>{
-    'make_user': (a) async =>
+    'make_user': (_, _) async =>
         _dataclass(name: 'User', typeId: 1, attrs: {'name': 'carol', 'age': 7}),
-    'make_order': (a) async =>
+    'make_order': (_, _) async =>
         _dataclass(name: 'Order', typeId: 2, attrs: {'id': 99, 'total': 12.5}),
   };
 

--- a/lib/src/externals.dart
+++ b/lib/src/externals.dart
@@ -5,10 +5,12 @@ export 'package:dart_monty_core/src/platform/os_call_exception.dart';
 
 /// A callback invoked when Python calls a registered host function.
 ///
-/// Receives the named arguments map from Python. Return value is
-/// serialized back to Python as the function's return value.
+/// [args] are the positional arguments in call order; [kwargs] are the
+/// keyword arguments by name (`null` when the call site used no kwargs).
+/// Return value is serialized back to Python as the function's return value.
 /// Return `null` to return `None` to Python.
-typedef MontyCallback = Future<Object?> Function(Map<String, Object?> args);
+typedef MontyCallback =
+    Future<Object?> Function(List<Object?> args, Map<String, Object?>? kwargs);
 
 /// A callback invoked when Python performs an OS operation (filesystem,
 /// environment, datetime).

--- a/lib/src/ffi/ffi_core_bindings.dart
+++ b/lib/src/ffi/ffi_core_bindings.dart
@@ -375,7 +375,7 @@ class FfiCoreBindings implements MontyCoreBindings {
     return CoreProgressResult(
       state: 'pending',
       functionName: progress.functionName ?? '',
-      arguments: args,
+      args: args,
       kwargs: kwargs,
       callId: progress.callId ?? 0,
       methodCall: progress.methodCall ?? false,
@@ -441,7 +441,7 @@ class FfiCoreBindings implements MontyCoreBindings {
     return CoreProgressResult(
       state: 'os_call',
       functionName: progress.functionName ?? '',
-      arguments: args,
+      args: args,
       kwargs: kwargs,
       callId: progress.callId ?? 0,
     );

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -426,7 +426,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
 
     return MontyPending(
       functionName: p.functionName ?? '',
-      arguments: _parseArgList(p.arguments),
+      args: _parseArgList(p.arguments),
       kwargs: _parseKwargMap(p.kwargs),
       callId: p.callId ?? 0,
       methodCall: p.methodCall ?? false,
@@ -438,7 +438,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
 
     return MontyOsCall(
       operationName: p.functionName ?? '',
-      arguments: _parseArgList(p.arguments),
+      args: _parseArgList(p.arguments),
       kwargs: _parseKwargMap(p.kwargs),
       callId: p.callId ?? 0,
     );

--- a/lib/src/platform/base_monty_platform.dart
+++ b/lib/src/platform/base_monty_platform.dart
@@ -426,7 +426,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
 
     return MontyPending(
       functionName: p.functionName ?? '',
-      args: _parseArgList(p.arguments),
+      args: _parseArgList(p.args),
       kwargs: _parseKwargMap(p.kwargs),
       callId: p.callId ?? 0,
       methodCall: p.methodCall ?? false,
@@ -438,7 +438,7 @@ abstract class BaseMontyPlatform extends MontyPlatform with MontyStateMixin {
 
     return MontyOsCall(
       operationName: p.functionName ?? '',
-      args: _parseArgList(p.arguments),
+      args: _parseArgList(p.args),
       kwargs: _parseKwargMap(p.kwargs),
       callId: p.callId ?? 0,
     );

--- a/lib/src/platform/core_bindings.dart
+++ b/lib/src/platform/core_bindings.dart
@@ -68,7 +68,7 @@ final class CoreRunResult {
 /// populated:
 ///
 /// - `'complete'` — [value] holds the Python return value.
-/// - `'pending'` — [functionName], [arguments], [kwargs], [callId], and
+/// - `'pending'` — [functionName], [args], [kwargs], [callId], and
 ///   [methodCall] describe the external function call.
 /// - `'resolve_futures'` — [pendingCallIds] lists call IDs awaiting
 ///   resolution.
@@ -83,7 +83,7 @@ final class CoreProgressResult {
     this.usage,
     this.printOutput,
     this.functionName,
-    this.arguments,
+    this.args,
     this.kwargs,
     this.callId,
     this.methodCall,
@@ -114,7 +114,7 @@ final class CoreProgressResult {
   final String? functionName;
 
   /// Positional arguments (when [state] is `'pending'`).
-  final List<Object?>? arguments;
+  final List<Object?>? args;
 
   /// Keyword arguments (when [state] is `'pending'`).
   final Map<String, Object?>? kwargs;

--- a/lib/src/platform/mock_monty_platform.dart
+++ b/lib/src/platform/mock_monty_platform.dart
@@ -136,7 +136,7 @@ final class MockCallHistory {
 /// For [start], [resume], and [resumeWithError], enqueue progress values
 /// using [enqueueProgress]:
 /// ```dart
-/// mock.enqueueProgress(MontyPending(functionName: 'fetch', arguments: []));
+/// mock.enqueueProgress(MontyPending(functionName: 'fetch', args: []));
 /// mock.enqueueProgress(MontyComplete(result: result));
 /// ```
 class MockMontyPlatform extends MontyPlatform

--- a/lib/src/platform/monty_progress.dart
+++ b/lib/src/platform/monty_progress.dart
@@ -21,10 +21,10 @@ const _deepEquality = DeepCollectionEquality();
 /// switch (progress) {
 ///   case MontyComplete(:final result):
 ///     print(result.value);
-///   case MontyPending(:final functionName, :final arguments):
-///     print('Call $functionName with $arguments');
-///   case MontyOsCall(:final operationName, :final arguments):
-///     print('OS call: $operationName with $arguments');
+///   case MontyPending(:final functionName, :final args):
+///     print('Call $functionName with $args');
+///   case MontyOsCall(:final operationName, :final args):
+///     print('OS call: $operationName with $args');
 ///   case MontyResolveFutures(:final pendingCallIds):
 ///     print('Resolve futures: $pendingCallIds');
 ///   case MontyNameLookup(:final variableName):
@@ -129,7 +129,7 @@ final class MontyPending extends MontyProgress {
   /// Creates a [MontyPending] from a JSON map.
   ///
   /// Expected keys: `type` (must be `'pending'`), `function_name`,
-  /// `arguments` (list, defaults to empty if absent), `kwargs` (map,
+  /// `arguments` (list, decoded into [args]), `kwargs` (map,
   /// optional), `call_id` (int, defaults to 0), `method_call` (bool,
   /// defaults to false).
   factory MontyPending.fromJson(Map<String, dynamic> json) {

--- a/lib/src/platform/monty_progress.dart
+++ b/lib/src/platform/monty_progress.dart
@@ -117,10 +117,10 @@ final class MontyComplete extends MontyProgress {
 /// ```
 @immutable
 final class MontyPending extends MontyProgress {
-  /// Creates a [MontyPending] with the given [functionName] and [arguments].
+  /// Creates a [MontyPending] with the given [functionName] and [args].
   const MontyPending({
     required this.functionName,
-    required this.arguments,
+    required this.args,
     this.kwargs,
     this.callId = 0,
     this.methodCall = false,
@@ -138,7 +138,7 @@ final class MontyPending extends MontyProgress {
 
     return MontyPending(
       functionName: json['function_name'] as String,
-      arguments: rawArgs != null
+      args: rawArgs != null
           ? rawArgs.map(MontyValue.fromJson).toList()
           : const [],
       kwargs: rawKwargs?.map((k, v) => MapEntry(k, MontyValue.fromJson(v))),
@@ -151,7 +151,7 @@ final class MontyPending extends MontyProgress {
   final String functionName;
 
   /// The positional arguments to pass to the external function.
-  final List<MontyValue> arguments;
+  final List<MontyValue> args;
 
   /// Keyword arguments from the Python call site.
   ///
@@ -174,7 +174,7 @@ final class MontyPending extends MontyProgress {
     return {
       'type': 'pending',
       'function_name': functionName,
-      'arguments': arguments.map((e) => e.toJson()).toList(),
+      'arguments': args.map((e) => e.toJson()).toList(),
       if (kwargs != null)
         'kwargs': kwargs!.map((k, v) => MapEntry(k, v.toJson())),
       if (callId != 0) 'call_id': callId,
@@ -187,7 +187,7 @@ final class MontyPending extends MontyProgress {
     return identical(this, other) ||
         (other is MontyPending &&
             other.functionName == functionName &&
-            _deepEquality.equals(other.arguments, arguments) &&
+            _deepEquality.equals(other.args, args) &&
             _deepEquality.equals(other.kwargs, kwargs) &&
             other.callId == callId &&
             other.methodCall == methodCall);
@@ -196,14 +196,14 @@ final class MontyPending extends MontyProgress {
   @override
   int get hashCode => Object.hash(
     functionName,
-    _deepEquality.hash(arguments),
+    _deepEquality.hash(args),
     _deepEquality.hash(kwargs),
     callId,
     methodCall,
   );
 
   @override
-  String toString() => 'MontyPending($functionName, $arguments)';
+  String toString() => 'MontyPending($functionName, $args)';
 }
 
 /// Execution paused, awaiting an OS/filesystem operation.
@@ -213,13 +213,13 @@ final class MontyPending extends MontyProgress {
 /// The host (Dart) handles the I/O and resumes with the result.
 ///
 /// ```dart
-/// case MontyOsCall(:final operationName, :final arguments):
+/// case MontyOsCall(:final operationName, :final args):
 ///   switch (operationName) {
 ///     case 'Path.exists':
-///       final path = arguments.first as String;
+///       final path = args.first as String;
 ///       progress = await platform.resume(File(path).existsSync());
 ///     case 'os.getenv':
-///       final key = arguments.first as String;
+///       final key = args.first as String;
 ///       progress = await platform.resume(Platform.environment[key]);
 ///   }
 /// ```
@@ -228,7 +228,7 @@ final class MontyOsCall extends MontyProgress {
   /// Creates a [MontyOsCall].
   const MontyOsCall({
     required this.operationName,
-    required this.arguments,
+    required this.args,
     this.kwargs,
     this.callId = 0,
   });
@@ -240,7 +240,7 @@ final class MontyOsCall extends MontyProgress {
 
     return MontyOsCall(
       operationName: json['operation_name'] as String,
-      arguments: rawArgs != null
+      args: rawArgs != null
           ? rawArgs.map(MontyValue.fromJson).toList()
           : const [],
       kwargs: rawKwargs?.map((k, v) => MapEntry(k, MontyValue.fromJson(v))),
@@ -252,7 +252,7 @@ final class MontyOsCall extends MontyProgress {
   final String operationName;
 
   /// The positional arguments for the operation.
-  final List<MontyValue> arguments;
+  final List<MontyValue> args;
 
   /// Keyword arguments from the Python call site.
   final Map<String, MontyValue>? kwargs;
@@ -265,7 +265,7 @@ final class MontyOsCall extends MontyProgress {
     return {
       'type': 'os_call',
       'operation_name': operationName,
-      'arguments': arguments.map((e) => e.toJson()).toList(),
+      'arguments': args.map((e) => e.toJson()).toList(),
       if (kwargs != null)
         'kwargs': kwargs!.map((k, v) => MapEntry(k, v.toJson())),
       if (callId != 0) 'call_id': callId,
@@ -277,7 +277,7 @@ final class MontyOsCall extends MontyProgress {
     return identical(this, other) ||
         (other is MontyOsCall &&
             other.operationName == operationName &&
-            _deepEquality.equals(other.arguments, arguments) &&
+            _deepEquality.equals(other.args, args) &&
             _deepEquality.equals(other.kwargs, kwargs) &&
             other.callId == callId);
   }
@@ -285,13 +285,13 @@ final class MontyOsCall extends MontyProgress {
   @override
   int get hashCode => Object.hash(
     operationName,
-    _deepEquality.hash(arguments),
+    _deepEquality.hash(args),
     _deepEquality.hash(kwargs),
     callId,
   );
 
   @override
-  String toString() => 'MontyOsCall($operationName, $arguments)';
+  String toString() => 'MontyOsCall($operationName, $args)';
 }
 
 /// Execution paused, awaiting resolution of pending futures.

--- a/lib/src/repl/ffi_repl_bindings.dart
+++ b/lib/src/repl/ffi_repl_bindings.dart
@@ -262,7 +262,7 @@ class FfiReplBindings implements ReplBindings {
         return CoreProgressResult(
           state: 'os_call',
           functionName: progress.functionName,
-          arguments: parsedArgs,
+          args: parsedArgs,
           kwargs: parsedKwargs,
           callId: progress.callId,
         );
@@ -310,7 +310,7 @@ class FfiReplBindings implements ReplBindings {
     return CoreProgressResult(
       state: 'pending',
       functionName: progress.functionName,
-      arguments: parsedArgs,
+      args: parsedArgs,
       kwargs: parsedKwargs,
       callId: progress.callId,
       methodCall: progress.methodCall,

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -536,15 +536,19 @@ class MontyRepl {
     switch (p.state) {
       case 'complete':
         _pending = false;
+
         return _buildCompleteProgress(p);
       case 'pending':
         _pending = true;
+
         return _buildPendingProgress(p);
       case 'os_call':
         _pending = true;
+
         return _buildOsCallProgress(p);
       case 'resolve_futures':
         _pending = true;
+
         return MontyResolveFutures(
           pendingCallIds: p.pendingCallIds ?? const [],
         );
@@ -592,6 +596,7 @@ class MontyRepl {
       final wireMessage = e.pythonExceptionType != null
           ? '${e.pythonExceptionType}: ${e.message}'
           : e.message;
+
       return _translateProgress(
         await _bindings.resumeWithError(wireMessage),
       );

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -33,7 +33,7 @@ MontyComplete _buildCompleteProgress(CoreProgressResult p) => MontyComplete(
 
 MontyPending _buildPendingProgress(CoreProgressResult p) => MontyPending(
   functionName: p.functionName ?? '',
-  args: _parseReplArgList(p.arguments),
+  args: _parseReplArgList(p.args),
   kwargs: _parseReplKwargMap(p.kwargs),
   callId: p.callId ?? 0,
   methodCall: p.methodCall ?? false,
@@ -41,7 +41,7 @@ MontyPending _buildPendingProgress(CoreProgressResult p) => MontyPending(
 
 MontyOsCall _buildOsCallProgress(CoreProgressResult p) => MontyOsCall(
   operationName: p.functionName ?? '',
-  args: _parseReplArgList(p.arguments),
+  args: _parseReplArgList(p.args),
   kwargs: _parseReplKwargMap(p.kwargs),
   callId: p.callId ?? 0,
 );
@@ -464,7 +464,7 @@ class MontyRepl {
                 final cbKwargs = progress.kwargs?.map(
                   (k, v) => MapEntry(k, v.dartValue),
                 );
-                final res = await syncCb!(cbArgs, cbKwargs);
+                final res = await cb(cbArgs, cbKwargs);
                 progress = _translateProgress(
                   await _bindings.resume(jsonEncode(res)),
                 );

--- a/lib/src/repl/monty_repl.dart
+++ b/lib/src/repl/monty_repl.dart
@@ -33,7 +33,7 @@ MontyComplete _buildCompleteProgress(CoreProgressResult p) => MontyComplete(
 
 MontyPending _buildPendingProgress(CoreProgressResult p) => MontyPending(
   functionName: p.functionName ?? '',
-  arguments: _parseReplArgList(p.arguments),
+  args: _parseReplArgList(p.arguments),
   kwargs: _parseReplKwargMap(p.kwargs),
   callId: p.callId ?? 0,
   methodCall: p.methodCall ?? false,
@@ -41,7 +41,7 @@ MontyPending _buildPendingProgress(CoreProgressResult p) => MontyPending(
 
 MontyOsCall _buildOsCallProgress(CoreProgressResult p) => MontyOsCall(
   operationName: p.functionName ?? '',
-  arguments: _parseReplArgList(p.arguments),
+  args: _parseReplArgList(p.arguments),
   kwargs: _parseReplKwargMap(p.kwargs),
   callId: p.callId ?? 0,
 );
@@ -79,21 +79,6 @@ List<MontyValue> _parseReplArgList(List<Object?>? args) =>
 
 Map<String, MontyValue>? _parseReplKwargMap(Map<String, Object?>? kwargs) =>
     kwargs?.map((k, v) => MapEntry(k, MontyValue.fromJson(v)));
-
-Map<String, Object?> _replArgsToMap(
-  List<MontyValue> positional,
-  Map<String, MontyValue>? kwargs,
-) {
-  final result = <String, Object?>{};
-  if (kwargs != null) {
-    result.addAll(kwargs.map((k, v) => MapEntry(k, v.dartValue)));
-  }
-  for (var i = 0; i < positional.length; i++) {
-    result['_$i'] = positional[i].dartValue;
-  }
-
-  return result;
-}
 
 /// A stateful REPL session backed by the Monty Rust interpreter.
 ///
@@ -463,11 +448,11 @@ class MontyRepl {
               // future, and tell the engine to keep running until it hits an
               // `await`. The engine will surface MontyResolveFutures with
               // the call IDs it now needs values for.
-              final args = _replArgsToMap(
-                progress.arguments,
-                progress.kwargs,
+              final cbArgs = progress.args.map((v) => v.dartValue).toList();
+              final cbKwargs = progress.kwargs?.map(
+                (k, v) => MapEntry(k, v.dartValue),
               );
-              final fut = Future<Object?>(() => asyncCb(args));
+              final fut = Future<Object?>(() => asyncCb(cbArgs, cbKwargs));
               pendingFutures[callId] = fut;
               // Suppress "unhandled async error" — errors are caught and
               // surfaced via the errors map during resolveFutures.
@@ -475,11 +460,11 @@ class MontyRepl {
               progress = _translateProgress(await _bindings.resumeAsFuture());
             } else {
               try {
-                final args = _replArgsToMap(
-                  progress.arguments,
-                  progress.kwargs,
+                final cbArgs = progress.args.map((v) => v.dartValue).toList();
+                final cbKwargs = progress.kwargs?.map(
+                  (k, v) => MapEntry(k, v.dartValue),
                 );
-                final res = await syncCb!(args);
+                final res = await syncCb!(cbArgs, cbKwargs);
                 progress = _translateProgress(
                   await _bindings.resume(jsonEncode(res)),
                 );
@@ -587,7 +572,7 @@ class MontyRepl {
       );
     }
     try {
-      final args = call.arguments.map((v) => v.dartValue).toList();
+      final args = call.args.map((v) => v.dartValue).toList();
       final kwargs = call.kwargs?.map((k, v) => MapEntry(k, v.dartValue));
       final result = await handler(call.operationName, args, kwargs);
 

--- a/lib/src/repl/wasm_repl_bindings.dart
+++ b/lib/src/repl/wasm_repl_bindings.dart
@@ -212,7 +212,7 @@ class WasmReplBindings implements ReplBindings {
       CoreProgressResult(
         state: 'pending',
         functionName: r.functionName,
-        arguments: r.arguments,
+        args: r.args,
         kwargs: r.kwargs,
         callId: r.callId,
         methodCall: r.methodCall,
@@ -222,7 +222,7 @@ class WasmReplBindings implements ReplBindings {
       CoreProgressResult(
         state: 'os_call',
         functionName: r.functionName,
-        arguments: r.arguments,
+        args: r.args,
         kwargs: r.kwargs,
         callId: r.callId,
       );

--- a/lib/src/wasm/wasm_bindings.dart
+++ b/lib/src/wasm/wasm_bindings.dart
@@ -64,7 +64,7 @@ final class WasmProgressResult {
     this.state,
     this.value,
     this.functionName,
-    this.arguments,
+    this.args,
     this.kwargs,
     this.callId,
     this.methodCall,
@@ -98,7 +98,7 @@ final class WasmProgressResult {
   final String? functionName;
 
   /// The function arguments (when state is `'pending'`).
-  final List<Object?>? arguments;
+  final List<Object?>? args;
 
   /// Keyword arguments from the Python call site (when state is `'pending'`).
   final Map<String, Object?>? kwargs;

--- a/lib/src/wasm/wasm_bindings_js.dart
+++ b/lib/src/wasm/wasm_bindings_js.dart
@@ -801,7 +801,7 @@ class WasmBindingsJs extends WasmBindings {
       value: map['value'],
       printOutput: map['print_output'] as String?,
       functionName: map['functionName'] as String?,
-      arguments: args != null ? List<Object?>.from(args) : null,
+      args: args != null ? List<Object?>.from(args) : null,
       kwargs: rawKwargs != null ? Map.from(rawKwargs) : null,
       callId: map['callId'] as int?,
       methodCall: map['methodCall'] as bool?,

--- a/lib/src/wasm/wasm_core_bindings.dart
+++ b/lib/src/wasm/wasm_core_bindings.dart
@@ -338,7 +338,7 @@ class WasmCoreBindings implements MontyCoreBindings {
         return CoreProgressResult(
           state: 'pending',
           functionName: progress.functionName ?? '',
-          arguments: progress.arguments ?? const [],
+          args: progress.args ?? const [],
           kwargs: progress.kwargs,
           callId: progress.callId ?? 0,
           methodCall: progress.methodCall ?? false,
@@ -348,7 +348,7 @@ class WasmCoreBindings implements MontyCoreBindings {
         return CoreProgressResult(
           state: 'os_call',
           functionName: progress.functionName ?? '',
-          arguments: progress.arguments ?? const [],
+          args: progress.args ?? const [],
           kwargs: progress.kwargs,
           callId: progress.callId ?? 0,
         );

--- a/packages/dart_monty_web/web/repl_demo.dart
+++ b/packages/dart_monty_web/web/repl_demo.dart
@@ -147,7 +147,7 @@ void _initReplPanel() {
       final result = await repl.feedRun(
         code,
         externalFunctions: {
-          'host_upper': (args) async => (args['_0'] as String).toUpperCase(),
+          'host_upper': (args, _) async => (args[0] as String).toUpperCase(),
         },
         osHandler: _vfsOsHandler,
       );
@@ -339,17 +339,17 @@ void _initExternalsPanel() {
 
   // Dart implementations of each external.
   final externals = <String, MontyCallback>{
-    'db_query': (args) async {
-      final table = args['_0'] as String;
-      final filter = args['filter'];
+    'db_query': (args, kwargs) async {
+      final table = args[0] as String;
+      final filter = kwargs?['filter'];
       final rows = _mockDb[table] ?? [];
       if (filter == null || filter == 'None' || filter == false) return rows;
       return rows.where((r) => r['active'] == true).toList();
     },
-    'compute': (args) async {
-      final op = args['_0'] as String;
-      final a = args['_1'] as num;
-      final b = args['_2'] as num;
+    'compute': (args, _) async {
+      final op = args[0] as String;
+      final a = args[1] as num;
+      final b = args[2] as num;
       return switch (op) {
         'add' => a + b,
         'mul' => a * b,
@@ -357,12 +357,12 @@ void _initExternalsPanel() {
         _ => throw Exception('unknown op: $op'),
       };
     },
-    'format_currency': (args) async {
-      final amount = args['_0'] as num;
-      final code = (args['code'] as String?) ?? 'USD';
+    'format_currency': (args, kwargs) async {
+      final amount = args[0] as num;
+      final code = (kwargs?['code'] as String?) ?? 'USD';
       return '$code ${amount.toStringAsFixed(2)}';
     },
-    'now': (_) async => DateTime.now().toIso8601String(),
+    'now': (_, _) async => DateTime.now().toIso8601String(),
   };
 
   Future<void> execute() async {
@@ -400,12 +400,12 @@ void _initExternalsPanel() {
 
           case MontyPending(
             :final functionName,
-            :final arguments,
+            :final args,
             :final kwargs,
             :final callId,
           ):
             final argStr = [
-              ...arguments.map((a) => _fmt(a)),
+              ...args.map((a) => _fmt(a)),
               if (kwargs != null)
                 ...kwargs.entries.map((e) => '${e.key}=${_fmt(e.value)}'),
             ].join(', ');
@@ -421,16 +421,11 @@ void _initExternalsPanel() {
               );
             } else {
               try {
-                final dartArgs = <String, Object?>{};
-                if (kwargs != null) {
-                  dartArgs.addAll(
-                    kwargs.map((k, v) => MapEntry(k, v.dartValue)),
-                  );
-                }
-                for (var i = 0; i < arguments.length; i++) {
-                  dartArgs['_$i'] = arguments[i].dartValue;
-                }
-                final result = await cb(dartArgs);
+                final dartArgs = args.map((v) => v.dartValue).toList();
+                final dartKwargs = kwargs?.map(
+                  (k, v) => MapEntry(k, v.dartValue),
+                );
+                final result = await cb(dartArgs, dartKwargs);
                 final resultStr = result is List
                     ? '[${(result as List).length} rows]'
                     : result.toString();

--- a/test/integration/_dataclass_hydrate_test_body.dart
+++ b/test/integration/_dataclass_hydrate_test_body.dart
@@ -52,9 +52,9 @@ void runDataclassHydrateTests() {
       () async {
         final r = await Monty('make_user("alice", 30)').run(
           externalFunctions: {
-            'make_user': (args) async => _userDataclass(
-              name: args['_0']! as String,
-              age: args['_1']! as int,
+            'make_user': (args, _) async => _userDataclass(
+              name: args[0]! as String,
+              age: args[1]! as int,
             ),
           },
         );
@@ -84,8 +84,8 @@ void runDataclassHydrateTests() {
       Future<Object?> dispatchAndHydrate(String code) async {
         final r = await Monty(code).run(
           externalFunctions: {
-            'make_user': (args) async => _userDataclass(name: 'eve', age: 9),
-            'make_order': (args) async => _orderDataclass(id: 99, total: 12.5),
+            'make_user': (_, _) async => _userDataclass(name: 'eve', age: 9),
+            'make_order': (_, _) async => _orderDataclass(id: 99, total: 12.5),
           },
         );
         if (r.value is! MontyDataclass) return r.value;
@@ -107,10 +107,10 @@ void runDataclassHydrateTests() {
       () async {
         final r = await Monty('make_user("frank", 20)').run(
           externalFunctions: {
-            'make_user': (args) async => {
+            'make_user': (args, _) async => {
               ..._userDataclass(
-                name: args['_0']! as String,
-                age: args['_1']! as int,
+                name: args[0]! as String,
+                age: args[1]! as int,
               ),
               'frozen': true,
             },

--- a/test/integration/_feedrun_async_matrix_body.dart
+++ b/test/integration/_feedrun_async_matrix_body.dart
@@ -27,11 +27,10 @@ void runFeedRunAsyncMatrixTests() {
       final r = await repl.feedRun(
         'fetch(7)',
         externalFunctions: {
-          'fetch': (args) {
+          'fetch': (args, _) {
             calls++;
 
-            // Synchronous-style: return a pre-resolved Future.
-            return Future.value((args['_0']! as int) + 1);
+            return Future.value((args[0]! as int) + 1);
           },
         },
       );
@@ -47,11 +46,11 @@ void runFeedRunAsyncMatrixTests() {
       final r = await repl.feedRun(
         'fetch(7)',
         externalFunctions: {
-          'fetch': (args) async {
+          'fetch': (args, _) async {
             calls++;
             await Future<void>.delayed(Duration.zero);
 
-            return (args['_0']! as int) + 1;
+            return (args[0]! as int) + 1;
           },
         },
       );
@@ -71,10 +70,10 @@ async def doubled(n):
 await doubled(3)
 ''',
         externalFunctions: {
-          'fetch': (args) {
+          'fetch': (args, _) {
             calls++;
 
-            return Future.value(args['_0']);
+            return Future.value(args[0]);
           },
         },
       );
@@ -94,11 +93,11 @@ async def doubled(n):
 await doubled(3)
 ''',
         externalFunctions: {
-          'fetch': (args) async {
+          'fetch': (args, _) async {
             calls++;
             await Future<void>.delayed(Duration.zero);
 
-            return args['_0'];
+            return args[0];
           },
         },
       );
@@ -117,11 +116,11 @@ await doubled(3)
         final r = await repl.feedRun(
           'await fetch("token")',
           externalAsyncFunctions: {
-            'fetch': (args) async {
+            'fetch': (args, _) async {
               calls++;
               await Future<void>.delayed(Duration.zero);
 
-              return 'value-for-${args['_0']}';
+              return 'value-for-${args[0]}';
             },
           },
         );
@@ -145,8 +144,8 @@ results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
 results
 ''',
           externalAsyncFunctions: {
-            'fetch': (args) async {
-              final n = args['_0']! as int;
+            'fetch': (args, _) async {
+              final n = args[0]! as int;
               fired.add(n);
               await Future<void>.delayed(Duration.zero);
 
@@ -172,7 +171,7 @@ results
         final r = await repl.feedRun(
           'await fetch(1)',
           externalFunctions: {
-            'fetch': (args) => Future.value(args['_0']),
+            'fetch': (args, _) => Future.value(args[0]),
           },
         );
 

--- a/test/integration/_monty_async_inputs_test_body.dart
+++ b/test/integration/_monty_async_inputs_test_body.dart
@@ -79,11 +79,11 @@ result
 ''').run(
                 inputs: {'key': 'token'},
                 externalFunctions: {
-                  'fetch': (args) async {
+                  'fetch': (args, _) async {
                     fetchCallCount++;
                     await Future<void>.delayed(Duration.zero);
 
-                    return 'value-for-${args['_0']}';
+                    return 'value-for-${args[0]}';
                   },
                 },
               );
@@ -112,11 +112,11 @@ result
 ''').run(
               inputs: {'key': 'token'},
               externalAsyncFunctions: {
-                'fetch': (args) async {
+                'fetch': (args, _) async {
                   fetchCallCount++;
                   await Future<void>.delayed(Duration.zero);
 
-                  return 'value-for-${args['_0']}';
+                  return 'value-for-${args[0]}';
                 },
               },
             );
@@ -142,8 +142,8 @@ results
 ''').run(
                 inputs: {'a': 1, 'b': 2, 'c': 3},
                 externalAsyncFunctions: {
-                  'fetch': (args) async {
-                    final n = args['_0']! as int;
+                  'fetch': (args, _) async {
+                    final n = args[0]! as int;
                     calls.add(n);
                     await Future<void>.delayed(Duration.zero);
 

--- a/test/integration/_monty_compile_run_test_body.dart
+++ b/test/integration/_monty_compile_run_test_body.dart
@@ -48,7 +48,7 @@ void runMontyCompileRunTests() {
       final r = await program.run(
         inputs: {'value': 7},
         externalFunctions: {
-          'double': (args) async => (args['_0']! as int) * 2,
+          'double': (args, _) async => (args[0]! as int) * 2,
         },
       );
       expect(r.error, isNull);

--- a/test/integration/_monty_exec_externals_test_body.dart
+++ b/test/integration/_monty_exec_externals_test_body.dart
@@ -14,7 +14,7 @@ void runMontyExecExternalsTests() {
       final result = await Monty.exec(
         'add(3, 4)',
         externalFunctions: {
-          'add': (args) async => (args['_0']! as int) + (args['_1']! as int),
+          'add': (args, _) async => (args[0]! as int) + (args[1]! as int),
         },
       );
 
@@ -26,7 +26,7 @@ void runMontyExecExternalsTests() {
       final result = await Monty.exec(
         'greet(name="World")',
         externalFunctions: {
-          'greet': (args) async => 'Hello, ${args['name']}!',
+          'greet': (_, kwargs) async => 'Hello, ${kwargs!['name']}!',
         },
       );
 
@@ -39,9 +39,9 @@ void runMontyExecExternalsTests() {
       final result = await Monty.exec(
         'double(double(double(1)))',
         externalFunctions: {
-          'double': (args) async {
+          'double': (args, _) async {
             calls++;
-            return (args['_0']! as int) * 2;
+            return (args[0]! as int) * 2;
           },
         },
       );
@@ -55,7 +55,7 @@ void runMontyExecExternalsTests() {
       final result = await Monty.exec(
         'sum(get_numbers())',
         externalFunctions: {
-          'get_numbers': (_) async => [1, 2, 3, 4],
+          'get_numbers': (_, _) async => [1, 2, 3, 4],
         },
       );
 

--- a/test/integration/_print_callback_test_body.dart
+++ b/test/integration/_print_callback_test_body.dart
@@ -74,7 +74,7 @@ void runPrintCallbackTests() {
       final r = await Monty('print(double(value))').run(
         inputs: {'value': 21},
         externalFunctions: {
-          'double': (args) async => (args['_0']! as int) * 2,
+          'double': (args, _) async => (args[0]! as int) * 2,
         },
         printCallback: (stream, text) => captured.add((stream, text)),
       );

--- a/test/integration/_repl_extfns_lifecycle_test_body.dart
+++ b/test/integration/_repl_extfns_lifecycle_test_body.dart
@@ -22,7 +22,7 @@ void runReplExtFnsLifecycleTests() {
         await repl.feedRun(
           'x = fetch(1)',
           externalFunctions: {
-            'fetch': (args) async => (args['_0']! as int) * 10,
+            'fetch': (args, _) async => (args[0]! as int) * 10,
           },
         );
 
@@ -43,7 +43,7 @@ void runReplExtFnsLifecycleTests() {
         // Iterative path: register `fetch`.
         await repl.feedRun(
           'x = fetch(7)',
-          externalFunctions: {'fetch': (args) async => args['_0']},
+          externalFunctions: {'fetch': (args, _) => Future.value(args[0])},
         );
 
         // Fast-path feed (no externalFunctions, no osHandler)
@@ -66,14 +66,14 @@ void runReplExtFnsLifecycleTests() {
         // Feed 1: register `a`.
         await repl.feedRun(
           'r = a(5)',
-          externalFunctions: {'a': (args) async => (args['_0']! as int) + 1},
+          externalFunctions: {'a': (args, _) async => (args[0]! as int) + 1},
         );
 
         // Feed 2: register `b` instead. `a` must no longer resolve
         // when referenced again.
         await repl.feedRun(
           'r = b(5)',
-          externalFunctions: {'b': (args) async => (args['_0']! as int) * 2},
+          externalFunctions: {'b': (args, _) async => (args[0]! as int) * 2},
         );
 
         final r = await repl.feedRun('r = a(5)');

--- a/test/integration/_repl_futures_test_body.dart
+++ b/test/integration/_repl_futures_test_body.dart
@@ -93,7 +93,7 @@ result
               (p) => p.callId == id,
               orElse: () => fail('callId $id not in observed pendings'),
             );
-            final arg = pending.arguments.first.dartValue! as String;
+            final arg = pending.args.first.dartValue! as String;
             results[id] = 'value-for-$arg';
           }
 
@@ -168,11 +168,11 @@ results
           // Every observed pending should have one int arg; record dispatch
           // order so we can assert all three fired before await yielded.
           for (final p in ps) {
-            dispatched.add(p.arguments.first.dartValue! as int);
+            dispatched.add(p.args.first.dartValue! as int);
           }
           final results = <int, Object?>{};
           for (final p in ps) {
-            results[p.callId] = (p.arguments.first.dartValue! as int) * 10;
+            results[p.callId] = (p.args.first.dartValue! as int) * 10;
           }
 
           return (results: results, errors: <int, String>{});
@@ -216,7 +216,7 @@ results
               final results = <int, Object?>{};
               final errors = <int, String>{};
               for (final p in ps) {
-                final n = p.arguments.first.dartValue! as int;
+                final n = p.args.first.dartValue! as int;
                 if (n == 2) {
                   errors[p.callId] = 'broken-$n';
                 } else {
@@ -250,7 +250,7 @@ b = await fetch(13)
             cycles++;
             final results = <int, Object?>{};
             for (final p in ps) {
-              results[p.callId] = (p.arguments.first.dartValue! as int) * 2;
+              results[p.callId] = (p.args.first.dartValue! as int) * 2;
             }
 
             return (results: results, errors: <int, String>{});
@@ -281,7 +281,7 @@ await doubled(21)
         resolver: (ids, ps) {
           final results = <int, Object?>{};
           for (final p in ps) {
-            results[p.callId] = p.arguments.first.dartValue;
+            results[p.callId] = p.args.first.dartValue;
           }
 
           return (results: results, errors: <int, String>{});
@@ -360,7 +360,7 @@ results = await asyncio.gather(fetch("int"), fetch("str"), fetch("list"), fetch(
         resolver: (ids, ps) {
           final results = <int, Object?>{};
           for (final p in ps) {
-            final tag = p.arguments.first.dartValue! as String;
+            final tag = p.args.first.dartValue! as String;
             results[p.callId] = switch (tag) {
               'int' => 42,
               'str' => 'hello',

--- a/test/integration/_repl_snapshot_lifecycle_test_body.dart
+++ b/test/integration/_repl_snapshot_lifecycle_test_body.dart
@@ -86,7 +86,7 @@ void runReplSnapshotLifecycleTests() {
       // dispatched.
       final r = await repl.feedRun(
         'r = double(21)',
-        externalFunctions: {'double': (args) async => (args['_0']! as int) * 2},
+        externalFunctions: {'double': (args, _) async => (args[0]! as int) * 2},
       );
       expect(r.error, isNull);
 

--- a/test/integration/_run_async_matrix_body.dart
+++ b/test/integration/_run_async_matrix_body.dart
@@ -20,10 +20,10 @@ void runRunAsyncMatrixTests() {
       var calls = 0;
       final r = await Monty('fetch(7)').run(
         externalFunctions: {
-          'fetch': (args) {
+          'fetch': (args, _) {
             calls++;
 
-            return Future.value((args['_0']! as int) + 1);
+            return Future.value((args[0]! as int) + 1);
           },
         },
       );
@@ -38,11 +38,11 @@ void runRunAsyncMatrixTests() {
       var calls = 0;
       final r = await Monty('fetch(7)').run(
         externalFunctions: {
-          'fetch': (args) async {
+          'fetch': (args, _) async {
             calls++;
             await Future<void>.delayed(Duration.zero);
 
-            return (args['_0']! as int) + 1;
+            return (args[0]! as int) + 1;
           },
         },
       );
@@ -62,10 +62,10 @@ async def doubled(n):
 await doubled(3)
 ''').run(
             externalFunctions: {
-              'fetch': (args) {
+              'fetch': (args, _) {
                 calls++;
 
-                return Future.value(args['_0']);
+                return Future.value(args[0]);
               },
             },
           );
@@ -85,11 +85,11 @@ async def doubled(n):
 await doubled(3)
 ''').run(
             externalFunctions: {
-              'fetch': (args) async {
+              'fetch': (args, _) async {
                 calls++;
                 await Future<void>.delayed(Duration.zero);
 
-                return args['_0'];
+                return args[0];
               },
             },
           );
@@ -107,11 +107,11 @@ await doubled(3)
         var calls = 0;
         final r = await Monty('await fetch("token")').run(
           externalAsyncFunctions: {
-            'fetch': (args) async {
+            'fetch': (args, _) async {
               calls++;
               await Future<void>.delayed(Duration.zero);
 
-              return 'value-for-${args['_0']}';
+              return 'value-for-${args[0]}';
             },
           },
         );
@@ -133,8 +133,8 @@ results = await asyncio.gather(fetch(1), fetch(2), fetch(3))
 results
 ''').run(
               externalAsyncFunctions: {
-                'fetch': (args) async {
-                  final n = args['_0']! as int;
+                'fetch': (args, _) async {
+                  final n = args[0]! as int;
                   fired.add(n);
                   await Future<void>.delayed(Duration.zero);
 
@@ -155,7 +155,7 @@ results
       'externalFunctions (sync): Python `await ext()` still raises TypeError',
       () async {
         final r = await Monty('await fetch(1)').run(
-          externalFunctions: {'fetch': (args) => Future.value(args['_0'])},
+          externalFunctions: {'fetch': (args, _) => Future.value(args[0])},
         );
 
         expect(r.error, isNotNull);
@@ -175,10 +175,10 @@ result
 ''').run(
               inputs: {'seed': 'alice'},
               externalAsyncFunctions: {
-                'fetch': (args) async {
+                'fetch': (args, _) async {
                   await Future<void>.delayed(Duration.zero);
 
-                  return 'hello, ${args['_0']}';
+                  return 'hello, ${args[0]}';
                 },
               },
             );

--- a/test/integration/oracle_ffi_ext_test.dart
+++ b/test/integration/oracle_ffi_ext_test.dart
@@ -91,13 +91,13 @@ Future<(String?, MontyValue?, bool)> _runDispatch(
           resultValue = result.value;
           break dispatchLoop;
 
-        case MontyPending(:final functionName, :final arguments):
+        case MontyPending(:final functionName, :final args):
           if (!_supportedExtFns.contains(functionName)) {
             skipped = true;
             break dispatchLoop;
           }
           try {
-            final ret = _dispatch(functionName, arguments);
+            final ret = _dispatch(functionName, args);
             progress = await platform.resume(ret);
           } on MontyScriptError catch (e) {
             thrownExcType = e.excType;

--- a/test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart
+++ b/test/integration/repros/issue_32_listcomp_global_clobber_ffi_test.dart
@@ -26,7 +26,7 @@ import '_xfail.dart';
 void main() {
   group('issue #32 — list-comp external survives repeat feedRun calls', () {
     Map<String, MontyCallback> externals() => {
-      'sync_fn': (_) async => 'sync_ok',
+      'sync_fn': (_, _) async => 'sync_ok',
     };
 
     test(

--- a/test/integration/wasm_runner.dart
+++ b/test/integration/wasm_runner.dart
@@ -815,7 +815,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
 
         case MontyPending(
           :final functionName,
-          :final arguments,
+          :final args,
           :final callId,
           :final kwargs,
           :final methodCall,
@@ -823,7 +823,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
           if (functionName == 'async_call') {
             // Echo function: store the result and convert to a future so the
             // engine can continue running other coroutines in the same gather.
-            pendingResults[callId] = _montyValueToDart(arguments.first);
+            pendingResults[callId] = _montyValueToDart(args.first);
             try {
               progress = await (platform as MontyFutureCapable)
                   .resumeAsFuture();
@@ -839,7 +839,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
               // Unknown public method on external dataclass — raise
               // AttributeError so Python try/except blocks can catch it.
               final typeName =
-                  (arguments.firstOrNull as MontyDataclass?)?.name ?? 'object';
+                  (args.firstOrNull as MontyDataclass?)?.name ?? 'object';
               try {
                 progress = await platform.resumeWithException(
                   'AttributeError',
@@ -857,11 +857,11 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
             final isRaiseError = functionName == 'raise_error';
             try {
               if (isRaiseError) {
-                final excType = (arguments.first as MontyString).value;
-                final msg = (arguments[1] as MontyString).value;
+                final excType = (args.first as MontyString).value;
+                final msg = (args[1] as MontyString).value;
                 progress = await platform.resumeWithException(excType, msg);
               } else {
-                final ret = _dispatch(functionName, arguments, kwargs);
+                final ret = _dispatch(functionName, args, kwargs);
                 progress = await platform.resume(ret);
               }
             } on MontyScriptError catch (e) {
@@ -875,13 +875,13 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
 
         case MontyOsCall(
           :final operationName,
-          :final arguments,
+          :final args,
           :final kwargs,
         ):
           Object? osRet;
           _OsError? osErr;
           try {
-            osRet = _osDispatch(operationName, arguments, kwargs, vfs);
+            osRet = _osDispatch(operationName, args, kwargs, vfs);
           } on _OsError catch (e) {
             osErr = e;
           }

--- a/test/integration/wasm_runner_wasm.dart
+++ b/test/integration/wasm_runner_wasm.dart
@@ -817,7 +817,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
 
         case MontyPending(
           :final functionName,
-          :final arguments,
+          :final args,
           :final callId,
           :final kwargs,
           :final methodCall,
@@ -825,7 +825,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
           if (functionName == 'async_call') {
             // Echo function: store the result and convert to a future so the
             // engine can continue running other coroutines in the same gather.
-            pendingResults[callId] = _montyValueToDart(arguments.first);
+            pendingResults[callId] = _montyValueToDart(args.first);
             try {
               progress = await (platform as MontyFutureCapable)
                   .resumeAsFuture();
@@ -841,7 +841,7 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
               // Unknown public method on external dataclass — raise
               // AttributeError so Python try/except blocks can catch it.
               final typeName =
-                  (arguments.firstOrNull as MontyDataclass?)?.name ?? 'object';
+                  (args.firstOrNull as MontyDataclass?)?.name ?? 'object';
               try {
                 progress = await platform.resumeWithException(
                   'AttributeError',
@@ -859,11 +859,11 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
             final isRaiseError = functionName == 'raise_error';
             try {
               if (isRaiseError) {
-                final excType = (arguments.first as MontyString).value;
-                final msg = (arguments[1] as MontyString).value;
+                final excType = (args.first as MontyString).value;
+                final msg = (args[1] as MontyString).value;
                 progress = await platform.resumeWithException(excType, msg);
               } else {
-                final ret = _dispatch(functionName, arguments, kwargs);
+                final ret = _dispatch(functionName, args, kwargs);
                 progress = await platform.resume(ret);
               }
             } on MontyScriptError catch (e) {
@@ -877,13 +877,13 @@ Future<(String?, MontyValue?, bool)> _runDispatchLoop(
 
         case MontyOsCall(
           :final operationName,
-          :final arguments,
+          :final args,
           :final kwargs,
         ):
           Object? osRet;
           _OsError? osErr;
           try {
-            osRet = _osDispatch(operationName, arguments, kwargs, vfs);
+            osRet = _osDispatch(operationName, args, kwargs, vfs);
           } on _OsError catch (e) {
             osErr = e;
           }


### PR DESCRIPTION
## Summary

- Replaces the flat `Map<String, Object?> args` in `MontyCallback` with separate `List<Object?> args` and `Map<String, Object?>? kwargs` parameters — direct parity with pydantic-monty's `*args, **kwargs` calling convention
- Renames `MontyPending.arguments` and `MontyOsCall.arguments` to `.args` for consistency with the new callback signature
- Deletes `_replArgsToMap` — `_driveLoop` now passes `progress.args` / `progress.kwargs` directly to the callback

## Before / After

```dart
// Before
externalFunctions: {
  'add': (args) async => (args['_0']! as int) + (args['_1']! as int),
  'greet': (args) async => 'Hello, ${args['name']}!',
}

// After
externalFunctions: {
  'add': (args, _) async => (args[0]! as int) + (args[1]! as int),
  'greet': (_, kwargs) async => 'Hello, ${kwargs!['name']}!',
}
```

## Why

The old encoding (`_0`, `_1`, …) collapsed positional and keyword args into a single namespace, making it impossible to distinguish `fetch(42)` from `fetch(**{'_0': 42})`. pydantic-monty keeps them properly separated; now Dart does too.

`MontyPending` and `MontyOsCall` already carried `args` and `kwargs` as separate fields internally — this change just surfaces that separation all the way to the callback.

## Test plan

- [ ] `dart test` — 251 passed
- [ ] `dart analyze` — no issues
- [ ] `dart format` — no changes
- [ ] `dcm analyze lib` — pre-existing warnings only