### PR TITLE
test(cm): with-statement context-manager conformance (FFI + WASM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,12 +23,15 @@
 
 ### Known limitations
 
-- Two corpus fixtures remain skipped on the WASM runners, for reasons outside
-  the host binding: `with__cm_*` need monty's testing-only `test-hooks` cargo
-  feature (the synthetic `_test_cm` CM; real `with open(...)` is covered by
-  `with__all`), and `range__ops` exercises `2**63` range membership where the
-  shared monty wasm32 engine diverges from native. The `open__fs` /
-  `open__fs_windows` and `pyobject__cycle_*` fixtures now pass on both backends.
+- `with__cm_*` use monty's synthetic `_test_cm()`, which only exists under the
+  testing-only `test-hooks` cargo feature (never shipped). They have dedicated
+  FFI conformance via `bash tool/test_cm.sh` (a marker-gated test-hooks build
+  of the oracle + FFI dylib); they stay skipped on the WASM runners, which use
+  the shipped no-test-hooks binary. Real `with open(...)` is covered by
+  `with__all` on both backends.
+- `range__ops` exercises `2**63` range membership where the shared monty
+  wasm32 engine diverges from native; skipped on the WASM runners only.
+- `open__fs` / `open__fs_windows` and `pyobject__cycle_*` pass on both backends.
 
 ## 0.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@
 
 - `with__cm_*` use monty's synthetic `_test_cm()`, which only exists under the
   testing-only `test-hooks` cargo feature (never shipped). They have dedicated
-  FFI conformance via `bash tool/test_cm.sh` (a marker-gated test-hooks build
-  of the oracle + FFI dylib); they stay skipped on the WASM runners, which use
-  the shipped no-test-hooks binary. Real `with open(...)` is covered by
-  `with__all` on both backends.
+  conformance on both backends via opt-in test-hooks builds that never touch
+  the shipped binaries: `bash tool/test_cm.sh` (FFI — marker-gated oracle +
+  dylib) and `bash tool/test_cm_wasm.sh` (WASM — a staged test-hooks `.wasm`
+  with the corpus runner compiled `-DMONTY_TEST_HOOKS=true`). The default
+  suites skip them. Real `with open(...)` is covered by `with__all`.
 - `range__ops` exercises `2**63` range membership where the shared monty
   wasm32 engine diverges from native; skipped on the WASM runners only.
 - `open__fs` / `open__fs_windows` and `pyobject__cycle_*` pass on both backends.

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -8,6 +8,8 @@ tags:
     skip: "FFI integration tests. Run: dart test -p vm --run-skipped --tags=ffi"
   wasm:
     skip: "WASM integration tests. Run: bash tool/test_wasm_unit.sh"
+  test-hooks:
+    skip: "Needs a test-hooks build of the native crate. Run: bash tool/test_cm.sh"
   example:
     skip: "Example smoke tests. Run: dart test -p vm --run-skipped --tags=example"
   ladder:

--- a/hook/build.dart
+++ b/hook/build.dart
@@ -35,11 +35,23 @@ void main(List<String> args) async {
       // Contributor path: always run cargo (handles incremental builds).
       final triple = _rustTriple(os, arch);
       final targetArgs = triple != null ? ['--target', triple] : <String>[];
+      // Testing-only opt-in: a `native/.test-hooks` marker file makes the hook
+      // build the dylib with monty's `test-hooks` feature so the `with__cm_*`
+      // conformance fixtures (which use the synthetic `_test_cm()`) can run.
+      // A marker file (not an env var) is used because native-assets build
+      // hooks run hermetically and don't inherit host env vars. The file is
+      // gitignored and only tool/test_cm.sh creates it — never in shipped
+      // builds.
+      final testHooksMarker = File.fromUri(nativeDir.resolve('.test-hooks'));
+      final testHooks = testHooksMarker.existsSync()
+          ? ['--features', 'test-hooks']
+          : <String>[];
       final result = await Process.run('cargo', [
         'build',
         '--release',
         '--lib',
         ...targetArgs,
+        ...testHooks,
       ], workingDirectory: Directory.fromUri(nativeDir).path);
       if (result.exitCode != 0) {
         throw StateError(

--- a/native/.gitignore
+++ b/native/.gitignore
@@ -1,0 +1,2 @@
+# Testing-only marker created by tool/test_cm.sh
+.test-hooks

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -20,6 +20,12 @@ num-bigint = "0.4"
 num-traits = "0.2"
 serde_json = "1"
 
+[features]
+# Testing-only: exposes monty's synthetic `_test_cm()` context manager so the
+# `with__cm_*` conformance fixtures can run. NEVER enabled in shipped builds —
+# only the dedicated test-build scripts pass `--features test-hooks`.
+test-hooks = ["monty/test-hooks"]
+
 [lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
 missing_debug_implementations = "warn"

--- a/test/integration/_unsupported_wasm_fixtures.dart
+++ b/test/integration/_unsupported_wasm_fixtures.dart
@@ -1,25 +1,31 @@
-// Shared skip-set for the WASM fixture harnesses (wasm_runner.dart,
+// Shared skip-sets for the WASM fixture harnesses (wasm_runner.dart,
 // wasm_runner_wasm.dart, wasm_fixture_test.dart).
-//
-// These corpus fixtures depend on capabilities outside the host binding's
-// reach. They are skipped (not failed); tracked in the CHANGELOG. Remove
-// entries if/when the underlying capability lands.
 
-const Set<String> unsupportedWasmFixtures = {
-  // Synthetic context-manager (`_test_cm()`): only exists under monty's
-  // testing-only `test-hooks` cargo feature, never in the shipped binary the
-  // WASM runners use. These have dedicated FFI conformance via a marker-gated
-  // test-hooks build — `bash tool/test_cm.sh` (ffi_with_cm_test.dart). A WASM
-  // equivalent would need a separate staged test-hooks wasm. Real
-  // `with open(...)` is covered by with__all.py on both backends.
+/// Fixtures that never run on the WASM corpus runners, regardless of build:
+/// the shared monty wasm32 engine diverges from native here, so it's an
+/// upstream concern, not a host-binding gap.
+const alwaysUnsupportedWasmFixtures = {
+  // Pure-Python range membership at `2**63` (beyond i64). Passes on native FFI;
+  // the same monty wasm32 engine diverges.
+  'range__ops.py',
+};
+
+/// Fixtures that need monty's synthetic `_test_cm()` context manager, which
+/// only exists under the testing-only `test-hooks` cargo feature. They run on
+/// the corpus runners ONLY when compiled with `-DMONTY_TEST_HOOKS=true` against
+/// a test-hooks WASM binary (see tool/test_cm_wasm.sh) — never in the shipped
+/// build. Real `with open(...)` is covered by with__all.py on both backends.
+const testHooksWasmFixtures = {
   'with__cm_behaviors.py',
   'with__cm_context_expr_raises_traceback.py',
   'with__cm_enter_raises_traceback.py',
   'with__cm_exit_raises_normal_exit_traceback.py',
   'with__cm_nested_body_raises_traceback.py',
   'with__cm_traceback.py',
-  // Pure-Python range membership at `2**63` (beyond i64). The same monty
-  // engine runs on both backends, so this is an upstream wasm32 big-int
-  // divergence (passes on native FFI), not a host-binding gap.
-  'range__ops.py',
+};
+
+/// Union of both — fixtures skipped under a normal (no-test-hooks) WASM build.
+const unsupportedWasmFixtures = {
+  ...alwaysUnsupportedWasmFixtures,
+  ...testHooksWasmFixtures,
 };

--- a/test/integration/_unsupported_wasm_fixtures.dart
+++ b/test/integration/_unsupported_wasm_fixtures.dart
@@ -6,11 +6,12 @@
 // entries if/when the underlying capability lands.
 
 const Set<String> unsupportedWasmFixtures = {
-  // Synthetic context-manager (`_test_cm()`): only exists when the native
-  // crate is built with monty's `test-hooks` cargo feature, which is
-  // explicitly testing-only and intentionally not in the shipped binary.
-  // Exercising these would need a parallel test-hooks build of both the FFI
-  // dylib and WASM binary. Real `with open(...)` is covered by with__all.py.
+  // Synthetic context-manager (`_test_cm()`): only exists under monty's
+  // testing-only `test-hooks` cargo feature, never in the shipped binary the
+  // WASM runners use. These have dedicated FFI conformance via a marker-gated
+  // test-hooks build — `bash tool/test_cm.sh` (ffi_with_cm_test.dart). A WASM
+  // equivalent would need a separate staged test-hooks wasm. Real
+  // `with open(...)` is covered by with__all.py on both backends.
   'with__cm_behaviors.py',
   'with__cm_context_expr_raises_traceback.py',
   'with__cm_enter_raises_traceback.py',

--- a/test/integration/ffi_with_cm_test.dart
+++ b/test/integration/ffi_with_cm_test.dart
@@ -1,0 +1,92 @@
+// Conformance for the `with__cm_*` fixtures, which exercise the `with`
+// machinery via monty's synthetic `_test_cm()` context manager.
+//
+// `_test_cm()` only exists when the native crate is built with the
+// `test-hooks` cargo feature, so this test is NOT part of the normal suite.
+// Run it via the dedicated builder, which compiles the oracle binary AND the
+// FFI dylib with `--features test-hooks`:
+//
+//   bash tool/test_cm.sh
+//
+// It compares the test-hooks oracle against the test-hooks FFI dylib (the same
+// contract as oracle_ffi_test) and asserts `_test_cm` actually resolved — i.e.
+// neither side raised `NameError`, proving test-hooks is active. Without the
+// dedicated build both sides NameError and the assertions below fail, which is
+// the intended guard against running this with a stock build.
+@Tags(['integration', 'ffi', 'test-hooks'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:dart_monty_core/src/ffi/monty_ffi.dart';
+import 'package:test/test.dart';
+
+import '_fixture_corpus.dart';
+import '_oracle_runner.dart';
+
+const _fixtureNames = [
+  'with__cm_behaviors.py',
+  'with__cm_context_expr_raises_traceback.py',
+  'with__cm_enter_raises_traceback.py',
+  'with__cm_exit_raises_normal_exit_traceback.py',
+  'with__cm_nested_body_raises_traceback.py',
+  'with__cm_traceback.py',
+];
+
+void main() {
+  group('with__cm (test-hooks)', () {
+    for (final name in _fixtureNames) {
+      test(name, () async {
+        final code = fixtureCorpus[name]!;
+
+        final oracleResult = MontyResult.fromJson(
+          Map.from(await runOracle(code)),
+        );
+
+        final platform = MontyFfi();
+        MontyResult? ffiResult;
+        String? ffiExcType;
+        try {
+          ffiResult = await platform.run(code, scriptName: name);
+          ffiExcType = ffiResult.error?.excType;
+        } on MontyScriptError catch (e) {
+          ffiExcType = e.excType;
+        } finally {
+          await platform.dispose();
+        }
+
+        // `_test_cm` must have resolved on both sides — a NameError here means
+        // the binary was built without test-hooks (run via tool/test_cm.sh).
+        expect(
+          oracleResult.error?.excType,
+          isNot('NameError'),
+          reason:
+              '$name: oracle hit NameError — build with --features test-hooks '
+              '(use tool/test_cm.sh)',
+        );
+        expect(
+          ffiExcType,
+          isNot('NameError'),
+          reason:
+              '$name: FFI hit NameError — set DART_MONTY_TEST_HOOKS=1 and '
+              'rebuild (use tool/test_cm.sh)',
+        );
+
+        // Oracle and FFI must agree (same conformance contract as oracle_ffi).
+        if (oracleResult.error != null) {
+          expect(
+            ffiExcType,
+            equals(oracleResult.error!.excType),
+            reason: 'excType mismatch for $name',
+          );
+        } else {
+          expect(ffiResult?.error, isNull, reason: 'unexpected error in $name');
+          expect(
+            ffiResult?.value,
+            equals(oracleResult.value),
+            reason: 'value mismatch for $name',
+          );
+        }
+      });
+    }
+  });
+}

--- a/test/integration/wasm_runner.dart
+++ b/test/integration/wasm_runner.dart
@@ -59,7 +59,9 @@ const Set<String> _unsupportedExtFns = {};
 
 /// v0.0.18 corpus fixtures exercising interpreter features not yet wired into
 /// the WASM binding. Shared with the other WASM fixture harnesses.
-const _unsupportedFixtures = unsupportedWasmFixtures;
+// Set by `dart compile js -DMONTY_TEST_HOOKS=true` (tool/test_cm_wasm.sh),
+// paired with a test-hooks WASM binary so `_test_cm`-based fixtures can run.
+const _testHooks = bool.fromEnvironment('MONTY_TEST_HOOKS');
 
 /// Dispatches a supported [functionName] call to its Dart implementation.
 /// Returns the Dart value to resume with (passed to MontyPlatform.resume).
@@ -1104,8 +1106,10 @@ Future<void> main() async {
   var skipped = 0;
 
   for (final MapEntry(:key, :value) in fixtureCorpus.entries) {
-    // Skip fixtures for v0.0.18 features not yet wired into the WASM binding.
-    if (_unsupportedFixtures.contains(key)) {
+    // Engine-level divergences are always skipped; test-hooks fixtures run
+    // only under a `-DMONTY_TEST_HOOKS=true` build against a test-hooks WASM.
+    if (alwaysUnsupportedWasmFixtures.contains(key) ||
+        (!_testHooks && testHooksWasmFixtures.contains(key))) {
       skipped++;
       continue;
     }

--- a/test/integration/wasm_runner_wasm.dart
+++ b/test/integration/wasm_runner_wasm.dart
@@ -65,7 +65,9 @@ const Set<String> _unsupportedExtFns = {};
 
 /// v0.0.18 corpus fixtures exercising interpreter features not yet wired into
 /// the WASM binding. Shared with the other WASM fixture harnesses.
-const _unsupportedFixtures = unsupportedWasmFixtures;
+// Set by `dart compile wasm -DMONTY_TEST_HOOKS=true` (tool/test_cm_wasm.sh),
+// paired with a test-hooks WASM binary so `_test_cm`-based fixtures can run.
+const _testHooks = bool.fromEnvironment('MONTY_TEST_HOOKS');
 
 /// Values supplied for [MontyNameLookup] progress when the engine encounters
 /// an unregistered global name. Mirrors the oracle in the monty-datatest crate.
@@ -1107,8 +1109,10 @@ Future<void> main() async {
 
   final stopwatch = Stopwatch()..start();
   for (final MapEntry(:key, :value) in fixtureCorpus.entries) {
-    // Skip fixtures for v0.0.18 features not yet wired into the WASM binding.
-    if (_unsupportedFixtures.contains(key)) {
+    // Engine-level divergences are always skipped; test-hooks fixtures run
+    // only under a `-DMONTY_TEST_HOOKS=true` build against a test-hooks WASM.
+    if (alwaysUnsupportedWasmFixtures.contains(key) ||
+        (!_testHooks && testHooksWasmFixtures.contains(key))) {
       skipped++;
       continue;
     }

--- a/tool/test_cm.sh
+++ b/tool/test_cm.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# =============================================================================
+# dart_monty_core — with__cm_* conformance (test-hooks build)
+# =============================================================================
+# The `with__cm_*` fixtures exercise the `with` machinery through monty's
+# synthetic `_test_cm()` context manager, which only exists when the native
+# crate is built with the `test-hooks` cargo feature. That feature is
+# testing-only and is NEVER in the shipped binaries, so these fixtures are
+# skipped by the normal suites (see test/integration/_unsupported_wasm_fixtures.dart).
+#
+# This script builds a test-hooks oracle binary AND a test-hooks FFI dylib
+# (via DART_MONTY_TEST_HOOKS=1, honored by hook/build.dart), then runs the
+# dedicated FFI conformance test that compares the two.
+#
+# Usage: bash tool/test_cm.sh
+# =============================================================================
+set -euo pipefail
+
+PKG="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PKG"
+
+echo "=== with__cm_* conformance (test-hooks) ==="
+
+echo "--- Building oracle with --features test-hooks ---"
+(cd native && cargo build --bin oracle --features test-hooks)
+
+# The FFI dylib is produced by hook/build.dart on `dart test`. It adds
+# --features test-hooks when the native/.test-hooks marker file exists (a file,
+# not an env var, because native-assets hooks run hermetically). The hook
+# caches by input hash and won't notice the marker, so drop its cache to force
+# a fresh build. Always clean up the marker on exit.
+MARKER="$PKG/native/.test-hooks"
+cleanup() { rm -f "$MARKER"; rm -rf "$PKG/.dart_tool/hooks_runner"; }
+trap cleanup EXIT
+
+echo "--- Enabling test-hooks marker + clearing hook cache ---"
+touch "$MARKER"
+rm -rf .dart_tool/hooks_runner
+
+echo "--- Running ffi_with_cm_test ---"
+dart test \
+  test/integration/ffi_with_cm_test.dart \
+  -p vm --run-skipped --tags=test-hooks
+
+echo ""
+echo "=== PASSED: with__cm_* conformance ==="
+# The EXIT trap removes the marker and the hook cache, so the next normal FFI
+# run rebuilds the stock (no-test-hooks) dylib automatically.

--- a/tool/test_cm_wasm.sh
+++ b/tool/test_cm_wasm.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# =============================================================================
+# dart_monty_core — with__cm_* conformance on WASM (staged test-hooks build)
+# =============================================================================
+# WASM counterpart to tool/test_cm.sh. The `with__cm_*` fixtures need monty's
+# synthetic `_test_cm()`, which only exists under the testing-only `test-hooks`
+# cargo feature. This builds a STAGED test-hooks WASM binary into
+# test/integration/web/ (never lib/assets, which must stay test-hooks-free),
+# compiles the corpus runner with `-DMONTY_TEST_HOOKS=true` (so it stops
+# skipping the test-hooks fixtures), and runs the corpus in headless Chrome.
+#
+# The committed JS bridge (lib/assets/*.js) is reused as-is — only the wasm
+# engine needs the feature.
+#
+# Usage: bash tool/test_cm_wasm.sh
+# =============================================================================
+set -euo pipefail
+
+PKG="$(cd "$(dirname "$0")/.." && pwd)"
+INTEG_WEB="$PKG/test/integration/web"
+WASI_PKG="$PKG/js/node_modules/@pydantic/monty-wasm32-wasi"
+SERVE_PORT=8096
+cd "$PKG"
+
+echo "=== with__cm_* conformance on WASM (test-hooks) ==="
+
+# -------------------------------------------------------
+# Step 1: Build a test-hooks WASM binary (staged, not lib/assets)
+# -------------------------------------------------------
+echo "--- Building test-hooks WASM (cargo wasm32-wasip1 --features test-hooks) ---"
+(cd native && cargo build --target wasm32-wasip1 --release --features test-hooks)
+WASM_SRC="$PKG/native/target/wasm32-wasip1/release/dart_monty_core_native.wasm"
+[ -f "$WASM_SRC" ] || { echo "FATAL: missing $WASM_SRC"; exit 1; }
+
+# -------------------------------------------------------
+# Step 2: Stage assets into test/integration/web/
+# -------------------------------------------------------
+echo "--- Staging assets (test-hooks wasm + committed JS bridge) ---"
+mkdir -p "$INTEG_WEB"
+cp "$WASM_SRC"                                   "$INTEG_WEB/dart_monty_core_native.wasm"
+cp "$PKG/lib/assets/dart_monty_core_bridge.js"   "$INTEG_WEB/"
+cp "$PKG/lib/assets/dart_monty_core_worker.js"   "$INTEG_WEB/"
+
+# WASI runtime (esbuild doesn't copy it; mirror tool/test_wasm.sh).
+if [ ! -f "$WASI_PKG/wasi-worker-browser.mjs" ]; then
+  echo "--- Installing WASI runtime (npm install --force in js/) ---"
+  (cd js && npm install --force --silent)
+fi
+mkdir -p "$INTEG_WEB/@pydantic/monty-wasm32-wasi"
+cp "$WASI_PKG/wasi-worker-browser.mjs" "$INTEG_WEB/@pydantic/monty-wasm32-wasi/"
+
+# -------------------------------------------------------
+# Step 3: Compile the corpus runner with MONTY_TEST_HOOKS=true
+# -------------------------------------------------------
+echo "--- Compiling wasm_runner.dart -> JS (-DMONTY_TEST_HOOKS=true) ---"
+dart pub get >/dev/null
+dart compile js \
+  -DMONTY_TEST_HOOKS=true \
+  test/integration/wasm_runner.dart \
+  -o "$INTEG_WEB/wasm_runner.dart.js" \
+  --no-source-maps
+echo "  Compile: OK"
+
+# -------------------------------------------------------
+# Cleanup trap
+# -------------------------------------------------------
+SERVE_PID=""
+cleanup() {
+  if [ -n "$SERVE_PID" ]; then kill "$SERVE_PID" 2>/dev/null || true; fi
+  rm -f "$INTEG_WEB/dart_monty_core_bridge.js" \
+        "$INTEG_WEB/dart_monty_core_worker.js" \
+        "$INTEG_WEB/dart_monty_core_native.wasm" \
+        "$INTEG_WEB/wasm_runner.dart.js" \
+        "$INTEG_WEB/wasm_runner.dart.js.deps"
+}
+trap cleanup EXIT
+
+# -------------------------------------------------------
+# Step 4: COOP/COEP server
+# -------------------------------------------------------
+echo "--- Starting COOP/COEP server on :$SERVE_PORT ---"
+python3 - "$INTEG_WEB" "$SERVE_PORT" <<'PYEOF' &
+import sys, http.server, functools
+directory = sys.argv[1]; port = int(sys.argv[2])
+class H(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+        self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+        self.send_header('Access-Control-Allow-Origin', '*')
+        self.send_header('Cache-Control', 'no-store')
+        super().end_headers()
+    def guess_type(self, path):
+        if path.endswith('.mjs'):  return 'application/javascript'
+        if path.endswith('.wasm'): return 'application/wasm'
+        return super().guess_type(path)
+    def log_message(self, fmt, *args): pass
+handler = functools.partial(H, directory=directory)
+http.server.HTTPServer(('127.0.0.1', port), handler).serve_forever()
+PYEOF
+SERVE_PID=$!
+sleep 1
+
+# -------------------------------------------------------
+# Step 5: Detect Chrome + run headless
+# -------------------------------------------------------
+CHROME=""
+for c in "google-chrome-stable" "google-chrome" \
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  "chromium" "chromium-browser"; do
+  if command -v "$c" &>/dev/null 2>&1 || [ -f "$c" ]; then CHROME="$c"; break; fi
+done
+[ -n "$CHROME" ] || { echo "WARN: Chrome not found; cannot run WASM tests."; exit 0; }
+
+echo "--- Running corpus (test-hooks) in headless Chrome ---"
+CHROME_LOG=$(mktemp)
+timeout 120 "$CHROME" --headless=new --disable-gpu --no-sandbox \
+  --disable-dev-shm-usage --enable-logging=stderr --v=0 \
+  "http://127.0.0.1:$SERVE_PORT/fixtures.html" 2>"$CHROME_LOG" || true
+
+# -------------------------------------------------------
+# Step 6: Parse — require the with__cm fixtures to have run and passed
+# -------------------------------------------------------
+RESULTS=$(grep -o 'FIXTURE_RESULT:{.*}' "$CHROME_LOG" 2>/dev/null || true)
+DONE=$(grep -o 'FIXTURE_DONE:{.*}' "$CHROME_LOG" 2>/dev/null | head -1 || true)
+FAILURES=$(echo "$RESULTS" | grep -c '"ok":false' || true)
+CM_RUN=$(echo "$RESULTS" | grep -c 'with__cm_' || true)
+rm -f "$CHROME_LOG"
+
+echo ""
+echo "$DONE"
+echo "with__cm fixtures executed: $CM_RUN (expected 6)"
+
+if [ -z "$DONE" ]; then echo "FAILED: no FIXTURE_DONE (Chrome crashed/timed out)"; exit 1; fi
+if [ "$FAILURES" -gt 0 ]; then
+  echo "FAILED: $FAILURES fixture(s) failed:"
+  echo "$RESULTS" | grep '"ok":false' | sed 's/^.*FIXTURE_RESULT:/  /'
+  exit 1
+fi
+if [ "$CM_RUN" -lt 6 ]; then
+  echo "FAILED: expected 6 with__cm fixtures to run, saw $CM_RUN"
+  echo "  (is the runner compiled with -DMONTY_TEST_HOOKS=true?)"
+  exit 1
+fi
+
+echo ""
+echo "=== PASSED: with__cm_* conformance on WASM ==="


### PR DESCRIPTION
Stacked on #110.

Context-manager (`with__cm_*`) conformance for `with open()` on both backends,
gated behind a marker-driven test-hooks build:

- FFI conformance for `with__cm_*`.
- WASM conformance for `with__cm_*` via the staged test-hooks build.

This is the branch the dart_monty 0.18 migration depends on (it carries the
full file-I/O + context-manager surface).

**Stack:** #108 → #109 → #110 → **test-hooks-cm** → demo-file-io → open-primitive