### PR TITLE
docs: update README and example for 0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.18.0
+## 0.17.1
 
 ### Breaking
 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ if (errors.isNotEmpty) return;
 final result = await Monty(llmCode).run(
   inputs: {'temperatureC': 22},
   externalFunctions: {
-    'fetchWeather': (args) async => weatherApi.get(args['_0'] as String),
-    'log': (args) async { logger.info(args['_0']); return null; },
+    'fetchWeather': (args, _) async => weatherApi.get(args[0] as String),
+    'log': (args, _) async { logger.info(args[0]); return null; },
   },
   limits: const MontyLimits(memoryBytes: 32 << 20, timeoutMs: 5000),
 );
@@ -75,7 +75,7 @@ await repl.dispose();
 | | |
 |---|---|
 | `Monty(code, {scriptName})` | Hold source as a re-runnable program |
-| `run({inputs, externalFunctions, limits, osHandler, printCallback})` | Run in a fresh interpreter |
+| `run({inputs, externalFunctions, externalAsyncFunctions, limits, osHandler, printCallback})` | Run in a fresh interpreter |
 | `Monty.exec(code, {…})` | One-shot wrapper |
 | `Monty.compile(code)` / `Monty.runPrecompiled(bytes, {…})` | Pre-compile and replay |
 | `Monty.typeCheck(code, {prefixCode, scriptName})` | Static type analysis → `List<MontyTypingError>` |
@@ -85,8 +85,8 @@ await repl.dispose();
 | | |
 |---|---|
 | `MontyRepl({scriptName, preamble})` | Auto-detected backend |
-| `feedRun(code, {inputs, externalFunctions, osHandler, printCallback})` | State persists |
-| `feedStart(code) + resume / resumeWithError` | Iterative externals + OS calls |
+| `feedRun(code, {inputs, externalFunctions, externalAsyncFunctions, osHandler, printCallback})` | State persists |
+| `feedStart(code, {externalFunctions, externalAsyncFunctions, …}) + resume / resumeWithError` | Iterative externals + OS calls |
 | `detectContinuation(code)` | `>>>` vs `...` mode |
 | `snapshot()` / `restore(bytes)` | Serialise / restore the heap |
 | `clearState()` / `dispose()` | Wipe / free |
@@ -184,7 +184,8 @@ await Monty('x is None').run(inputs: {'x': const MontyNone()});
 
 `inputs:` is a textual prepend, so it composes with **any** script —
 including ones that use `async def` / `await` / `asyncio.gather`. Pure-
-Python async (no Dart externals) works at every API layer with no flag:
+Python async (no Dart externals) works at every API layer with no extra
+setup:
 
 ```dart
 await Monty('''
@@ -194,23 +195,24 @@ await double()
 // → MontyInt(42)
 ```
 
-For a script that `await`s a Dart-registered external function, opt
-into the futures path with `useFutures: true`:
+For a script that `await`s a Dart-registered external function, register
+it under `externalAsyncFunctions` instead of `externalFunctions`:
 
 ```dart
 await Monty('result = await fetch(key)\nresult').run(
   inputs: {'key': 'token'},
-  externalFunctions: {'fetch': (args) async => 'value-for-${args['_0']}'},
-  useFutures: true,
+  externalAsyncFunctions: {
+    'fetch': (args, _) async => 'value-for-${args[0]}',
+  },
 );
 // → MontyString('value-for-token')
 ```
 
-The flag also enables concurrent dispatch — `asyncio.gather(fetch(a),
-fetch(b), fetch(c))` fires all three callbacks before the first
-`MontyResolveFutures`, then resolves them in argument order. Default is
-`false` for back-compat (callbacks resolve eagerly Dart-side; Python
-`await ext()` raises `TypeError` on the eager value).
+`asyncio.gather` over multiple `externalAsyncFunctions` callbacks runs
+them concurrently — all callbacks fire before the first
+`MontyResolveFutures`, then resolve in argument order. Callbacks in
+`externalFunctions` resolve eagerly Dart-side; Python `await ext()` on
+one of those raises `TypeError`.
 
 For the cell-by-cell contract across every API layer × backend, see
 [`docs/deep-dives/async-matrix.md`][async-matrix].
@@ -219,22 +221,35 @@ For the cell-by-cell contract across every API layer × backend, see
 
 ### External functions
 
-Python calls Dart callbacks by name. Positional args at `_0`, `_1`, …;
-kwargs by Python name. Sync or async.
+Python calls Dart callbacks by name. The callback signature is
+`(List<Object?> args, Map<String, Object?>? kwargs)` — positional args
+by index, keyword args by name.
 
 ```dart
 await Monty('compute("mul", 6, 7)').run(externalFunctions: {
-  'compute': (args) async => switch (args['_0']) {
-    'mul' => (args['_1'] as int) * (args['_2'] as int),
+  'compute': (args, _) async => switch (args[0]) {
+    'mul' => (args[1] as int) * (args[2] as int),
     _ => 0,
   },
 });
 ```
 
-A callback returning a `Future` is awaited and resolved
-synchronously from Python's perspective — see *Inputs injection →
-Async scripts* for the await-able variant pending on
-`feat/repl-future-capable`.
+Use `externalAsyncFunctions` when Python needs to `await` the result
+directly or when you want concurrent dispatch via `asyncio.gather`:
+
+```dart
+await Monty('result = await fetch(key)').run(
+  inputs: {'key': 'token'},
+  externalAsyncFunctions: {
+    'fetch': (args, _) async => 'value-for-${args[0]}',
+  },
+);
+```
+
+Callbacks in `externalFunctions` are awaited Dart-side before Python
+resumes (sync from Python's perspective). Callbacks in
+`externalAsyncFunctions` hand Python a coroutine — Python `await`s it,
+and `asyncio.gather` over multiple such calls runs them concurrently.
 
 ### OS calls
 

--- a/README.md
+++ b/README.md
@@ -377,6 +377,19 @@ External functions can't be called from inside iterator-consuming C
 builtins — `map(ext_fn, …)`, `filter(ext_fn, …)`, `sorted(…, key=ext_fn)`
 raise `RuntimeError` upstream. First-class references work everywhere else.
 
+## Stability and versioning
+
+This package does **not** follow semantic versioning. Breaking changes can
+land in any release. The [CHANGELOG](CHANGELOG.md) is kept up-to-date with
+every breaking change, so pin to a specific version and read the changelog
+before upgrading.
+
+We expect to stabilise the API and adopt semver when the package goes into
+production — roughly 1–3 months from now. If you are planning to depend on
+this package, please let us know (open an issue or email
+[alan@enfoldsystems.com](mailto:alan@enfoldsystems.com)) so we can factor
+your use-case into the stabilisation work.
+
 ## License
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -386,9 +386,8 @@ before upgrading.
 
 We expect to stabilise the API and adopt semver when the package goes into
 production — roughly 1–3 months from now. If you are planning to depend on
-this package, please let us know (open an issue or email
-[alan@enfoldsystems.com](mailto:alan@enfoldsystems.com)) so we can factor
-your use-case into the stabilisation work.
+this package, please open an issue so we can factor your use-case into the
+stabilisation work.
 
 ## License
 

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,12 +2,13 @@
 //
 // dart_monty_core — featured example
 //
-// Covers the four main usage patterns:
+// Covers the five main usage patterns:
 //
 //  1. One-shot  — Monty.exec / Monty.run
 //  2. Inputs    — chain programs: feed one result into the next as a Python variable
 //  3. Externals — sync and async Dart callbacks from Python
 //  4. REPL      — stateful interpreter with persistent variables
+//  5. VFS       — sandboxed in-memory filesystem via Python pathlib
 //
 // Run: dart run example/example.dart
 
@@ -60,4 +61,22 @@ a + b
   final fib = await repl.feedRun('result');
   print('fib(10) = ${fib.value.dartValue}'); // 55
   await repl.dispose();
+
+  // ── 5. VFS — sandboxed in-memory filesystem ──────────────────────────────────
+  // Pre-populate a Dart Map, mount it at /data, then let Python read and
+  // write through pathlib.Path. The backing Map is ordinary Dart — inspect
+  // or update it from either side with no serialisation needed.
+  final vfs = <String, String>{'/data/input.txt': 'hello from Dart'};
+  final handler = memoryMountedOsHandler(
+    mounts: const [MountDir(virtualPath: '/data')],
+    vfs: vfs,
+  );
+
+  await Monty('''
+from pathlib import Path
+text = Path("/data/input.txt").read_text()
+Path("/data/output.txt").write_text(text.upper())
+''').run(osHandler: handler);
+
+  print(vfs['/data/output.txt']); // HELLO FROM DART
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,63 @@
+// ignore_for_file: avoid_print
+//
+// dart_monty_core — featured example
+//
+// Covers the four main usage patterns:
+//
+//  1. One-shot  — Monty.exec / Monty.run
+//  2. Inputs    — chain programs: feed one result into the next as a Python variable
+//  3. Externals — sync and async Dart callbacks from Python
+//  4. REPL      — stateful interpreter with persistent variables
+//
+// Run: dart run example/example.dart
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+
+Future<void> main() async {
+  // ── 1. One-shot ─────────────────────────────────────────────────────────────
+  final r = await Monty.exec('2 ** 10');
+  print('2**10 = ${r.value.dartValue}'); // 1024
+
+  // ── 2. Inputs — chaining programs ───────────────────────────────────────────
+  // Run a data program, then feed its result into a second program.
+  // The Dart value returned by the first run becomes a named Python variable
+  // in the next — no serialisation boilerplate required.
+  final squares = await Monty('[x**2 for x in range(10)]').run();
+
+  final total = await Monty('sum(squares)').run(
+    inputs: {'squares': squares.value.dartValue},
+  );
+  print('sum of squares 0–9² = ${total.value.dartValue}'); // 285
+
+  // ── 3. Externals ────────────────────────────────────────────────────────────
+  // externalFunctions: Python calls Dart synchronously.
+  final sync = await Monty('shout(msg)').run(
+    inputs: {'msg': 'hello'},
+    externalFunctions: {
+      'shout': (args, _) async => (args[0] as String).toUpperCase(),
+    },
+  );
+  print(sync.value.dartValue); // HELLO
+
+  // externalAsyncFunctions: Python can `await` the Dart callback directly.
+  // asyncio.gather over multiple calls runs them concurrently in Dart.
+  final async_ = await Monty('''
+import asyncio
+a, b = await asyncio.gather(fetch(1), fetch(2))
+a + b
+''').run(
+    externalAsyncFunctions: {
+      'fetch': (args, _) async => (args[0] as int) * 10,
+    },
+  );
+  print(async_.value.dartValue); // 30  (10 + 20)
+
+  // ── 4. Stateful REPL ────────────────────────────────────────────────────────
+  // Variables, functions, and imports persist across feedRun calls.
+  final repl = MontyRepl();
+  await repl.feedRun('def fib(n): return n if n < 2 else fib(n-1) + fib(n-2)');
+  await repl.feedRun('result = fib(10)');
+  final fib = await repl.feedRun('result');
+  print('fib(10) = ${fib.value.dartValue}'); // 55
+  await repl.dispose();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_monty_core
 description: Sandboxed Python scripting for Dart. Low-level binding for pydantic/monty's interpreter.
-version: 0.17.0
+version: 0.17.1
 homepage: https://github.com/runyaga/dart_monty_core
 repository: https://github.com/runyaga/dart_monty_core
 topics:


### PR DESCRIPTION
## Summary

- Callback syntax `(args['_0'])` → `(args, _)` / `args[0]`
- `useFutures: true` → `externalAsyncFunctions` in async scripts section
- External functions section rewritten with both sync and async patterns
- API tables updated to include `externalAsyncFunctions`