### PR TITLE
chore: add 0.18.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.18.0
+
+### Breaking
+
+- **`MontyCallback` is now `(List<Object?> args, Map<String, Object?>? kwargs)`.**
+  Positional args by index (`args[0]`…); keyword args in `kwargs`. Old single-map
+  form (`args['_0']`) no longer compiles.
+- **`.arguments` renamed to `.args`** on `MontyPending`, `MontyOsCall`,
+  `CoreProgressResult`, and `WasmProgressResult`.
+- **`useFutures` removed** from `feedRun`/`feedStart`/`Monty.run`. Use
+  `externalAsyncFunctions` instead.
+
+### Added
+
+- **`inputs:`** on `Monty.run`/`feedRun`/`feedStart` — inject Dart values as
+  Python variables for one execution.
+- **`externalAsyncFunctions`** — callbacks dispatched via `resumeAsFuture`;
+  Python can `await` them and `asyncio.gather` runs them concurrently.
+- **`MontyInternalError`** — new `MontyError` subtype for interpreter-internal
+  failures.
+- **`MontyNone` literal** — `feedRun('None')` now returns `MontyNone`.
+
 ## 0.17.0
 
 Re-cut release: align versioning with `dart_monty`. Supersedes the


### PR DESCRIPTION
Adds the 0.18.0 changelog entry covering the breaking changes and new features landed since v0.17.0:

- `MontyCallback` signature (`args`/`kwargs`)
- `.arguments` → `.args` rename
- `useFutures` removal / `externalAsyncFunctions`
- `inputs:`, `MontyInternalError`, `MontyNone` literal