### PR TITLE
test(wasm): resolve cycle + open__fs fixture follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,12 @@
 
 ### Known limitations
 
-- The exhaustive `open__fs` / `open__fs_windows` corpus fixtures pass on FFI
-  but remain skipped on the WASM runners (binary-buffer/seek edge cases and
-  Windows text-encoding specifics). Core file I/O is covered by `with__all`
-  (un-skipped) and `wasm_open_test`. The `with__cm_*` (test-hooks),
-  `pyobject__cycle_*` (runner comparison), and `range__ops` (dart2js big-int)
-  fixtures remain skipped as before.
+- Two corpus fixtures remain skipped on the WASM runners, for reasons outside
+  the host binding: `with__cm_*` need monty's testing-only `test-hooks` cargo
+  feature (the synthetic `_test_cm` CM; real `with open(...)` is covered by
+  `with__all`), and `range__ops` exercises `2**63` range membership where the
+  shared monty wasm32 engine diverges from native. The `open__fs` /
+  `open__fs_windows` and `pyobject__cycle_*` fixtures now pass on both backends.
 
 ## 0.18.0
 

--- a/test/integration/_fixture_parser.dart
+++ b/test/integration/_fixture_parser.dart
@@ -197,6 +197,23 @@ ExpectRaise? _parseTracebackDocstring(String source) {
 }
 
 Object? _parseReturnValue(String raw) {
+  final trimmed = raw.trim();
+
+  // Nested list/dict reprs (only the cyclic fixtures use these). A bracket
+  // pair containing just `...` is the cycle marker, which the engine
+  // serialises as the placeholder string `[...]` / `{...}` — so parsing it to
+  // that same string makes structural comparison match.
+  if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+    final parser = _ReprParser(trimmed);
+    final value = parser.tryParse();
+    if (value != _ReprParser.failed) return value;
+    // Fall through to scalar handling on parse failure.
+  }
+
+  return _parseScalarRepr(trimmed);
+}
+
+Object? _parseScalarRepr(String raw) {
   if (raw == 'None') return null;
   if (raw == 'True') return true;
   if (raw == 'False') return false;
@@ -213,6 +230,125 @@ Object? _parseReturnValue(String raw) {
   }
 
   return raw;
+}
+
+/// Minimal recursive-descent parser for the Python-repr subset used in
+/// `# Return=` directives: nested lists/dicts, scalars, and the cycle
+/// markers `[...]` / `{...}` (emitted as their placeholder strings).
+class _ReprParser {
+  _ReprParser(this._s);
+
+  static const Object failed = Object();
+
+  final String _s;
+  int _i = 0;
+  bool _error = false;
+
+  Object? tryParse() {
+    final value = _value();
+    _skipSpace();
+    if (_error || _i != _s.length) return failed;
+
+    return value;
+  }
+
+  Object? _value() {
+    _skipSpace();
+    if (_i >= _s.length) {
+      _error = true;
+
+      return null;
+    }
+    final c = _s[_i];
+    if (c == '[') return _collection(']', '[...]', isDict: false);
+    if (c == '{') return _collection('}', '{...}', isDict: true);
+
+    return _scalar();
+  }
+
+  Object? _collection(String close, String marker, {required bool isDict}) {
+    _i++; // consume the already-matched opening bracket
+    _skipSpace();
+    if (_peek() == '.') {
+      // `...` cycle marker → placeholder string.
+      if (!_consume('...')) return null;
+      _skipSpace();
+      if (!_consume(close)) return null;
+
+      return marker;
+    }
+    final list = <Object?>[];
+    final map = <String, Object?>{};
+    while (true) {
+      _skipSpace();
+      if (_peek() == close) {
+        _i++;
+        break;
+      }
+      final key = _value();
+      if (_error) return null;
+      if (isDict) {
+        _skipSpace();
+        if (!_consume(':')) return null;
+        final val = _value();
+        if (_error) return null;
+        map['$key'] = val;
+      } else {
+        list.add(key);
+      }
+      _skipSpace();
+      if (_peek() == ',') {
+        _i++;
+      }
+    }
+
+    return isDict ? map : list;
+  }
+
+  Object? _scalar() {
+    final start = _i;
+    final first = _peek();
+    if (first == "'" || first == '"') {
+      _i++;
+      final buf = StringBuffer();
+      while (_i < _s.length && _s[_i] != first) {
+        buf.write(_s[_i]);
+        _i++;
+      }
+      if (_i >= _s.length) {
+        _error = true;
+
+        return null;
+      }
+      _i++; // closing quote
+
+      return buf.toString();
+    }
+    while (_i < _s.length && !',]}:'.contains(_s[_i])) {
+      _i++;
+    }
+
+    return _parseScalarRepr(_s.substring(start, _i).trim());
+  }
+
+  String _peek() => _i < _s.length ? _s[_i] : '';
+
+  bool _consume(String token) {
+    if (_s.startsWith(token, _i)) {
+      _i += token.length;
+
+      return true;
+    }
+    _error = true;
+
+    return false;
+  }
+
+  void _skipSpace() {
+    while (_i < _s.length && _s[_i] == ' ') {
+      _i++;
+    }
+  }
 }
 
 FixtureExpectation _parseRaise(String raw) {

--- a/test/integration/_unsupported_wasm_fixtures.dart
+++ b/test/integration/_unsupported_wasm_fixtures.dart
@@ -1,32 +1,24 @@
 // Shared skip-set for the WASM fixture harnesses (wasm_runner.dart,
 // wasm_runner_wasm.dart, wasm_fixture_test.dart).
 //
-// These v0.0.18 corpus fixtures exercise interpreter features not yet wired
-// into the WASM binding. They are skipped (not failed) until support lands;
-// tracked in the CHANGELOG. Remove entries as each gap is closed.
+// These corpus fixtures depend on capabilities outside the host binding's
+// reach. They are skipped (not failed); tracked in the CHANGELOG. Remove
+// entries if/when the underlying capability lands.
 
 const Set<String> unsupportedWasmFixtures = {
-  // Exhaustive `open()` fixtures: pass on FFI, but the corpus runner still
-  // diverges on binary-buffer / seek edge cases (open__fs) and Windows
-  // text-encoding specifics (open__fs_windows). Core file I/O is covered by
-  // with__all.py (un-skipped) and wasm_open_test.dart.
-  'open__fs.py',
-  'open__fs_windows.py',
-  // Context-manager behaviors driven by the synthetic `_test_cm()` hook, which
-  // only exists when the native crate is built with the `test-hooks` cargo
-  // feature (not enabled in the shipped build) — fixtures NameError otherwise.
+  // Synthetic context-manager (`_test_cm()`): only exists when the native
+  // crate is built with monty's `test-hooks` cargo feature, which is
+  // explicitly testing-only and intentionally not in the shipped binary.
+  // Exercising these would need a parallel test-hooks build of both the FFI
+  // dylib and WASM binary. Real `with open(...)` is covered by with__all.py.
   'with__cm_behaviors.py',
   'with__cm_context_expr_raises_traceback.py',
   'with__cm_enter_raises_traceback.py',
   'with__cm_exit_raises_normal_exit_traceback.py',
   'with__cm_nested_body_raises_traceback.py',
   'with__cm_traceback.py',
-  // Cyclic containers: FFI produces the correct cyclic value; only the WASM
-  // fixture comparison mismatches the `[[...]]` cycle repr.
-  'pyobject__cycle_dict_self.py',
-  'pyobject__cycle_list_dict.py',
-  'pyobject__cycle_list_self.py',
-  'pyobject__cycle_multiple_refs.py',
-  // dart2js divergence on `2**63`-scale range membership (big-int boundary).
+  // Pure-Python range membership at `2**63` (beyond i64). The same monty
+  // engine runs on both backends, so this is an upstream wasm32 big-int
+  // divergence (passes on native FFI), not a host-binding gap.
   'range__ops.py',
 };

--- a/test/integration/wasm_runner.dart
+++ b/test/integration/wasm_runner.dart
@@ -342,7 +342,9 @@ final class _VirtualFs {
     return t.runes.length; // codepoint count, not UTF-16 unit count
   }
 
-  void writeBytes(String p, List<int> b) {
+  /// Writes bytes to [p] and returns the number of bytes written (needed by
+  /// the buffered binary `open(...).write()` path to advance position).
+  int writeBytes(String p, List<int> b) {
     if (_dirs.contains(p)) {
       throw _OsError(
         "[Errno 21] Is a directory: '$p'",
@@ -357,6 +359,8 @@ final class _VirtualFs {
       );
     }
     _files[p] = b;
+
+    return b.length;
   }
 
   /// Performs the open-time effect for `open(p, mode)` and returns the
@@ -649,9 +653,7 @@ Object? _osDispatch(
           pythonExceptionType: 'TypeError',
         );
       }
-      vfs.appendBytes(p, abArg.value);
-
-      return null;
+      return vfs.appendBytes(p, abArg.value);
 
     // ---- datetime ----
     case 'date.today':
@@ -763,7 +765,9 @@ Object? _osDispatch(
           pythonExceptionType: 'FileNotFoundError',
         );
       }
-      final b = c is String ? c.codeUnits : c as List<int>;
+      // utf8.encode (not codeUnits) so non-ASCII text reads back as its real
+      // on-disk UTF-8 bytes (e.g. β → 0xCE 0xB2, not the UTF-16 unit 946).
+      final b = c is String ? utf8.encode(c) : c as List<int>;
 
       return {'__type': 'bytes', 'value': b};
 
@@ -805,9 +809,8 @@ Object? _osDispatch(
           pythonExceptionType: 'TypeError',
         );
       }
-      vfs.writeBytes(p, wbArg.value);
 
-      return null;
+      return vfs.writeBytes(p, wbArg.value);
 
     case 'Path.mkdir':
       final p = _pathStr(args.first);

--- a/test/integration/wasm_runner_wasm.dart
+++ b/test/integration/wasm_runner_wasm.dart
@@ -357,7 +357,9 @@ final class _VirtualFs {
     return t.runes.length; // codepoint count, not UTF-16 unit count
   }
 
-  void writeBytes(String p, List<int> b) {
+  /// Writes bytes to [p] and returns the number of bytes written (needed by
+  /// the buffered binary `open(...).write()` path to advance position).
+  int writeBytes(String p, List<int> b) {
     if (_dirs.contains(p)) {
       throw _OsError(
         "[Errno 21] Is a directory: '$p'",
@@ -372,6 +374,8 @@ final class _VirtualFs {
       );
     }
     _files[p] = b;
+
+    return b.length;
   }
 
   /// Performs the open-time effect for `open(p, mode)` and returns the
@@ -664,9 +668,7 @@ Object? _osDispatch(
           pythonExceptionType: 'TypeError',
         );
       }
-      vfs.appendBytes(p, abArg.value);
-
-      return null;
+      return vfs.appendBytes(p, abArg.value);
 
     // ---- datetime ----
     case 'date.today':
@@ -778,7 +780,9 @@ Object? _osDispatch(
           pythonExceptionType: 'FileNotFoundError',
         );
       }
-      final b = c is String ? c.codeUnits : c as List<int>;
+      // utf8.encode (not codeUnits) so non-ASCII text reads back as its real
+      // on-disk UTF-8 bytes (e.g. β → 0xCE 0xB2, not the UTF-16 unit 946).
+      final b = c is String ? utf8.encode(c) : c as List<int>;
 
       return {'__type': 'bytes', 'value': b};
 
@@ -820,9 +824,8 @@ Object? _osDispatch(
           pythonExceptionType: 'TypeError',
         );
       }
-      vfs.writeBytes(p, wbArg.value);
 
-      return null;
+      return vfs.writeBytes(p, wbArg.value);
 
     case 'Path.mkdir':
       final p = _pathStr(args.first);


### PR DESCRIPTION
Stacked on #109.

WASM-side coverage follow-ups for the file-I/O work:

- `open__fs` fixture follow-ups.
- Resolve-cycle edge cases surfaced while validating `open()` on the WASM
  backend.

**Stack:** #108 → #109 → **wasm-edge-cases** → test-hooks-cm → demo-file-io → open-primitive