### PR TITLE
feat(mount)!: host-reaching files (VFS Phase 5), and the open() mode defect it surfaced

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -818,14 +818,25 @@ jobs:
         # test_cm_wasm.sh stages into temp dirs and builds into its own
         # CARGO_TARGET_DIR precisely so it cannot leave a test-hooks engine
         # where lib/assets/ is staged from. Assert that, rather than trust it.
+        #
+        # js/package-lock.json is EXCLUDED, and the exclusion is not a shrug.
+        # `npm install --force` rewrites it whenever the runner's npm resolves
+        # differently from whoever last committed it, which is npm's churn and
+        # not something the corpus did. Four other jobs in this file run the
+        # same `npm install --force` (lines ~317, ~540, ~716, ~785) and none of
+        # them guards its tree, so this job was simply the first to look.
+        # Whether the committed lockfile should match CI's npm is a real
+        # question; it is not this job's to answer, and failing here would only
+        # teach people to ignore a red corpus check.
         run: |
           set -euo pipefail
-          if [ -n "$(git status --porcelain)" ]; then
+          DIRTY="$(git status --porcelain -- . ':(exclude)js/package-lock.json')"
+          if [ -n "$DIRTY" ]; then
             echo "FAIL: the test-hooks corpus modified the working tree:"
-            git status --porcelain
+            echo "$DIRTY"
             exit 1
           fi
-          echo "OK: tree clean"
+          echo "OK: tree clean (js/package-lock.json excluded — see comment)"
 
   # ---------------------------------------------------------------------------
   # Patch coverage gate — PRs must maintain >= 70% coverage on changed lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ it went from 1321 to 306 public items and most of what this package uses moved t
 the new `monty-types` crate — so this is a substantial internal change with a
 small consumer-facing surface.
 
+### Added
+
+- **`package:dart_monty_core/unsafe_callback_file.dart` — host-reaching virtual
+  files.** `VfsCallbackFile(path, read:, write:)` backs a virtual file with
+  host callbacks, mirroring upstream's `CallbackFile` (`os_access.py:676`). It
+  ships in a **separate library** because importing it is a security decision:
+  the callbacks run on the host with full access to the filesystem, network and
+  every other system resource, and one that touches the real filesystem breaks
+  the Monty sandbox. Upstream's warning is repeated on the class.
+
+  The callback always receives the path the file was **seeded** at, never its
+  live `path`. A rename rewrites the live path of every file in the moved
+  subtree, so passing that to the callback would let sandboxed Python choose the
+  argument the host receives simply by renaming inside the mount.
+
+  **This separation is a signal, not a boundary, and the distinction is worth
+  your attention.** `VfsFile` is an open interface, so a host-reaching backing
+  can be written against the main library with no import at all — that was true
+  before this release and remains true. The reviewer's rule is *audit every
+  `VfsFile` that is not a `MontyMemoryFile`*; this library makes the common case
+  greppable and does not replace that rule.
+
 ### Breaking
 
 - **A path outside every mount is reported as absent, not denied.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,26 @@ small consumer-facing surface.
   Found by porting upstream's `test_os_access.py`, whose own test for this is a
   named data-loss regression guard.
 
+- **A `rename` TARGET outside every mount is absent too, not denied.** The rule
+  below was never carried through to the second path of a two-path call. A
+  target outside every mount declined instead, which with no fallthrough
+  surfaced as `PermissionError: Permission denied: '<target>'` — so sandboxed
+  code could map the sandbox by comparing exceptions: `PermissionError` meant
+  "outside your mounts", `FileNotFoundError` meant "just missing". It now
+  raises `FileNotFoundError: [Errno 2] No such file or directory: '<target>'`,
+  the same message a target whose parent is simply missing already gets, which
+  is what makes the two indistinguishable.
+
+  Upstream does not pin this case — `route_call` propagates "no mount" as a
+  non-answer (`monty-fs/src/mount_table.rs:125`) and upstream's own security
+  test accepts either outcome outright (`monty-fs/tests/fs_security.rs:1078`:
+  `None => {} // Also acceptable`).
+
+  Also fixed in the same place: declining to a `fallthrough` rewrote the call to
+  a single argument, so a fallthrough handler received `Path.rename` with its
+  **source dropped**. It now forwards both. (Upstream's `on_no_handler` names
+  the source for a rename, never the target — `monty-types/src/os.rs:241`.)
+
 - **A path outside every mount is reported as absent, not denied.**
   `memoryMountedOsHandler` raised `PermissionError` for anything it does not
   mount, which made `Path('/nonexistent').exists()` unusable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,42 @@ it went from 1321 to 306 public items and most of what this package uses moved t
 the new `monty-types` crate — so this is a substantial internal change with a
 small consumer-facing surface.
 
+### Mount lifetime and mode — read this if you are porting from `pydantic_monty`
+
+Three behaviours that were true but documented nowhere. None is a change; all
+three surprise people, and one of them differs from upstream's default.
+
+- **Our default mount mode is `readWrite`. Upstream's is `overlay`.** Pass no
+  `mode` and writes **persist** for the life of the handler. Upstream's
+  `MountDir(mode='overlay')` — its default (`_monty.pyi:90`) — captures writes
+  in memory and **discards them at feed end**. We have no overlay mode
+  (`MountMode` is `readOnly | readWrite`) because upstream's overlay falls
+  through to a real host directory and our mounts have no host path: our tree
+  *is* the filesystem, so there is nothing to fall through to.
+
+  In practice the two are **indistinguishable within one feed over a mount with
+  nothing underneath it** — which is why both of upstream's own
+  `OverlayMemory`-generated `mount_fs` fixtures pass green against our
+  `readWrite` tree.
+
+- **Mount state is scoped to the HANDLER, not to a feed.** Upstream discards by
+  dropping a per-feed mount table; our equivalent is dropping the handler.
+  Because `osHandler` is a per-feed parameter, **constructing a fresh handler
+  over fresh files per feed reproduces upstream's overlay behaviour exactly**,
+  with no extra API. Reusing one handler across feeds gives persistence.
+
+- **Seeded `VfsFile` objects are mutated IN PLACE by sandboxed code.** This is
+  upstream's contract (`os_access.py:608`, *"When Monty code writes to this
+  file, the content attribute is updated"*) and it is what makes output capture
+  work: seed `MontyMemoryFile('/out.txt', '')`, run, read `.content` back.
+
+  The consequence to know about: a fresh handler over **reused** seed objects
+  gives a *half* discard — files the sandbox created are gone, but your own
+  objects stay rewritten. If you want a clean slate, construct fresh
+  `MontyMemoryFile`s, not just a fresh handler. Pinned by
+  `memory_mounted_os_handler_test.dart`, "a fresh handler over REUSED seeds
+  half-discards, on purpose".
+
 ### Added
 
 - **`package:dart_monty_core/unsafe_callback_file.dart` — host-reaching virtual
@@ -75,7 +111,7 @@ small consumer-facing surface.
   Ported from upstream rather than invented: the default matches
   `DEFAULT_MEMORY_USAGE_LIMIT` (`monty-fs/src/mount_table.rs:18`), and each node
   is charged `entryMemoryUsage` (256 bytes) plus its content, matching
-  `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:22`). The per-entry
+  `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:21`). The per-entry
   charge is what stops a million empty files, which cost no content bytes and a
   great deal of real memory.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,28 @@ small consumer-facing surface.
   `VfsFile` that is not a `MontyMemoryFile`*; this library makes the common case
   greppable and does not replace that rule.
 
+### Fixed
+
+- **`open()` with a malformed mode raised nothing and created a file.**
+  `resolveOpenCall` string-compared the mode and treated *everything*
+  unrecognised as append: `open(p, 'wxyz')`, `open(p, 'x')` and even
+  `open(p, '')` fell through to create-if-missing. It now parses the mode
+  before any side effect and raises `ValueError: invalid mode: '<mode>'`,
+  which is what upstream does and for the reason upstream states
+  (`os_access.py:870-876`) — a direct caller must not be able to trigger the
+  truncate/create branch with a mode that was never valid.
+
+  Two consequences beyond the rejection. `b`, `t` and `+` are now understood as
+  orthogonal to the open-time action, so `r+`, `rt` and `rb+` are read actions
+  that check existence instead of silently creating, and `w+`/`wt`/`wb+`
+  truncate. And `x` (exclusive create) is rejected rather than treated as
+  append — upstream's own code asserts the action is one of `r`/`w`/`a`
+  (`os_access.py:896`), so accepting it would invent a semantic neither side
+  implements.
+
+  Found by porting upstream's `test_os_access.py`, whose own test for this is a
+  named data-loss regression guard.
+
 ### Breaking
 
 - **A path outside every mount is reported as absent, not denied.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,45 @@ small consumer-facing surface.
   Found by porting upstream's `test_os_access.py`, whose own test for this is a
   named data-loss regression guard.
 
+- **`MountDir.writeBytesLimit` is now CUMULATIVE, not per-write.** It capped a
+  single call, which bounds nothing an attacker cares about:
+  `write_bytes(b'x' * limit)` in a loop passed every check and exhausted host
+  memory. Measured against the old code, a limit of 100 bytes let **all ten** of
+  ten 30-byte writes through.
+
+  Upstream's parameter of the same name has always been cumulative — *"Cap on
+  cumulative bytes written through the mount within one feed"*
+  (`_monty.pyi:111-113`) — so the old behaviour was a silent contract mismatch
+  for anyone porting from `pydantic_monty`. It is monotonic: deleting a file
+  does not buy budget back, because the bytes were still written.
+
+  The message now matches upstream's too:
+  `OSError: disk write limit of 10 bytes exceeded` (was
+  `Write exceeds mount limit (100 > 10 bytes): /path`).
+
+- **New: `MountDir.memoryUsageLimit`, defaulting to 100 MB.** Bounds the bytes
+  a mount **currently retains**, where `writeBytesLimit` bounds what has flowed
+  through. Deleting refunds this one. Exceeding it raises
+  `MemoryError: mount memory usage limit of 100 MB exceeded`.
+
+  Ported from upstream rather than invented: the default matches
+  `DEFAULT_MEMORY_USAGE_LIMIT` (`monty-fs/src/mount_table.rs:18`), and each node
+  is charged `entryMemoryUsage` (256 bytes) plus its content, matching
+  `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:22`). The per-entry
+  charge is what stops a million empty files, which cost no content bytes and a
+  great deal of real memory.
+
+  Two deliberate scoping choices, both documented on `VfsAccountant`: content
+  **seeded** through `files:` is not charged, because the budget exists to bound
+  what untrusted code makes us retain rather than what the consumer handed us;
+  and a host-reaching file's content is never charged *or measured*, since
+  asking it for a size would fire a host callback — accounting must not have
+  side effects.
+
+  Because we have no feed boundary to hang state on, both limits are scoped to
+  the handler instance. For a one-shot `run()` that is identical to upstream;
+  for a long-lived REPL it is stricter.
+
 - **A `rename` TARGET outside every mount is absent too, not denied.** The rule
   below was never carried through to the second path of a two-path call. A
   target outside every mount declined instead, which with no fallthrough

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ small consumer-facing surface.
   `VfsFile` that is not a `MontyMemoryFile`*; this library makes the common case
   greppable and does not replace that rule.
 
-### Fixed
+### Breaking
 
-- **`open()` with a malformed mode raised nothing and created a file.**
+- **`open()` parses its mode, and rejects a malformed one.**
   `resolveOpenCall` string-compared the mode and treated *everything*
   unrecognised as append: `open(p, 'wxyz')`, `open(p, 'x')` and even
   `open(p, '')` fell through to create-if-missing. It now parses the mode
@@ -50,8 +50,6 @@ small consumer-facing surface.
 
   Found by porting upstream's `test_os_access.py`, whose own test for this is a
   named data-loss regression guard.
-
-### Breaking
 
 - **A path outside every mount is reported as absent, not denied.**
   `memoryMountedOsHandler` raised `PermissionError` for anything it does not

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,6 +20,23 @@ analyzer:
     # analysing it would double-report that package's issues. `.gitignore`
     # does not help here — the analyzer does not consult it.
     - 'site/**'
+    # Agent worktrees (`git worktree add .claude/worktrees/...`). Each is a
+    # FULL checkout of this package nested inside it, so without this the
+    # analyzer walks N extra copies of lib/ and test/ — and reports their
+    # issues against THIS package, at paths that do not exist on this branch.
+    #
+    # THE COMPENSATING STEP IS THAT THERE IS NOTHING TO COMPENSATE FOR: unlike
+    # a normal exclusion, this hides no code from analysis. Every file under a
+    # worktree is the same package analysed in its own root, by its own
+    # `dart analyze` / gate run, against its own branch. Excluding it here
+    # removes duplicate reporting, not coverage.
+    #
+    # Measured 2026-08-03: a worktree agent's gate went red with
+    # `Error when reading 'lib/src/mount/vfs_limits.dart': No such file or
+    # directory` — a file that exists on one branch and not another, surfaced
+    # because two checkouts were in one analysis scope. Five stale worktrees
+    # were live at the time.
+    - '.claude/worktrees/**'
 
   language:
     strict-casts: true

--- a/docs/contributor/vfs-phases.md
+++ b/docs/contributor/vfs-phases.md
@@ -377,11 +377,41 @@ action, as upstream has them — `r+` is a *read* action and no longer creates.
 
 Neither item is "not done yet"; both are decisions already taken.
 
-- [ ] **overlay mode + `deleted` tombstones** — "only if a consumer needs it",
-      and the VFS API currently has **no downstream consumer at all**
-      (measured: zero hits for `VfsFile`/`memoryMountedOsHandler` across
-      `dart_monty`, `dart_monty_labs` and every `soliplex*` repo). Building it
-      now would be speculative.
+- [x] ~~**overlay mode + `deleted` tombstones**~~ — **SETTLED AGAINST, and the
+      two were wrongly bundled.** Bundling them made the feature look ~4× more
+      expensive than its useful part, which hid the real answer.
+
+      Upstream's overlay separates into three independent ingredients, and only
+      the first is intrinsically about a host directory:
+
+      1. an **immutable lower layer** — the one property we genuinely lack;
+      2. an **in-memory upper layer with tombstones** — needed *only because
+         upstream cannot unlink a host file*. We can delete from our tree, so
+         tombstones are a consequence of (1), not of overlay;
+      3. **discard at feed end** — **already reachable today.** `osHandler` is a
+         per-feed parameter, so a fresh handler over fresh files reproduces
+         upstream's overlay observable exactly, with no new API.
+
+      Two measurements decided it. Both of upstream's own
+      `OverlayMemory`-generated `mount_fs` fixtures pass green against our
+      `readWrite` tree — within one feed, over a mount with nothing underneath,
+      overlay and read-write are **observationally identical**, which is why the
+      missing mode has never shown up. And `overlay.rs` is 1221 lines that exist
+      to reconcile a *real directory* with an in-memory diff; we have no real
+      directory, so porting the diff machinery would be building the expensive
+      half of a feature whose cheap half already works.
+
+      It is also a **lifetime, not a mode**: `MountDir` is a `const` value object
+      while the thing being scoped is mutable per-feed state. Upstream gets away
+      with `OverlayMemory(OverlayState)` only because Rust enums carry payloads
+      and its `Mount` is rebuilt per feed.
+
+      If a consumer ever needs an immutable lower layer, the variant to build is
+      **`fallthrough` as the lower layer** — its "host" is a consumer-written
+      callback, which is *consistent with* the host-mount decision below rather
+      than a reversal of it. Note it would re-scope an existing public
+      parameter: `fallthrough` is consulted today only for paths outside every
+      mount, never for a path inside one that is merely absent.
 - [ ] **boundary-enforced host mounts** (`MountDir.hostPath` + a Dart
       `path_security`) — **settled against.** A solo-maintained Dart
       re-derivation of upstream's Rust boundary module, tested against one
@@ -426,9 +456,17 @@ Neither item is "not done yet"; both are decisions already taken.
       3. **The engine passes `..` through verbatim.** Probed:
          `ENGINE PASSED: Path.read_text /data/../../etc/passwd` — it collapses
          `.` only. Our clamp is load-bearing, not belt-and-braces.
-      4. **Phase 6 changes `lookup`.** The `deleted` flag goes on the node, so
+      4. ~~**Phase 6 changes `lookup`.** The `deleted` flag goes on the node, so
          publishing `lookup` now turns a planned internal change into a breaking
-         one.
+         one.~~ **STRUCK — the premise was not upstream's shape.** Upstream's
+         tombstone is a **peer variant in a flat, per-feed map** (`Deleted`
+         alongside `File`/`RealFileRef`/`Directory`, `overlay_state.rs:207-223`),
+         not a bool on a tree node — and a bool on `VfsFile` could not express a
+         tombstoned *directory*, which `rmdir` needs (`overlay.rs:705`). Under a
+         Rust-shaped design the tombstone lives beside `VfsTree`, the merge
+         happens in the handler, and `lookup` does not change at all. The
+         decision to keep `VfsTree` internal stands on 1–3; 2 was always the
+         strong one.
       If this is ever reversed, the minimum bill is: mark it `final class` (it
       currently has no modifier, so exporting publishes ten *overridable*
       methods), export `normalizeVfsPath` with a note about `..`, and say in the

--- a/docs/contributor/vfs-phases.md
+++ b/docs/contributor/vfs-phases.md
@@ -1,10 +1,15 @@
-# VFS rework — phase checklist
+# VFS rework — phase checklist and design record
 
-Execution checklist for the VFS rework. Design and rationale live in
-`~/dev/plans/monty-0.19-upgrade/vfs-design.md`; this file is the part you tick
-off, and it is deliberately machine-checkable.
+Execution checklist for the VFS rework, and now the single home for its design
+rationale. A separate `vfs-design.md` lived outside the repo; it was **deleted**
+once the work landed, because its tail had gone systematically stale — it still
+posed questions about a `VfsStore` that §5 of the same document had deleted, and
+listed as open a memory budget that had already shipped. A design doc that
+outlives its own premises misleads the next reader. The arguments worth keeping
+are consolidated in "Why this shape" at the bottom.
 
-Branch: `feat/vfs-019`.
+Branches: `feat/vfs-019` (Phases 1–4), `feat/vfs-callback-file` (Phase 5, §6c
+and the limits).
 
 ## The two commands
 
@@ -384,11 +389,94 @@ Neither item is "not done yet"; both are decisions already taken.
       consumer deliberately wrote. Challenged in review and the objection was
       withdrawn.
 
-## Open decisions (owner, not implementer)
+## Owner decisions — all three CLOSED
 
-- [ ] **Per-feed or persistent writes?** 0.19 discards overlay writes at feed
-      end; ours persist. A consumer porting from `pydantic_monty` will assume
-      upstream's.
-- [ ] **Per-mount memory budget?** Without one, `write_bytes` in a loop can
-      exhaust host memory — `writeBytesLimit` caps a single write, not the total.
-- [ ] Is the store type public API?
+- [x] **Per-feed or persistent writes?** **Not actually open — it named the
+      wrong host.** The per-feed discard belongs to `MountDir(mode='overlay')`
+      (`_monty.pyi:110`), the Rust/pool path, where a real host directory is the
+      durable thing and the overlay is scratch. We have no overlay and no host
+      directory: our tree *is* the filesystem, so "discard at feed end" would
+      either erase what the consumer seeded or erase writes while seeds survive.
+      The host we mirror is Python `OSAccess`, and it **persists** — *"When
+      Monty code writes to this file, the content attribute is updated"*
+      (`os_access.py:608`), which is what Phase 1a implemented. A consumer
+      porting from `pydantic_monty` assumes persistence and gets it. Revisit
+      only if Phase 6 lands overlay mode, which is when we would need a feed
+      boundary we do not currently model.
+- [x] **Per-mount memory budget?** Shipped. And the framing understated it: our
+      `writeBytesLimit` had upstream's *name* with per-write semantics, which
+      bounds nothing — measured, a 100-byte cap let all ten of ten 30-byte
+      writes through. Now cumulative, plus `memoryUsageLimit` at upstream's
+      100 MB default.
+- [x] **Is the store type public API?** **No — `VfsTree` stays internal.** The
+      question as originally posed asked about a `VfsStore` that the design doc
+      had already deleted in favour of per-file backing, and named a
+      `hostMountedOsHandler` that was settled against. On the live version:
+      1. **The decision is not symmetric.** Adding an export later is additive;
+         removing one is breaking. Zero consumers makes this the cheapest moment
+         to decide the *reversible* direction, not either direction.
+      2. **Exporting it is a half-kit.** `OsCallHandler` is a bare typedef and
+         `resolveOpenCall` is exported and store-agnostic by design
+         (`open_call.dart:10-12`), so a consumer *can* author a working
+         tree-backed handler — verified by probe — but with no mount matching,
+         no `MountMode`, no accounting, and **no path clamp**, because
+         `normalizeVfsPath` and `VfsAccountant` are unexported. It ships the
+         part that makes a wrong handler easy and withholds what a right one
+         needs.
+      3. **The engine passes `..` through verbatim.** Probed:
+         `ENGINE PASSED: Path.read_text /data/../../etc/passwd` — it collapses
+         `.` only. Our clamp is load-bearing, not belt-and-braces.
+      4. **Phase 6 changes `lookup`.** The `deleted` flag goes on the node, so
+         publishing `lookup` now turns a planned internal change into a breaking
+         one.
+      If this is ever reversed, the minimum bill is: mark it `final class` (it
+      currently has no modifier, so exporting publishes ten *overridable*
+      methods), export `normalizeVfsPath` with a note about `..`, and say in the
+      class doc that the tree is a data structure and **not** a policy boundary.
+
+## Why this shape — the durable arguments
+
+Consolidated from the deleted design doc. These are the arguments that would
+otherwise get re-litigated.
+
+**Upstream wrote both candidate designs and shipped the tree.** Its repo
+contains two managed hosts: `OSAccess`, a recursive `dict[str, File | Tree]`
+(`os_access.py:591`), shipped in production; and `TestOS`, a
+`dict[str, bytes]` **plus** a `set[str]`, which exists only as a test fixture
+(`test_os_access_raw.py:26-27`). An earlier draft of our design proposed the
+`TestOS` model. Compare one operation — `TestOS.path_iterdir` needs two scans
+and a dedupe over two collections, while `OSAccess.path_iterdir` is one line
+(`os_access.py:1019`). The tree wins on three concrete grounds, not aesthetics: one
+source of truth, so a path in both collections or a file whose parent is missing
+from the dir set is unrepresentable; every operation needs a three-way answer
+(file / dir / missing) which the tree gives structurally; and empty directories
+exist for free.
+
+**The platform split is per-FILE, not per-store.** Web supplies only in-memory
+files; a host-reaching backing is one more `VfsFile` implementation. One store,
+one tree, one code path — the difference is which file objects are in it. This
+is why there is no `VfsStore` abstraction and why `VfsFile` is an open interface
+while `VfsNode` is sealed: the set of node *kinds* is closed, the set of content
+*backings* is not.
+
+**Do not reimplement `path_security.rs` in Dart.** Upstream calls it their sole
+security boundary. A solo-maintained Dart re-derivation, tested against one
+person's adversarial imagination, is more dangerous than a callback the consumer
+deliberately wrote. Challenged in adversarial review; the objection was
+withdrawn.
+
+**The corpus is not the only spec.** Upstream's Python binding has four test
+files covering behaviour no fixture reaches, and mining them found a live
+data-loss defect (see §6c):
+
+| file | what it pins |
+|---|---|
+| `tests/test_os_access.py` | the `OSAccess` behaviour spec — empty dirs, the mkdir matrix, `IsADirectoryError` sites, `open()` modes, return-value units |
+| `tests/test_os_access_raw.py` | the raw callback protocol, `NOT_HANDLED` fallthrough, and the `TestOS` model upstream did not ship |
+| `tests/test_os_calls.py` | the bare callback contract and mkdir kwarg marshalling |
+| `tests/test_mount_table.py` | mount semantics, incl. `resolve()` normalising `..` |
+
+**A store swap silently changes what every injected predicate means.** The
+lesson from Phase 1b, worth carrying forward: grep for the *predicates*, not
+just the store. `exists` meant "a file is here" under a flat map and "a node is
+here" under a tree, and one nested `if` was wrong for a week because of it.

--- a/docs/contributor/vfs-phases.md
+++ b/docs/contributor/vfs-phases.md
@@ -272,15 +272,75 @@ filesystem fixture.
       an exit code — `test_cm_wasm.sh:222` exits 0 when Chrome is missing.
 - [x] regression script green · gate green
 
-## Phase 5 — FFI local files · STOP, needs review
+## Phase 5 — host-reaching files · reviewed, shipped
 
-**Do not automate.** A sandbox-escape surface.
+- [x] `VfsCallbackFile` in a **separate library**
+      (`package:dart_monty_core/unsafe_callback_file.dart`), so importing it is
+      an affirmative act visible in review
+- [x] ~~The default entry point cannot accept one without that import~~
+      **DELETED — the guarantee does not exist.** See below.
+- [x] Upstream's warning repeated verbatim (`os_access.py:684-706`, Python
+      example translated to Dart)
+- [x] Own branch, own review
+- [x] The callback receives the **seeded** path, never the live one
+- [x] regression script green · gate green
 
-- [ ] `VfsCallbackFile` in a **separate library**, so importing it is an
-      affirmative act visible in review
-- [ ] The default entry point cannot accept one without that import
-- [ ] Upstream's warning repeated verbatim
-- [ ] Own branch, own review
+### Box 2 was never true, and deleting it is the point
+
+The box asked for something Dart cannot express, and — worse — for a property
+this library never had.
+
+Not expressible: `VfsFile` is an `abstract interface class` (`vfs_node.dart:37`)
+and the entry point takes `List<VfsFile>` (`memory_mounted_os_handler.dart:64`),
+so any `VfsFile` satisfies it. The import gates **construction**, not
+**passing**.
+
+Never true, which is the part that matters. **A host-reaching `VfsFile` is
+constructible today from the shipped public API, with no Phase 5 code and no
+special import.** Measured: a separate package with a path dependency,
+importing only `package:dart_monty_core/dart_monty_core.dart`, ~20 lines —
+
+```dart
+class HostFile implements VfsFile {
+  @override
+  VfsContent get content => VfsText(File(hostPath).readAsStringSync());
+  // …path, permissions
+}
+```
+
+— analysed clean and read host content out through `Path.read_text`.
+
+So a checkbox promising the entry point *cannot* accept an unsafe file would
+teach a reviewer that the `files:` list needs no scrutiny, which is exactly
+backwards. A guarantee you advertise but cannot enforce is worse than none,
+because it displaces the manual control doing the real work.
+
+**The honest rule, which replaces the box: audit every `VfsFile` that is not a
+`MontyMemoryFile`.** `unsafe_callback_file.dart` makes the common case
+greppable; it does not make the unlabelled route unavailable.
+
+Reviewed adversarially by two model families independently (Gemini 3.6 and
+Claude), both of which killed the alternative designs — a sealed marker
+supertype, a runtime whitelist, and a declared `reachesHost` bit on the
+interface. Full disposition ledger:
+`~/dev/plans/monty-0.19-upgrade/artifacts/phase5/LEDGER.md`.
+
+### Why the callback gets the seeded path
+
+A rename rewrites the live `path` of every file in the moved subtree
+(`vfs_tree.dart:168`). Handing that to the callback would let sandboxed Python
+choose the argument the host receives, just by renaming inside the mount —
+demonstrated red before the fix, in `vfs_callback_file_test.dart`. Upstream has
+the same exposure via directory rename (`os_access.py:1128-1136`); we had it via
+file rename too, because our `move()` rewrites both.
+
+`VfsCallbackFile` freezes `seededPath` at construction and hands the callback
+that. `path` still tracks the tree, so `resolve` and `iterdir` stay correct.
+
+Two bounds worth recording, both measured: sandboxed code **cannot leave the
+mount** (the clamp at `vfs_path.dart` plus "outside a mount means absent"), and
+**cannot mint a callback file** — every file Monty creates is a
+`MontyMemoryFile` (`vfs_tree.dart:126`, mirroring `os_access.py:967`).
 
 ## Phase 6 — deferred
 

--- a/docs/contributor/vfs-phases.md
+++ b/docs/contributor/vfs-phases.md
@@ -342,11 +342,47 @@ mount** (the clamp at `vfs_path.dart` plus "outside a mount means absent"), and
 **cannot mint a callback file** — every file Monty creates is a
 `MontyMemoryFile` (`vfs_tree.dart:126`, mirroring `os_access.py:967`).
 
-## Phase 6 — deferred
+## §6c — port upstream's `OSAccess` suite · done
 
-- [ ] overlay mode + `deleted` tombstones
-- [ ] boundary-enforced host mounts (`MountDir.hostPath` + a Dart
-      `path_security`) — own branch, own adversarial suite
+The 531-fixture corpus is not the only spec. `test_os_access.py` pins
+directory and mode semantics no fixture reaches, and the design doc flagged it
+as worth mining. It was, immediately:
+
+- [x] `iterdir` of an **empty** directory lists as empty and does not raise —
+      distinct from a missing path, which does
+- [x] `append_text` returns **characters** where `append_bytes` returns
+      **bytes**: `'αβγ'` is 3 and 6, so the two calls must disagree
+- [x] root is a directory, lists its children, and is not a file
+- [x] **`open()` rejects a malformed mode before any side effect** — this one
+      found a live defect, see below
+- [x] regression script green · gate green
+
+### The defect it found
+
+`resolveOpenCall` string-compared the mode and sent *everything* unrecognised
+to `createIfMissing`, so `open(p, 'wxyz')`, `open(p, 'x')` and `open(p, '')`
+silently created a file instead of raising. `open_call.dart` is exported, so a
+direct caller reached it. Upstream's own test for this is a named data-loss
+regression guard (`os_access.py:870-876`).
+
+The fix parses the mode first. That also made `b`/`t`/`+` orthogonal to the
+action, as upstream has them — `r+` is a *read* action and no longer creates.
+
+## Phase 6 — deferred, and deliberately so
+
+Neither item is "not done yet"; both are decisions already taken.
+
+- [ ] **overlay mode + `deleted` tombstones** — "only if a consumer needs it",
+      and the VFS API currently has **no downstream consumer at all**
+      (measured: zero hits for `VfsFile`/`memoryMountedOsHandler` across
+      `dart_monty`, `dart_monty_labs` and every `soliplex*` repo). Building it
+      now would be speculative.
+- [ ] **boundary-enforced host mounts** (`MountDir.hostPath` + a Dart
+      `path_security`) — **settled against.** A solo-maintained Dart
+      re-derivation of upstream's Rust boundary module, tested against one
+      person's adversarial imagination, is more dangerous than a callback the
+      consumer deliberately wrote. Challenged in review and the objection was
+      withdrawn.
 
 ## Open decisions (owner, not implementer)
 

--- a/example/12_mount_dir.dart
+++ b/example/12_mount_dir.dart
@@ -10,7 +10,8 @@
 //  - Sandbox boundary — `..` traversal that escapes raises
 //    PermissionError.
 //  - MountMode (readOnly rejects writes).
-//  - Per-write writeBytesLimit (cumulative tracking is a follow-up).
+//  - Cumulative writeBytesLimit (total bytes through the mount) and
+//    memoryUsageLimit (bytes currently retained; 100 MB by default).
 //
 // Compared to a hand-rolled OsCallHandler (see example 03), MountDir
 // declares the policy once and lets the helper enforce it.
@@ -75,8 +76,9 @@ Future<void> _readOnly() async {
   print('write:  error="${fail.error?.message}"');
 }
 
-// ── writeBytesLimit caps per-call write size ─────────────────────────────────
-// Useful when accepting writes from Python you don't fully trust.
+// ── writeBytesLimit caps CUMULATIVE bytes through the mount ──────────────────
+// Monotonic: deleting does not buy budget back. memoryUsageLimit is the
+// companion that bounds the live tree instead, and IS refunded on delete.
 Future<void> _writeLimit() async {
   print('\n── writeBytesLimit ──');
 

--- a/lib/dart_monty_core.dart
+++ b/lib/dart_monty_core.dart
@@ -30,6 +30,11 @@ export 'src/mount/mount_dir.dart';
 export 'src/mount/mount_mode.dart';
 export 'src/mount/open_call.dart';
 export 'src/mount/vfs_content.dart';
+// `VfsAccountant` (src/mount/vfs_accountant.dart) is deliberately NOT exported: it is the handler's internal
+// bookkeeping, and exposing it would make the accounting model — which nothing
+// outside depends on — public API.
+export 'src/mount/vfs_limits.dart'
+    show defaultMemoryUsageLimit, entryMemoryUsage, formatBytesPretty;
 export 'src/mount/vfs_node.dart';
 export 'src/platform/code_capture.dart';
 export 'src/platform/inputs_encoder.dart';

--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -16,8 +16,11 @@ import 'package:dart_monty_core/src/platform/monty_value.dart';
 /// from an in-memory virtual filesystem.
 ///
 /// `mounts` declare which path prefixes Python can reach. `files` seeds the
-/// backing store. Paths outside every mount fall through to [fallthrough] (or
-/// raise `PermissionError` in Python if no fallthrough is given).
+/// backing store. Paths outside every mount fall through to [fallthrough] (or,
+/// with no fallthrough, are reported as **absent** — `FileNotFoundError`, and
+/// `false` from the existence queries. Not `PermissionError`: saying a path is
+/// both denied and non-existent contradicts itself, and "denied" confirms the
+/// path was worth denying. That holds for a `rename` target too).
 ///
 /// ```dart
 /// final handler = memoryMountedOsHandler(
@@ -509,7 +512,36 @@ OsCallHandler memoryMountedOsHandler({
         final target = normalizeVfsPath(rawTarget);
         final targetMount = _findMount(target, normalizedMounts);
         if (targetMount == null) {
-          return notMine(op, [target], kwargs);
+          // FB-11 P5 again, and it was never carried through to here. A TARGET
+          // outside every mount used to decline, which with no fallthrough
+          // surfaced as `PermissionError: Permission denied: '<target>'` — the
+          // exact secret the source path at :237-264 was changed to stop
+          // telling. Sandboxed code could distinguish "outside my mounts" from
+          // "fine" by which exception came back.
+          //
+          // Upstream does not pin this case: `route_call` propagates `None` for
+          // an unmounted dst (monty-fs/src/mount_table.rs:125) and its own
+          // security test accepts either outcome outright —
+          // `None => {} // Also acceptable — dst doesn't match any mount.`
+          // (monty-fs/tests/fs_security.rs:1078). So this is our call, and our
+          // own stated reasoning already answers it.
+          //
+          // FileNotFoundError naming the target also makes an out-of-mount
+          // target indistinguishable from one whose parent is simply missing,
+          // which `requireParentDir` already reports with this same message.
+          if (fallthrough == null) {
+            throw OsCallException(
+              "[Errno 2] No such file or directory: '$target'",
+              pythonExceptionType: 'FileNotFoundError',
+            );
+          }
+
+          // `args`, not `[target]`. Declining used to rewrite the call to a
+          // single argument, so a fallthrough handler received `Path.rename`
+          // with its source dropped — and upstream's own `on_no_handler` names
+          // the SOURCE for a rename (monty-types/src/os.rs:241,
+          // `Self::Rename(a) => Some(a.src.as_str())`), never the target.
+          return notMine(op, args, kwargs);
         }
         _requireWritable(targetMount, target);
         // CPython's rename is four errors and one SILENT OVERWRITE,

--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -6,6 +6,7 @@ import 'package:dart_monty_core/src/externals.dart';
 import 'package:dart_monty_core/src/mount/mount_dir.dart';
 import 'package:dart_monty_core/src/mount/mount_mode.dart';
 import 'package:dart_monty_core/src/mount/open_call.dart';
+import 'package:dart_monty_core/src/mount/vfs_accountant.dart';
 import 'package:dart_monty_core/src/mount/vfs_content.dart';
 import 'package:dart_monty_core/src/mount/vfs_node.dart';
 import 'package:dart_monty_core/src/mount/vfs_path.dart';
@@ -39,8 +40,13 @@ import 'package:dart_monty_core/src/platform/monty_value.dart';
 ///   `PermissionError`)
 /// - **Mode** (writes against a [MountMode.readOnly] mount raise
 ///   `PermissionError`)
-/// - **Per-write byte limit** (writes exceeding `writeBytesLimit` raise
-///   `OSError`); cumulative tracking across calls is a follow-up.
+/// - **Cumulative write limit** — bytes written through a mount, totalled
+///   across calls, capped by `MountDir.writeBytesLimit` (`OSError`)
+/// - **Retained-memory budget** — bytes the sandbox currently holds under a
+///   mount, capped by `MountDir.memoryUsageLimit`, 100 MB by default
+///   (`MemoryError`). Deleting gives budget back; the write limit is monotonic
+///   and does not. A `write_bytes` loop is caught by the first, a large live
+///   tree by the second.
 ///
 /// Serves **all 19 filesystem operations** the engine can issue (the
 /// `is_filesystem` set at monty-types/src/os.rs:178): `open`, `Path.read_text`,
@@ -74,6 +80,7 @@ OsCallHandler memoryMountedOsHandler({
           virtualPath: normalizeVfsPath(m.virtualPath),
           mode: m.mode,
           writeBytesLimit: m.writeBytesLimit,
+          memoryUsageLimit: m.memoryUsageLimit,
         ),
       )
       .toList(growable: false);
@@ -87,6 +94,11 @@ OsCallHandler memoryMountedOsHandler({
     ],
     mountRoots: normalizedMounts.map((m) => m.virtualPath),
   );
+
+  // Per-mount byte accounting. Seeded content is deliberately NOT charged —
+  // see [VfsAccountant] — so the budget bounds what the sandbox makes us
+  // retain, not what the consumer handed us.
+  final accountant = VfsAccountant();
 
   /// Requires that [path]'s parent directory exists before a file is created
   /// there, per upstream's `_write_file` (os_access.py:964-970).
@@ -224,9 +236,17 @@ OsCallHandler memoryMountedOsHandler({
         // stale semantics — a false green, which is worse than a red.
         isDirectory: (p) => vfs.lookup(p) is VfsDir,
         ensureWritable: (p) => _requireWritable(mount, p),
-        truncate: (p) => putContent(p, VfsText('')),
+        // `open(p, 'w')` and `open(p, 'a')` create nodes, so they are charged
+        // the per-entry cost even though they write no content — a million
+        // `open(..., 'w')` calls is exactly the exhaustion the budget bounds.
+        truncate: (p) {
+          accountant.recordWrite(mount, p, wrote: 0, retains: 0);
+          putContent(p, VfsText(''));
+        },
         createIfMissing: (p) {
-          if (!vfs.exists(p)) putContent(p, VfsText(''));
+          if (vfs.exists(p)) return;
+          accountant.recordWrite(mount, p, wrote: 0, retains: 0);
+          putContent(p, VfsText(''));
         },
       );
     }
@@ -301,7 +321,13 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'TypeError',
           );
         }
-        _enforceLimit(mount, path, utf8.encode(value).length);
+        final wroteText = utf8.encode(value).length;
+        accountant.recordWrite(
+          mount,
+          path,
+          wrote: wroteText,
+          retains: wroteText,
+        );
         putContent(path, VfsText(value));
 
         return _codepointCount(value);
@@ -318,7 +344,12 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'TypeError',
           );
         }
-        _enforceLimit(mount, path, bytes.length);
+        accountant.recordWrite(
+          mount,
+          path,
+          wrote: bytes.length,
+          retains: bytes.length,
+        );
         putContent(path, VfsBytes(Uint8List.fromList(bytes)));
 
         return bytes.length;
@@ -332,13 +363,20 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'TypeError',
           );
         }
-        _enforceLimit(mount, path, utf8.encode(value).length);
         refuseDirectory(path);
         final existing = vfs.fileAt(path);
         final head = existing == null
             ? ''
             : _decodeUtf8(existing.content.bytes);
-        putContent(path, VfsText('$head$value'));
+        final combined = '$head$value';
+        // An append WROTE only the new bytes but RETAINS the whole file.
+        accountant.recordWrite(
+          mount,
+          path,
+          wrote: utf8.encode(value).length,
+          retains: utf8.encode(combined).length,
+        );
+        putContent(path, VfsText(combined));
 
         return _codepointCount(value);
 
@@ -354,13 +392,16 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'TypeError',
           );
         }
-        _enforceLimit(mount, path, bytes.length);
         refuseDirectory(path);
         final prior = vfs.fileAt(path);
-        putContent(
+        final joined = Uint8List.fromList([...?prior?.content.bytes, ...bytes]);
+        accountant.recordWrite(
+          mount,
           path,
-          VfsBytes(Uint8List.fromList([...?prior?.content.bytes, ...bytes])),
+          wrote: bytes.length,
+          retains: joined.length,
         );
+        putContent(path, VfsBytes(joined));
 
         return bytes.length;
 
@@ -393,6 +434,7 @@ OsCallHandler memoryMountedOsHandler({
         // one that carries a message worth reading.
         requireFile(path);
         vfs.remove(path);
+        accountant.recordRemove(mount, path);
 
         return null;
 
@@ -464,8 +506,9 @@ OsCallHandler memoryMountedOsHandler({
               pythonExceptionType: 'FileNotFoundError',
             );
           }
-          _mkdirParents(vfs, path);
+          _mkdirParents(vfs, path, accountant, mount);
         }
+        accountant.recordMkdir(mount, path);
         vfs.mkdir(path);
 
         return null;
@@ -488,7 +531,10 @@ OsCallHandler memoryMountedOsHandler({
             // An empty directory is now a real, removable node — including a
             // mount root, which the flat model had to exempt because it could
             // not tell one from an absent path.
-            if (!_isMountRoot(path, normalizedMounts)) vfs.remove(path);
+            if (!_isMountRoot(path, normalizedMounts)) {
+              vfs.remove(path);
+              accountant.recordRemove(mount, path);
+            }
 
             return null;
           case null:
@@ -587,7 +633,11 @@ OsCallHandler memoryMountedOsHandler({
             // Everything left over is a move: onto nothing, onto a file it
             // replaces, or onto an empty directory it takes the place of.
             requireParentDir(target);
+            // A rename onto an existing file destroys it, so release the
+            // target's charge before the source takes its key.
+            accountant.recordRemove(targetMount, target);
             vfs.move(path, target);
+            accountant.recordMove(mount, path, targetMount, target);
 
             return null;
         }
@@ -632,16 +682,6 @@ void _requireWritable(MountDir mount, String path) {
   }
 }
 
-void _enforceLimit(MountDir mount, String path, int bytes) {
-  final limit = mount.writeBytesLimit;
-  if (limit != null && bytes > limit) {
-    throw OsCallException(
-      'Write exceeds mount limit ($bytes > $limit bytes): $path',
-      pythonExceptionType: 'OSError',
-    );
-  }
-}
-
 /// Creates the missing directories above [path], for `mkdir(parents=True)`.
 ///
 /// A FILE in the way stops it: `mkdir -p /mnt/hello.txt/sub` cannot succeed
@@ -649,7 +689,12 @@ void _enforceLimit(MountDir mount, String path, int bytes) {
 /// rather than the `StateError` the tree throws when asked to insert under a
 /// non-directory. That StateError is a bug report for us, not an answer for
 /// Python.
-void _mkdirParents(VfsTree vfs, String path) {
+void _mkdirParents(
+  VfsTree vfs,
+  String path,
+  VfsAccountant accountant,
+  MountDir mount,
+) {
   final components = VfsTree.splitPath(path);
   final walked = StringBuffer();
   for (final component in components.sublist(0, components.length - 1)) {
@@ -664,6 +709,11 @@ void _mkdirParents(VfsTree vfs, String path) {
       case VfsDir():
         continue;
       case null:
+        // Charged BEFORE the mkdir, so a budget refusal leaves the tree as it
+        // was. `parents: true` is inherently partial on failure anyway —
+        // upstream tolerates that (os_access.py:988-995) — but a node we
+        // refused to charge must never exist.
+        accountant.recordMkdir(mount, soFar);
         vfs.mkdir(soFar);
     }
   }

--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -8,6 +8,7 @@ import 'package:dart_monty_core/src/mount/mount_mode.dart';
 import 'package:dart_monty_core/src/mount/open_call.dart';
 import 'package:dart_monty_core/src/mount/vfs_content.dart';
 import 'package:dart_monty_core/src/mount/vfs_node.dart';
+import 'package:dart_monty_core/src/mount/vfs_path.dart';
 import 'package:dart_monty_core/src/mount/vfs_tree.dart';
 import 'package:dart_monty_core/src/platform/monty_value.dart';
 
@@ -67,7 +68,7 @@ OsCallHandler memoryMountedOsHandler({
   final normalizedMounts = mounts
       .map(
         (m) => MountDir(
-          virtualPath: _normalizePath(m.virtualPath),
+          virtualPath: normalizeVfsPath(m.virtualPath),
           mode: m.mode,
           writeBytesLimit: m.writeBytesLimit,
         ),
@@ -79,7 +80,7 @@ OsCallHandler memoryMountedOsHandler({
   // special case in every existence question.
   final vfs = VfsTree(
     files: [
-      for (final f in files) f..path = _normalizePath(f.path),
+      for (final f in files) f..path = normalizeVfsPath(f.path),
     ],
     mountRoots: normalizedMounts.map((m) => m.virtualPath),
   );
@@ -189,7 +190,7 @@ OsCallHandler memoryMountedOsHandler({
     if (op == 'open') {
       final rawPath = args.firstOrNull;
       if (rawPath is! String) return notMine(op, args, kwargs);
-      final path = _normalizePath(rawPath);
+      final path = normalizeVfsPath(rawPath);
       final mount = _findMount(path, normalizedMounts);
       if (mount == null) {
         // Same premise as the Path.* ops below: outside every mount, the file
@@ -231,7 +232,7 @@ OsCallHandler memoryMountedOsHandler({
 
     final rawPath = args.firstOrNull;
     if (rawPath is! String) return notMine(op, args, kwargs);
-    final path = _normalizePath(rawPath);
+    final path = normalizeVfsPath(rawPath);
     final mount = _findMount(path, normalizedMounts);
     if (mount == null) {
       // FB-11 P5. A QUERY about a path is not an ACCESS of it. CPython
@@ -505,7 +506,7 @@ OsCallHandler memoryMountedOsHandler({
             pythonExceptionType: 'TypeError',
           );
         }
-        final target = _normalizePath(rawTarget);
+        final target = normalizeVfsPath(rawTarget);
         final targetMount = _findMount(target, normalizedMounts);
         if (targetMount == null) {
           return notMine(op, [target], kwargs);
@@ -562,43 +563,6 @@ OsCallHandler memoryMountedOsHandler({
 
     return notMine(op, args, kwargs);
   };
-}
-
-/// Collapses `.`, `..` and empty segments, CLAMPING at the root.
-///
-/// Deliberately hand-rolled rather than `package:path`'s `p.posix.normalize`,
-/// which is a correct POSIX normaliser and therefore the wrong tool here.
-/// Measured, on the cases that matter:
-///
-///     input                       p.posix.normalize   this
-///     /mnt/../../../etc/passwd    /etc/passwd         /etc/passwd
-///     ../escape.txt               ../escape.txt       /escape.txt
-///     '' (empty)                  .                   /
-///
-/// This is a clamp, not a normalisation: every path is treated as absolute and
-/// `..` can never survive, so no input can produce a result that is not rooted
-/// before `_findMount` sees it. `p.posix.normalize` preserves a leading `..`
-/// because that is what POSIX means, and it would hand a relative string to
-/// the mount check.
-///
-/// (Dart has no first-class `Path` type to lean on — `package:path` is
-/// functions over `String` by design, and `MontyPath` is a wire value, not a
-/// path library.)
-String _normalizePath(String path) {
-  if (path.isEmpty) return '/';
-  final isAbs = path.startsWith('/');
-  final segments = <String>[];
-  for (final part in path.split('/')) {
-    if (part.isEmpty || part == '.') continue;
-    if (part == '..') {
-      if (segments.isNotEmpty) segments.removeLast();
-      continue;
-    }
-    segments.add(part);
-  }
-  final joined = segments.join('/');
-
-  return isAbs ? '/$joined' : joined;
 }
 
 MountDir? _findMount(String normalized, List<MountDir> mounts) {

--- a/lib/src/mount/memory_mounted_os_handler.dart
+++ b/lib/src/mount/memory_mounted_os_handler.dart
@@ -192,7 +192,7 @@ OsCallHandler memoryMountedOsHandler({
   // `mkdir` is a no-op: the parent it demands can never come into existence,
   // so `mkdir` followed by writing into that directory failed. See the
   // "mkdir then write into it" test, and reinstate this in Phase 1 once
-  // directories are first-class (~/dev/plans/monty-0.19-upgrade/vfs-design.md).
+  // directories are first-class (docs/contributor/vfs-phases.md, Phase 1b).
 
   return (op, args, kwargs) async {
     // Carries [path, mode]; reads and writes then arrive separately as

--- a/lib/src/mount/mount_dir.dart
+++ b/lib/src/mount/mount_dir.dart
@@ -1,4 +1,5 @@
 import 'package:dart_monty_core/src/mount/mount_mode.dart';
+import 'package:dart_monty_core/src/mount/vfs_limits.dart';
 
 /// Declarative description of a virtual mount point inside the sandbox.
 ///
@@ -14,9 +15,7 @@ import 'package:dart_monty_core/src/mount/mount_mode.dart';
 ///     MountDir(virtualPath: '/data', mode: MountMode.readOnly),
 ///     MountDir(virtualPath: '/tmp'),
 ///   ],
-///   vfs: {
-///     '/data/config.json': '{"debug": true}',
-///   },
+///   files: [MontyMemoryFile('/data/config.json', '{"debug": true}')],
 /// );
 /// ```
 class MountDir {
@@ -25,6 +24,7 @@ class MountDir {
     required this.virtualPath,
     this.mode = MountMode.readWrite,
     this.writeBytesLimit,
+    this.memoryUsageLimit = defaultMemoryUsageLimit,
   });
 
   /// The path prefix Python sees inside the sandbox (e.g. `/data`).
@@ -36,8 +36,32 @@ class MountDir {
   /// Whether this mount allows writes.
   final MountMode mode;
 
-  /// Optional cap on total bytes written through this mount.
+  /// Cap on **cumulative** bytes written through this mount, or `null` for
+  /// unlimited.
   ///
-  /// `null` = unlimited.
+  /// Monotonic: deleting a file does not buy budget back, because the bytes
+  /// were still written. Exceeding it raises `OSError` in the sandbox, with
+  /// upstream's wording — `disk write limit of <n> exceeded`.
+  ///
+  /// **This was a PER-WRITE cap before 0.19.** A per-write cap does not bound
+  /// anything an attacker cares about: `write_bytes(b'x' * limit)` in a loop
+  /// passes every check and exhausts host memory. Upstream's parameter of the
+  /// same name has always been cumulative — *"Cap on cumulative bytes written
+  /// through the mount within one feed"* (`_monty.pyi:111-113`) — so the old
+  /// behaviour was a silent contract mismatch for anyone porting.
   final int? writeBytesLimit;
+
+  /// Cap on bytes **currently retained** under this mount, or `null` for
+  /// unlimited. Defaults to [defaultMemoryUsageLimit] (100 MB), as upstream
+  /// does.
+  ///
+  /// Unlike [writeBytesLimit] this one is given back when files are deleted —
+  /// it bounds how large the live tree may get, not how much has flowed
+  /// through. Exceeding it raises `MemoryError`, again with upstream's
+  /// wording: `mount memory usage limit of <n> exceeded`.
+  ///
+  /// Only nodes the **sandbox** created are charged, at [entryMemoryUsage]
+  /// each plus their content. Content seeded through `files:` is not charged —
+  /// see `VfsAccountant` for why.
+  final int? memoryUsageLimit;
 }

--- a/lib/src/mount/open_call.dart
+++ b/lib/src/mount/open_call.dart
@@ -37,8 +37,16 @@ MontyFileHandle resolveOpenCall(
   bool Function(String path) isDirectory = _alwaysFalse,
   void Function(String path)? ensureWritable,
 }) {
-  final readOnly = mode == 'r' || mode == 'rb';
-  if (readOnly) {
+  // Parse the mode BEFORE any side effect. Upstream builds its handle first
+  // for exactly this reason (`os_access.py:870-876`): "a malformed `mode`
+  // raises `ValueError` without touching the filesystem. Direct callers (not
+  // routed through Monty, which pre-validates) could otherwise pass e.g.
+  // `'wxyz'` and silently trigger the truncate/create branch."
+  //
+  // We had the mirror-image bug: every unrecognised mode fell through to
+  // [createIfMissing], so `open(p, 'wxyz')` silently CREATED a file.
+  final action = _openAction(mode);
+  if (action == 'r') {
     // Two INDEPENDENT checks, not nested. Upstream states them as one
     // sentence — "verify the file exists and is not a directory"
     // (os_access.py:851-853) — and the distinction only became visible when
@@ -60,7 +68,7 @@ MontyFileHandle resolveOpenCall(
     }
   } else {
     ensureWritable?.call(path);
-    if (mode == 'w' || mode == 'wb') {
+    if (action == 'w') {
       truncate(path);
     } else {
       createIfMissing(path);
@@ -69,5 +77,52 @@ MontyFileHandle resolveOpenCall(
 
   return MontyFileHandle(path: path, mode: mode);
 }
+
+/// The open-time action for [mode] — `r`, `w` or `a` — or a Python
+/// `ValueError` if [mode] is malformed.
+///
+/// `b`/`t`/`+` are orthogonal to the open-time effect: only the leading action
+/// decides whether we check existence, truncate, or create-if-missing. That is
+/// upstream's split too (`os_access.py:878-882`), which is why `r+` is a read
+/// action and does not truncate.
+///
+/// Rejecting rather than defaulting is the point. `x` (exclusive create) is
+/// deliberately NOT accepted: upstream's own code asserts the action is one of
+/// `r`/`w`/`a` (`os_access.py:896`), so silently treating `x` as append would
+/// invent a semantic neither side implements.
+String _openAction(String mode) {
+  var action = '';
+  var binary = false;
+  var text = false;
+  var plus = false;
+
+  for (final c in mode.split('')) {
+    switch (c) {
+      case 'r' || 'w' || 'a':
+        if (action.isNotEmpty) throw _invalidMode(mode);
+        action = c;
+      case 'b':
+        if (binary) throw _invalidMode(mode);
+        binary = true;
+      case 't':
+        if (text) throw _invalidMode(mode);
+        text = true;
+      case '+':
+        if (plus) throw _invalidMode(mode);
+        plus = true;
+      default:
+        throw _invalidMode(mode);
+    }
+  }
+
+  // No action character at all (`''`, `'+'`, `'b'`), or the contradictory
+  // `bt` pair, which CPython also rejects.
+  if (action.isEmpty || (binary && text)) throw _invalidMode(mode);
+
+  return action;
+}
+
+OsCallException _invalidMode(String mode) =>
+    OsCallException("invalid mode: '$mode'", pythonExceptionType: 'ValueError');
 
 bool _alwaysFalse(String path) => false;

--- a/lib/src/mount/vfs_accountant.dart
+++ b/lib/src/mount/vfs_accountant.dart
@@ -1,0 +1,146 @@
+import 'package:dart_monty_core/src/mount/mount_dir.dart';
+import 'package:dart_monty_core/src/mount/vfs_limits.dart';
+import 'package:dart_monty_core/src/platform/os_call_exception.dart';
+
+/// Per-mount byte accounting for a mounted virtual filesystem.
+///
+/// Two limits, because they bound different things and upstream keeps them
+/// separate (`_monty.pyi:111-118`):
+///
+/// - [MountDir.writeBytesLimit] bounds **cumulative bytes written** through the
+///   mount. Monotonic: deleting a file does not buy back budget, because the
+///   bytes were still written. Raises `OSError`.
+/// - [MountDir.memoryUsageLimit] bounds **currently retained bytes**. Deleting
+///   gives the budget back. Raises `MemoryError`.
+///
+/// A loop of `write_bytes` is caught by the first; a large live tree by the
+/// second. Neither subsumes the other.
+///
+/// ## What "retained" deliberately does NOT include
+///
+/// Only nodes the **sandbox** created are charged. Content a consumer seeded
+/// via `files:` is memory they already allocated and handed us, and charging it
+/// would make a large legitimate seed indistinguishable from sandbox growth —
+/// the budget exists to bound what untrusted code can make us retain.
+///
+/// A host-reaching file's content is likewise never charged: the host owns
+/// those bytes, we retain none of them. It also must not be *measured*, since
+/// asking such a file for its size invokes a host callback — accounting must
+/// not have side effects.
+///
+/// ## Scope is the handler, not a feed
+///
+/// Upstream scopes its write limit to "one feed". We have no feed boundary to
+/// hang state on, so both limits are scoped to the handler instance, which for
+/// a one-shot `run()` is the same thing and for a long-lived REPL is stricter.
+/// Stated here rather than implied, because it is the one place these diverge.
+final class VfsAccountant {
+  /// Cumulative bytes written per mount, keyed by the mount's virtual path.
+  final Map<String, int> _written = {};
+
+  /// Currently retained bytes per mount, keyed by the mount's virtual path.
+  final Map<String, int> _retained = {};
+
+  /// What we charged for each node, keyed by absolute virtual path.
+  ///
+  /// We remember what we stored rather than asking the tree, so accounting
+  /// never touches a node's content and therefore never fires a callback.
+  final Map<String, int> _charge = {};
+
+  /// Cumulative bytes written through [mount] so far. Test/diagnostic.
+  int writtenFor(MountDir mount) => _written[mount.virtualPath] ?? 0;
+
+  /// Bytes currently retained under [mount]. Test/diagnostic.
+  int retainedFor(MountDir mount) => _retained[mount.virtualPath] ?? 0;
+
+  /// Charges a write at [path], throwing if either limit is exceeded. Nothing
+  /// is recorded when it throws, so the caller may mutate the tree afterwards.
+  ///
+  /// The two counts differ, and an append is why: appending 10 bytes to a 1 MB
+  /// file *writes* 10 but *retains* 1 MB + 10. Charging `wrote` against the
+  /// memory budget would let an appender grow the tree without bound; charging
+  /// `retains` against the write cap would bill the same bytes on every append.
+  void recordWrite(
+    MountDir mount,
+    String path, {
+    required int wrote,
+    required int retains,
+  }) {
+    final writeLimit = mount.writeBytesLimit;
+    final written = writtenFor(mount) + wrote;
+    if (writeLimit != null && written > writeLimit) {
+      throw OsCallException(
+        'disk write limit of ${formatBytesPretty(writeLimit)} exceeded',
+        pythonExceptionType: 'OSError',
+      );
+    }
+
+    // May throw on the memory budget, which leaves `_written` untouched — the
+    // operation did not happen, so it must not be billed.
+    _applyCharge(mount, path, entryMemoryUsage + retains);
+    _written[mount.virtualPath] = written;
+  }
+
+  /// Charges the node a `mkdir` creates.
+  void recordMkdir(MountDir mount, String path) =>
+      _applyCharge(mount, path, entryMemoryUsage);
+
+  /// Releases whatever [path] was charged. Safe on a path never charged.
+  void recordRemove(MountDir mount, String path) {
+    final prior = _charge.remove(path);
+    if (prior == null) return;
+    _retained[mount.virtualPath] = retainedFor(mount) - prior;
+  }
+
+  /// Re-keys the charges for a moved subtree.
+  ///
+  /// A rename inside one mount does not change any total, but the per-path keys
+  /// must follow the nodes or a later overwrite computes its delta against the
+  /// wrong baseline. Across mounts the charge moves with the bytes.
+  void recordMove(
+    MountDir fromMount,
+    String from,
+    MountDir toMount,
+    String to,
+  ) {
+    // Snapshot first: we are about to mutate the map we are walking.
+    final moved = <String, int>{};
+    for (final entry in _charge.entries) {
+      if (entry.key == from || entry.key.startsWith('$from/')) {
+        moved[entry.key] = entry.value;
+      }
+    }
+
+    for (final MapEntry(key: oldPath, value: charge) in moved.entries) {
+      _charge.remove(oldPath);
+      final newPath = oldPath == from
+          ? to
+          : '$to${oldPath.substring(from.length)}';
+      _charge[newPath] = charge;
+
+      if (fromMount.virtualPath != toMount.virtualPath) {
+        _retained[fromMount.virtualPath] = retainedFor(fromMount) - charge;
+        _retained[toMount.virtualPath] = retainedFor(toMount) + charge;
+      }
+    }
+  }
+
+  /// Applies a new charge for [path], checking the memory budget against the
+  /// DELTA so that overwriting a file in place does not double-count it.
+  void _applyCharge(MountDir mount, String path, int charge) {
+    final prior = _charge[path] ?? 0;
+    final delta = charge - prior;
+    final limit = mount.memoryUsageLimit;
+    final retained = retainedFor(mount) + delta;
+
+    if (limit != null && retained > limit) {
+      throw OsCallException(
+        'mount memory usage limit of ${formatBytesPretty(limit)} exceeded',
+        pythonExceptionType: 'MemoryError',
+      );
+    }
+
+    _charge[path] = charge;
+    _retained[mount.virtualPath] = retained;
+  }
+}

--- a/lib/src/mount/vfs_callback_file.dart
+++ b/lib/src/mount/vfs_callback_file.dart
@@ -1,0 +1,109 @@
+import 'package:dart_monty_core/src/mount/vfs_content.dart';
+import 'package:dart_monty_core/src/mount/vfs_node.dart';
+import 'package:dart_monty_core/src/mount/vfs_path.dart';
+
+/// Reads content for a [VfsCallbackFile]. Runs on the HOST.
+typedef VfsReadCallback = VfsContent Function(String path);
+
+/// Writes content for a [VfsCallbackFile]. Runs on the HOST.
+typedef VfsWriteCallback = void Function(String path, VfsContent content);
+
+/// A virtual file backed by custom read/write callbacks.
+///
+/// This class allows you to create files whose content is dynamically generated
+/// or persisted through custom logic. When Monty code reads or writes to this
+/// file, the provided callbacks are invoked.
+///
+/// ## Security Warning
+///
+/// The callbacks execute in the host environment with FULL access to
+/// the real filesystem, network, and all system resources. A callback that
+/// accesses the real filesystem effectively breaks the Monty sandbox.
+///
+/// Example of UNSAFE usage that breaks the sandbox:
+///
+/// ```dart
+/// // DON'T DO THIS - allows Monty to read real files!
+/// VfsCallbackFile(
+///   '/config.txt',
+///   read: (p) => VfsText(File('/etc/passwd').readAsStringSync()),
+///   write: (p, c) => File('/tmp/out').writeAsStringSync(c.text),
+/// );
+/// ```
+///
+/// For sandboxed execution, use `MontyMemoryFile` instead, which stores content
+/// purely in memory with no external access.
+///
+/// Safe use cases for [VfsCallbackFile]:
+///
+/// - Returning dynamically computed content (e.g. current timestamp)
+/// - Logging writes without persisting them
+/// - Validating/transforming content before storage in memory
+/// - Integration testing with controlled external resources
+///
+/// (The warning above is upstream's, repeated verbatim in substance from
+/// `os_access.py:684-706`, with the Python example translated to Dart.)
+///
+/// ## This class is not a sandbox boundary
+///
+/// It is a *labelled* way to do something the shipped API already permits:
+/// `VfsFile` is an open interface, so any consumer can write a host-reaching
+/// backing with no import at all. Importing this library makes the intent
+/// greppable; it does not make the unlabelled route unavailable. Review every
+/// `VfsFile` that is not a `MontyMemoryFile`, not just this one.
+///
+/// ## The callback always receives the SEEDED path
+///
+/// Sandboxed Python can rename a file, and a rename rewrites the live [path] of
+/// every file in the moved subtree. If the callback were handed that live path,
+/// untrusted code could choose the argument the host callback receives, simply
+/// by renaming the file inside the mount. Upstream has the same exposure via
+/// directory rename (`os_access.py:1128-1136`).
+///
+/// So the callback is handed [seededPath] — the clamped path this file was
+/// constructed with — and never [path]. A rename still moves the file within
+/// the tree, and [path] still tracks it so `resolve` and `iterdir` stay
+/// correct; only the host-facing argument is frozen.
+final class VfsCallbackFile implements VfsFile {
+  /// Creates a callback-backed virtual file at [path].
+  ///
+  /// [read] is invoked whenever Monty reads the file, [write] whenever it
+  /// writes. Both run on the host — see the security warning on the class.
+  VfsCallbackFile(
+    String path, {
+    required this.read,
+    required this.write,
+    this.permissions = 0x1A4,
+  }) : seededPath = normalizeVfsPath(path),
+       path = normalizeVfsPath(path);
+
+  /// The clamped path this file was constructed with.
+  ///
+  /// This, never [path], is what [read] and [write] receive. See the class
+  /// doc for why.
+  final String seededPath;
+
+  /// Invoked on every read. Runs on the HOST.
+  final VfsReadCallback read;
+
+  /// Invoked on every write. Runs on the HOST.
+  final VfsWriteCallback write;
+
+  /// The file's live path in the tree. A rename rewrites it.
+  ///
+  /// Deliberately NOT what the callbacks receive.
+  @override
+  String path;
+
+  @override
+  final int permissions;
+
+  /// Invokes [read] with [seededPath]. Note that `stat()` reads too — sizing a
+  /// file means asking for its content, exactly as upstream does
+  /// (`os_access.py:1024`).
+  @override
+  VfsContent get content => read(seededPath);
+
+  @override
+  set content(VfsContent value) => write(seededPath, value);
+}

--- a/lib/src/mount/vfs_limits.dart
+++ b/lib/src/mount/vfs_limits.dart
@@ -6,7 +6,7 @@ const int defaultMemoryUsageLimit = 100000000;
 
 /// Bookkeeping charge for each node the sandbox creates, on top of its content.
 ///
-/// Mirrors upstream's `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:22`),
+/// Mirrors upstream's `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:21`),
 /// which describes it as covering "the map node, key allocation, and entry
 /// metadata", with variable-size contents charged separately. Without it a
 /// sandbox can exhaust host memory with a million empty files, each of which

--- a/lib/src/mount/vfs_limits.dart
+++ b/lib/src/mount/vfs_limits.dart
@@ -1,0 +1,40 @@
+/// Default per-mount memory budget in bytes — 100 MB.
+///
+/// Matches upstream's `DEFAULT_MEMORY_USAGE_LIMIT`
+/// (`monty-fs/src/mount_table.rs:18`).
+const int defaultMemoryUsageLimit = 100000000;
+
+/// Bookkeeping charge for each node the sandbox creates, on top of its content.
+///
+/// Mirrors upstream's `ENTRY_MEMORY_USAGE` (`monty-fs/src/overlay_state.rs:22`),
+/// which describes it as covering "the map node, key allocation, and entry
+/// metadata", with variable-size contents charged separately. Without it a
+/// sandbox can exhaust host memory with a million empty files, each of which
+/// costs zero content bytes and a real allocation.
+const int entryMemoryUsage = 256;
+
+/// Formats [bytes] the way upstream's limit messages do
+/// (`monty-fs/src/error.rs:207-234`): plain bytes under 1 KB, then decimal —
+/// not binary — units, dropping a trailing `.0`.
+String formatBytesPretty(int bytes) {
+  const kb = 1000;
+  const mb = 1000000;
+  const gb = 1000000000;
+  const tb = 1000000000000;
+
+  if (bytes < kb) return '$bytes bytes';
+
+  final (double value, String unit) = switch (bytes) {
+    < mb => (bytes / kb, 'KB'),
+    < gb => (bytes / mb, 'MB'),
+    < tb => (bytes / gb, 'GB'),
+    _ => (bytes / tb, 'TB'),
+  };
+
+  // Drop the decimal place when it rounds to `.0`, as upstream does.
+  final tenths = ((value * 10).round() % 10).abs();
+
+  return tenths == 0
+      ? '${value.toStringAsFixed(0)} $unit'
+      : '${value.toStringAsFixed(1)} $unit';
+}

--- a/lib/src/mount/vfs_path.dart
+++ b/lib/src/mount/vfs_path.dart
@@ -1,0 +1,42 @@
+/// Collapses `.`, `..` and empty segments, CLAMPING at the root.
+///
+/// Deliberately hand-rolled rather than `package:path`'s `p.posix.normalize`,
+/// which is a correct POSIX normaliser and therefore the wrong tool here.
+/// Measured, on the cases that matter:
+///
+///     input                       p.posix.normalize   this
+///     /mnt/../../../etc/passwd    /etc/passwd         /etc/passwd
+///     ../escape.txt               ../escape.txt       /escape.txt
+///     '' (empty)                  .                   /
+///
+/// This is a clamp, not a normalisation: every path is treated as absolute and
+/// `..` can never survive, so no input can produce a result that is not rooted
+/// before `_findMount` sees it. `p.posix.normalize` preserves a leading `..`
+/// because that is what POSIX means, and it would hand a relative string to
+/// the mount check.
+///
+/// (Dart has no first-class `Path` type to lean on — `package:path` is
+/// functions over `String` by design, and `MontyPath` is a wire value, not a
+/// path library.)
+///
+/// Internal, but shared: `memoryMountedOsHandler` clamps every path that
+/// crosses its surface, and `VfsCallbackFile` clamps the path it freezes at
+/// construction so the two agree. They must agree — the handler re-clamps a
+/// seeded file's `path`, and a callback file whose frozen path differed from
+/// its seeded one would hand the host a path the tree never used.
+String normalizeVfsPath(String path) {
+  if (path.isEmpty) return '/';
+  final isAbs = path.startsWith('/');
+  final segments = <String>[];
+  for (final part in path.split('/')) {
+    if (part.isEmpty || part == '.') continue;
+    if (part == '..') {
+      if (segments.isNotEmpty) segments.removeLast();
+      continue;
+    }
+    segments.add(part);
+  }
+  final joined = segments.join('/');
+
+  return isAbs ? '/$joined' : joined;
+}

--- a/lib/unsafe_callback_file.dart
+++ b/lib/unsafe_callback_file.dart
@@ -1,0 +1,21 @@
+/// Host-reaching virtual files — **importing this library is a security
+/// decision.**
+///
+/// A `VfsCallbackFile`'s callbacks run in the host environment with full access
+/// to the real filesystem, network, and all system resources. A callback that
+/// touches the real filesystem effectively breaks the Monty sandbox. That is
+/// the caller's decision to make, which is why it lives here rather than in
+/// `package:dart_monty_core/dart_monty_core.dart`: the import is an
+/// affirmative act, visible in review.
+///
+/// For sandboxed execution, use `MontyMemoryFile` from the main library.
+///
+/// **This separation is a signal, not a boundary.** `VfsFile` is an open
+/// interface, so a host-reaching backing can be written with no import at all.
+/// The reviewer's rule is "audit every `VfsFile` that is not a
+/// `MontyMemoryFile`" — this library makes the common case greppable, and does
+/// not replace that rule.
+library;
+
+export 'src/mount/vfs_callback_file.dart'
+    show VfsCallbackFile, VfsReadCallback, VfsWriteCallback;

--- a/packages/dart_monty_web/web/feature_matrix.dart
+++ b/packages/dart_monty_web/web/feature_matrix.dart
@@ -716,6 +716,49 @@ const _fixtureSourceBase =
 /// (native/Cargo.toml:36-38, "NEVER enabled in shipped builds").
 const bool _testHooks = bool.fromEnvironment('MONTY_TEST_HOOKS');
 
+/// Whether the ENGINE actually has the `test-hooks` cargo feature, probed at
+/// runtime rather than assumed from [_testHooks].
+///
+/// `null` until [_probeEngineTestHooks] has run.
+bool? _engineHasTestHooks;
+
+/// Asks the engine whether it has test-hooks, by doing the thing only a
+/// test-hooks engine can do.
+///
+/// **Why this exists.** [_testHooks] is a *Dart compile-time define* and the
+/// engine's feature is a *separate cargo build*. Two independent axes, and
+/// nothing checked that they agree. Both mismatches are reachable:
+///
+/// - **define off, engine on** — eight fixtures are skipped that would have
+///   passed. Under-reports, harmless but confusing: the page says 521/531 where
+///   it could say 529/531.
+/// - **define on, engine off** — the eight are NOT skipped. They run, and they
+///   FAIL, and the page shows eight red rows that look exactly like a
+///   regression. This is the dangerous one, and it is the reason a probe beats
+///   a warning: nothing else in the repo would tell you.
+///
+/// Measured 2026-08-03: a gate run silently produces the first case, because
+/// `tool/check_pages.sh` copies the shipped engine over `web/` and recompiles
+/// the Dart without the define. `tool/serve_demo.sh` now refuses
+/// `--test-hooks --skip-build` for the same reason, but that guard only covers
+/// the one entry point; this covers the page however it was built.
+Future<void> _probeEngineTestHooks() async {
+  try {
+    // `sys.setrecursionlimit` is the discriminator, and deliberately so: the
+    // repo records (unsupported_wasm_fixtures.dart) that `testCmFixtures` pass
+    // on web WITHOUT a test-hooks build while `setRecursionLimitFixtures`
+    // genuinely need it. Probing with the wrong half would answer yes on a
+    // shipped engine.
+    final r = await Monty(
+      'import sys\nsys.setrecursionlimit(100)\nTrue',
+    ).run().timeout(const Duration(seconds: 20));
+    _engineHasTestHooks = r.error == null;
+  } on Object {
+    // A throw is an answer too: the capability is absent.
+    _engineHasTestHooks = false;
+  }
+}
+
 SkipKind? _skipReason(_Fixture f) {
   if (alwaysUnsupportedWasmFixtures.contains(f.name)) {
     return SkipKind.divergent;
@@ -1382,7 +1425,50 @@ void _renderGapNote(List<String> gapNotes) {
   );
 }
 
+/// Renders a banner when the Dart define and the engine's feature disagree.
+///
+/// Nothing at all when they agree, which is the same rule `_renderGapNote`
+/// follows: a message that is always present teaches people to stop reading it.
+void _renderTestHooksMismatch() {
+  final el = _doc.getElementById('engine-note');
+  if (el == null) return;
+  el.textContent = '';
+  el.className = 'muted';
+
+  final engine = _engineHasTestHooks;
+  if (engine == null || engine == _testHooks) return;
+
+  final n = testHooksWasmFixtures.length;
+  el.className = 'v-fail';
+  el.append(_el('strong', text: 'BUILD MISMATCH'));
+  el.append(
+    _el(
+      'span',
+      text: _testHooks
+          // The dangerous direction: the eight are not skipped, so they run
+          // against an engine that cannot serve them and go red.
+          ? ' — this page was compiled with MONTY_TEST_HOOKS=true but the '
+                'engine it loaded does NOT have the test-hooks cargo feature. '
+                'The $n fixtures that need `sys.setrecursionlimit` are being '
+                'RUN rather than skipped, so any red among them is this '
+                'mismatch and not a regression. Rebuild with '
+                '`bash tool/serve_demo.sh --test-hooks`.'
+          // The under-reporting direction.
+          : ' — the engine HAS the test-hooks feature but this page was '
+                'compiled without MONTY_TEST_HOOKS, so $n fixtures are being '
+                'skipped that would pass. The corpus count below is lower than '
+                'this build can actually achieve. Rebuild with '
+                '`bash tool/serve_demo.sh --test-hooks`.',
+    ),
+  );
+}
+
 Future<void> _runAll() async {
+  // Before the probes, because _skipReason consults the define and the banner
+  // has to be able to contradict it.
+  await _probeEngineTestHooks();
+  _renderTestHooksMismatch();
+
   final probes = _probes();
   final tbody = _doc.getElementById('rows')!..textContent = '';
   for (var i = 0; i < probes.length; i++) {

--- a/packages/dart_monty_web/web/feature_matrix.dart
+++ b/packages/dart_monty_web/web/feature_matrix.dart
@@ -21,10 +21,18 @@
 //   FAIL       it does not — something is broken, and the diff is shown
 //   KNOWN GAP  it does not, we know, and the row names the issue
 //
-// The third state exists because two rows are genuinely and knowingly wrong on
-// one backend (core#137, FB-9). Hiding them would make the page a lie; painting
-// them red would say "this package is broken" when what is true is "this
-// package knows exactly where its edges are".
+// The third state exists because some rows are genuinely and knowingly wrong on
+// one backend. Hiding them would make the page a lie; painting them red would
+// say "this package is broken" when what is true is "this package knows exactly
+// where its edges are".
+//
+// HOW MANY there are, and which issues they name, is deliberately NOT recorded
+// here. It was — "two rows … (core#137, FB-9)" — and it was wrong within weeks:
+// FB-9 was fixed, FB-9 appears nowhere else in this repo, and the count stayed
+// at two in this comment and in both HTML shells. A status claim in a comment
+// has an expiry date. `_renderGapNote` derives the count, the pluralisation and
+// the issue IDs from the gaps that actually occurred, so the page cannot
+// disagree with itself and there is nothing here to keep in sync.
 //
 // Compiled twice from this one source — dart2js and dart2wasm — because that is
 // the axis where the two backends actually differ: dart2js has a single number
@@ -851,10 +859,13 @@ Future<String> _runFixture(_Fixture f, FixtureExpectation expectation) async {
             ),
           );
 
-      // A red row must say why. These two currently fail on FB-11 (a missing
-      // file INSIDE a mount reports PermissionError instead of
-      // FileNotFoundError), and leaving them red rather than relabelling them
-      // is deliberate: the library really does fail them.
+      // A red row must say why, so whatever the engine actually reported is
+      // captured and shown next to the row.
+      //
+      // No list of which fixtures are currently red lives here. One did — two
+      // mount-fs rows, blamed on FB-11 — and FB-11 was fixed while the comment
+      // stayed, so the page's own source claimed a failure the page was not
+      // showing. The reason travels with the failure instead.
       if (r.error != null) _skipNotes[f.name] = _describeError(r.error!);
 
       return switch (expectation) {
@@ -1328,6 +1339,49 @@ void _summarise(Map<Verdict, int> counts, Duration took) {
   );
 }
 
+/// Writes the KNOWN-GAP paragraph from the gaps that actually occurred.
+///
+/// This used to be hand-written prose in `matrix_js.html` and
+/// `matrix_wasm.html` — the same sentence in both — claiming "Two rows are
+/// knowingly wrong on one backend". It was one row by the time anyone looked,
+/// because the other was fixed and nobody edited the copy. A page whose whole
+/// pitch is "nothing here is a claim copied from a README" cannot afford a
+/// hand-maintained count, so the count, the pluralisation and the issue IDs are
+/// all derived from [gapNotes].
+///
+/// At zero gaps this renders NOTHING, which is the property that matters most:
+/// fixing the last gap deletes the paragraph instead of leaving it lying. That
+/// is why the two backends disagree here on purpose — dart2wasm has no gaps and
+/// shows no paragraph at all.
+void _renderGapNote(List<String> gapNotes) {
+  final el = _doc.getElementById('gap-note');
+  if (el == null) return;
+  el.textContent = '';
+  if (gapNotes.isEmpty) return;
+
+  // Notes are written `'<issue> · <why>'`, so the issue IDs come from the gap
+  // outcomes rather than from a comment someone has to remember to update.
+  final issues = gapNotes
+      .map((n) => n.split(' · ').first.trim())
+      .toSet()
+      .toList();
+  final n = gapNotes.length;
+
+  el.append(_el('strong', text: 'KNOWN GAP'));
+  el.append(
+    _el(
+      'span',
+      text:
+          ' is a third state on purpose. '
+          '${n == 1 ? 'One row is' : '$n rows are'} knowingly wrong on this '
+          'backend (${issues.join(', ')}); '
+          '${n == 1 ? 'it is' : 'they are'} shown and named rather than '
+          'hidden. Regression testing lives in the repo\'s gate and CI — this '
+          'page exists to be read.',
+    ),
+  );
+}
+
 Future<void> _runAll() async {
   final probes = _probes();
   final tbody = _doc.getElementById('rows')!..textContent = '';
@@ -1336,6 +1390,7 @@ Future<void> _runAll() async {
   }
 
   final counts = <Verdict, int>{};
+  final gapNotes = <String>[];
   final started = DateTime.now();
 
   for (var i = 0; i < probes.length; i++) {
@@ -1351,10 +1406,14 @@ Future<void> _runAll() async {
       outcome = Outcome(Verdict.crash, _firstLine(e.toString()));
     }
     counts[outcome.verdict] = (counts[outcome.verdict] ?? 0) + 1;
+    if (outcome.verdict == Verdict.gap && outcome.note != null) {
+      gapNotes.add(outcome.note!);
+    }
     _paint(i, outcome);
   }
 
   _summarise(counts, DateTime.now().difference(started));
+  _renderGapNote(gapNotes);
   (_doc.getElementById('rerun') as web.HTMLButtonElement?)?.disabled = false;
 }
 

--- a/packages/dart_monty_web/web/matrix_js.html
+++ b/packages/dart_monty_web/web/matrix_js.html
@@ -29,6 +29,10 @@
          and at zero gaps this stays empty. The sentence used to be hardcoded
          here in BOTH matrix shells and went stale. -->
     <p class="muted" id="gap-note"></p>
+    <!-- Filled in by feature_matrix.dart ONLY when the Dart define
+         MONTY_TEST_HOOKS disagrees with the engine's actual cargo
+         feature, probed at runtime. Empty when they agree. -->
+    <p class="muted" id="engine-note"></p>
     <div class="controls">
       <button id="rerun" class="btn" disabled>Re-run</button>
       <span id="summary"></span>

--- a/packages/dart_monty_web/web/matrix_js.html
+++ b/packages/dart_monty_web/web/matrix_js.html
@@ -24,12 +24,11 @@
       next to the summary is when these results were produced, which is
       moments ago.
     </p>
-    <p class="muted">
-      <strong>KNOWN GAP</strong> is a third state on purpose. Two rows are
-      knowingly wrong on one backend; they are shown, named and linked rather
-      than hidden. Regression testing lives in the repo's gate and CI — this
-      page exists to be read.
-    </p>
+    <!-- Filled in by feature_matrix.dart from the gaps that actually
+         occurred: the count, the pluralisation and the issue IDs are derived,
+         and at zero gaps this stays empty. The sentence used to be hardcoded
+         here in BOTH matrix shells and went stale. -->
+    <p class="muted" id="gap-note"></p>
     <div class="controls">
       <button id="rerun" class="btn" disabled>Re-run</button>
       <span id="summary"></span>

--- a/packages/dart_monty_web/web/matrix_wasm.html
+++ b/packages/dart_monty_web/web/matrix_wasm.html
@@ -29,6 +29,10 @@
          and at zero gaps this stays empty. The sentence used to be hardcoded
          here in BOTH matrix shells and went stale. -->
     <p class="muted" id="gap-note"></p>
+    <!-- Filled in by feature_matrix.dart ONLY when the Dart define
+         MONTY_TEST_HOOKS disagrees with the engine's actual cargo
+         feature, probed at runtime. Empty when they agree. -->
+    <p class="muted" id="engine-note"></p>
     <div class="controls">
       <button id="rerun" class="btn" disabled>Re-run</button>
       <span id="summary"></span>

--- a/packages/dart_monty_web/web/matrix_wasm.html
+++ b/packages/dart_monty_web/web/matrix_wasm.html
@@ -24,12 +24,11 @@
       next to the summary is when these results were produced, which is
       moments ago.
     </p>
-    <p class="muted">
-      <strong>KNOWN GAP</strong> is a third state on purpose. Two rows are
-      knowingly wrong on one backend; they are shown, named and linked rather
-      than hidden. Regression testing lives in the repo's gate and CI — this
-      page exists to be read.
-    </p>
+    <!-- Filled in by feature_matrix.dart from the gaps that actually
+         occurred: the count, the pluralisation and the issue IDs are derived,
+         and at zero gaps this stays empty. The sentence used to be hardcoded
+         here in BOTH matrix shells and went stale. -->
+    <p class="muted" id="gap-note"></p>
     <div class="controls">
       <button id="rerun" class="btn" disabled>Re-run</button>
       <span id="summary"></span>

--- a/test/unit/mount/memory_mounted_os_handler_test.dart
+++ b/test/unit/mount/memory_mounted_os_handler_test.dart
@@ -83,6 +83,11 @@ void main() {
       );
     });
 
+    // This asserted only the exception TYPE, which both a per-write and a
+    // cumulative cap satisfy — so it could not tell the two apart, and did not
+    // notice when `writeBytesLimit` was per-write and therefore bounded
+    // nothing. It now pins the message too. The semantics themselves live in
+    // vfs_limits_test.dart.
     test('writeBytesLimit rejects oversize writes with OSError', () {
       final handler = memoryMountedOsHandler(
         mounts: const [
@@ -98,11 +103,17 @@ void main() {
           null,
         ),
         throwsA(
-          isA<OsCallException>().having(
-            (e) => e.pythonExceptionType,
-            'pythonExceptionType',
-            'OSError',
-          ),
+          isA<OsCallException>()
+              .having(
+                (e) => e.pythonExceptionType,
+                'pythonExceptionType',
+                'OSError',
+              )
+              .having(
+                (e) => e.message,
+                'message',
+                'disk write limit of 10 bytes exceeded',
+              ),
         ),
       );
     });

--- a/test/unit/mount/memory_mounted_os_handler_test.dart
+++ b/test/unit/mount/memory_mounted_os_handler_test.dart
@@ -63,6 +63,56 @@ void main() {
       expect(read, 'written');
     });
 
+    // The consequence of the test above, across handlers — pinned because it
+    // SURPRISES, not because it is wrong.
+    //
+    // Mount state lives in the handler closure, so a fresh handler starts with
+    // a fresh tree and anything the sandbox CREATED is gone. But a seeded file
+    // is the caller's own object, mutated in place, so its content SURVIVES.
+    // Reusing seed objects across handlers therefore gives a half-discard:
+    // created files vanish, seeded content does not.
+    //
+    // That is deliberate. In-place mutation is upstream's contract
+    // (`os_access.py:608`, "When Monty code writes to this file, the content
+    // attribute is updated") and it is what makes the output-capture pattern
+    // work — seed `MontyMemoryFile('/out.txt', '')`, run, read `.content`. A
+    // copy-on-write "fix" would silently break every caller doing that, which
+    // is why this is a test and not a bug report. Anyone tempted to make writes
+    // replace the node instead of mutating it has to delete this test first,
+    // and read this comment to do so.
+    test(
+      'a fresh handler over REUSED seeds half-discards, on purpose',
+      () async {
+        final seed = MontyMemoryFile('/tmp/seeded.txt', 'ORIGINAL');
+
+        final first = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/tmp')],
+          files: [seed],
+        );
+        await first('Path.write_text', [
+          '/tmp/scratch.txt',
+          'FROM-RUN-1',
+        ], null);
+        await first('Path.write_text', ['/tmp/seeded.txt', 'MUTATED'], null);
+
+        // A NEW handler over the SAME seed object — the natural thing to do,
+        // since `files:` takes objects the caller constructed and still holds.
+        final second = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/tmp')],
+          files: [seed],
+        );
+
+        // Created-by-sandbox: gone, because the tree is new.
+        expect(await second('Path.exists', ['/tmp/scratch.txt'], null), false);
+        // Seeded: NOT gone, because the object itself was rewritten.
+        expect(
+          await second('Path.read_text', ['/tmp/seeded.txt'], null),
+          'MUTATED',
+        );
+        expect(seed.content, VfsText('MUTATED'));
+      },
+    );
+
     test('readOnly mount rejects writes with PermissionError', () {
       final handler = memoryMountedOsHandler(
         mounts: const [

--- a/test/unit/mount/upstream_os_access_test.dart
+++ b/test/unit/mount/upstream_os_access_test.dart
@@ -1,0 +1,237 @@
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+/// Behaviours pinned by upstream's Python `OSAccess` suite that **no corpus
+/// fixture reaches** (`vfs-design.md` §6c).
+///
+/// The 531-fixture oracle corpus is not the only spec: upstream's
+/// `crates/monty-python/tests/test_os_access.py` covers directory and mode
+/// semantics the fixtures underspecify. These are ported from it, and one of
+/// them found a live defect — see the `open()` group.
+Matcher raises(String excType, String message) => throwsA(
+  isA<OsCallException>()
+      .having((e) => e.pythonExceptionType, 'excType', excType)
+      .having((e) => e.message, 'message', message),
+);
+
+void main() {
+  group('iterdir — the three-way answer', () {
+    // An EMPTY directory and a MISSING path must not look alike. The old flat
+    // store returned an empty list for both, which is the worst of the three
+    // answers: indistinguishable from a successful listing.
+    test('an empty directory lists as empty, and does NOT raise', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [MontyMemoryFile('/mnt/sub/file.txt', 'hello')],
+      );
+
+      await h('Path.mkdir', ['/mnt/empty'], null);
+
+      expect(await h('Path.iterdir', ['/mnt/empty'], null), isEmpty);
+      // Upstream: test_iterdir_empty_directory_direct.
+    });
+
+    test('a MISSING path raises rather than listing as empty', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [MontyMemoryFile('/mnt/sub/file.txt', 'hello')],
+      );
+
+      await expectLater(
+        () => h('Path.iterdir', ['/mnt/nope'], null),
+        raises(
+          'FileNotFoundError',
+          "[Errno 2] No such file or directory: '/mnt/nope'",
+        ),
+      );
+    });
+  });
+
+  group('append return units — chars vs bytes', () {
+    // Upstream: test_append_text_non_ascii_returns_char_count and
+    // test_append_bytes_returns_byte_count. 'αβγ' is 3 characters and 6 UTF-8
+    // bytes, so the two calls MUST disagree.
+    test('append_text returns CHARACTERS, not encoded bytes', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [MontyMemoryFile('/mnt/file.txt', 'start ')],
+      );
+
+      expect(await h('Path.append_text', ['/mnt/file.txt', 'αβγ'], null), 3);
+      expect(
+        await h('Path.read_text', ['/mnt/file.txt'], null),
+        'start αβγ',
+      );
+    });
+
+    test('append_bytes returns BYTES for the same content', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [MontyMemoryFile('/mnt/file.bin', 'start ')],
+      );
+
+      // The UTF-8 encoding of 'αβγ' — 6 bytes.
+      const utf8Abg = [0xCE, 0xB1, 0xCE, 0xB2, 0xCE, 0xB3];
+      expect(
+        await h('Path.append_bytes', ['/mnt/file.bin', utf8Abg], null),
+        6,
+      );
+      expect(
+        await h('Path.read_text', ['/mnt/file.bin'], null),
+        'start αβγ',
+      );
+    });
+  });
+
+  group('the root directory', () {
+    // Upstream: test_root_directory. Root has no name, which is what makes it
+    // unnameable and therefore always present — but only inside a mount that
+    // covers it, which is our model's one deliberate difference from upstream's
+    // mountless OSAccess.
+    test('root is a directory and lists its children', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/')],
+        files: [MontyMemoryFile('/file.txt', 'root file')],
+      );
+
+      expect(await h('Path.is_dir', ['/'], null), true);
+      expect(await h('Path.exists', ['/'], null), true);
+      // iterdir yields MontyPath, not bare strings — Python must receive
+      // `pathlib.Path` objects, which is what Phase 3 fixed.
+      expect(await h('Path.iterdir', ['/'], null), [
+        const MontyPath('/file.txt'),
+      ]);
+    });
+
+    test('root is not a file', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/')],
+        files: [MontyMemoryFile('/file.txt', 'root file')],
+      );
+
+      expect(await h('Path.is_file', ['/'], null), false);
+    });
+  });
+
+  group('open() rejects a malformed mode BEFORE any side effect', () {
+    // Upstream: test_path_open_invalid_mode_does_not_truncate, which exists as
+    // a REGRESSION guard — "a malformed mode that starts with w/a must reject
+    // the open BEFORE the truncate/create side effect, otherwise direct
+    // callers can destroy data by passing e.g. 'wxyz'".
+    //
+    // We had the mirror-image bug: any unrecognised mode fell through to
+    // `createIfMissing`, so a garbage mode silently CREATED a file instead of
+    // raising. `resolveOpenCall` is exported, so a direct caller reaches it.
+    // NOT in this list: 'r+', 'w+', 'rt', 'ab+'. `b`/`t`/`+` are orthogonal to
+    // the open-time action, so those are VALID — see the group below. 'x' IS
+    // rejected: upstream asserts the action is one of r/w/a
+    // (os_access.py:896), so treating it as append would invent a semantic.
+    for (final mode in ['wxyz', 'axyz', 'w!', 'a?', 'x', 'rw', 'bt', '']) {
+      test('mode ${mode.isEmpty ? "(empty)" : mode} raises ValueError', () {
+        expect(
+          () => resolveOpenCall(
+            '/data/file.txt',
+            mode,
+            exists: (_) => true,
+            truncate: (_) => fail('truncate ran for mode $mode'),
+            createIfMissing: (_) => fail('createIfMissing ran for mode $mode'),
+          ),
+          throwsA(
+            isA<OsCallException>().having(
+              (e) => e.pythonExceptionType,
+              'excType',
+              'ValueError',
+            ),
+          ),
+        );
+      });
+    }
+
+    // `b`/`t`/`+` do not change the open-time effect, only the leading action
+    // does. Upstream splits it the same way (os_access.py:878-882), which is
+    // why 'r+' checks existence rather than truncating.
+    test('b, t and + are orthogonal to the action', () {
+      for (final mode in ['r+', 'rt', 'rb+']) {
+        resolveOpenCall(
+          '/data/file.txt',
+          mode,
+          exists: (_) => true,
+          truncate: (_) => fail('$mode is a READ action; it must not truncate'),
+          createIfMissing: (_) => fail('$mode must not create'),
+        );
+      }
+
+      var truncated = 0;
+      for (final mode in ['w+', 'wt', 'wb+']) {
+        resolveOpenCall(
+          '/data/file.txt',
+          mode,
+          exists: (_) => true,
+          truncate: (_) => truncated++,
+          createIfMissing: (_) => fail('$mode must truncate, not create'),
+        );
+      }
+      expect(truncated, 3);
+    });
+
+    test('a read action with a missing file still raises', () {
+      expect(
+        () => resolveOpenCall(
+          '/data/gone.txt',
+          'r+',
+          exists: (_) => false,
+          truncate: (_) => fail('no side effect on a failed read open'),
+          createIfMissing: (_) => fail('r+ must not create a missing file'),
+        ),
+        raises(
+          'FileNotFoundError',
+          "[Errno 2] No such file or directory: '/data/gone.txt'",
+        ),
+      );
+    });
+
+    test('the six modes monty emits still work', () {
+      final effects = <String>[];
+      for (final mode in ['r', 'rb']) {
+        final h = resolveOpenCall(
+          '/data/file.txt',
+          mode,
+          exists: (_) => true,
+          truncate: (_) => effects.add('truncate'),
+          createIfMissing: (_) => effects.add('create'),
+        );
+        expect(h.mode, mode);
+      }
+      expect(effects, isEmpty, reason: 'read modes have no open-time effect');
+
+      for (final mode in ['w', 'wb']) {
+        resolveOpenCall(
+          '/data/file.txt',
+          mode,
+          exists: (_) => true,
+          truncate: (_) => effects.add('truncate:$mode'),
+          createIfMissing: (_) => fail('w must truncate, not create'),
+        );
+      }
+      for (final mode in ['a', 'ab']) {
+        resolveOpenCall(
+          '/data/file.txt',
+          mode,
+          exists: (_) => true,
+          truncate: (_) => fail('a must create-if-missing, not truncate'),
+          createIfMissing: (_) => effects.add('create:$mode'),
+        );
+      }
+
+      expect(effects, [
+        'truncate:w',
+        'truncate:wb',
+        'create:a',
+        'create:ab',
+      ]);
+    });
+  });
+}

--- a/test/unit/mount/upstream_os_access_test.dart
+++ b/test/unit/mount/upstream_os_access_test.dart
@@ -5,7 +5,7 @@ import 'package:dart_monty_core/dart_monty_core.dart';
 import 'package:test/test.dart';
 
 /// Behaviours pinned by upstream's Python `OSAccess` suite that **no corpus
-/// fixture reaches** (`vfs-design.md` §6c).
+/// fixture reaches** (`docs/contributor/vfs-phases.md`, §6c).
 ///
 /// The 531-fixture oracle corpus is not the only spec: upstream's
 /// `crates/monty-python/tests/test_os_access.py` covers directory and mode

--- a/test/unit/mount/vfs_callback_file_test.dart
+++ b/test/unit/mount/vfs_callback_file_test.dart
@@ -1,0 +1,227 @@
+@Tags(['unit'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:dart_monty_core/unsafe_callback_file.dart';
+import 'package:test/test.dart';
+
+/// Every write this test does not care about lands here, so the tests that DO
+/// care can assert on their own list and the rest still have a real callback
+/// rather than an empty block.
+final _discarded = <(String, VfsContent)>[];
+
+void _discard(String path, VfsContent content) =>
+    _discarded.add((path, content));
+
+/// Named-field read, mirroring the helper in
+/// `memory_mounted_os_handler_test.dart`: a positional read says nothing about
+/// which field it meant.
+MontyValue? _stat(MontyNamedTuple t, String field) {
+  final i = t.fieldNames.indexOf(field);
+
+  return i < 0 ? null : t.values.elementAtOrNull(i);
+}
+
+Matcher raises(String excType, String message) => throwsA(
+  isA<OsCallException>()
+      .having((e) => e.pythonExceptionType, 'excType', excType)
+      .having((e) => e.message, 'message', message),
+);
+
+void main() {
+  group('VfsCallbackFile', () {
+    test('read_text invokes the read callback', () async {
+      final seen = <String>[];
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.txt',
+            read: (p) {
+              seen.add(p);
+
+              return VfsText('content from $p');
+            },
+            write: _discard,
+          ),
+        ],
+      );
+
+      expect(
+        await h('Path.read_text', ['/mnt/live.txt'], null),
+        'content from /mnt/live.txt',
+      );
+      expect(seen, ['/mnt/live.txt']);
+    });
+
+    test('write_text invokes the write callback with VfsText', () async {
+      final written = <(String, VfsContent)>[];
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.txt',
+            read: (_) => VfsText(''),
+            write: (p, c) => written.add((p, c)),
+          ),
+        ],
+      );
+
+      await h('Path.write_text', ['/mnt/live.txt', 'hello'], null);
+
+      expect(written, [('/mnt/live.txt', VfsText('hello'))]);
+    });
+
+    test('write_bytes hands the callback VfsBytes, not VfsText', () async {
+      final written = <VfsContent>[];
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.bin',
+            read: (_) => VfsBytes(Uint8List(0)),
+            write: (_, c) => written.add(c),
+          ),
+        ],
+      );
+
+      await h('Path.write_bytes', [
+        '/mnt/live.bin',
+        <int>[0xFF, 0x00],
+      ], null);
+
+      expect(written, [
+        VfsBytes(Uint8List.fromList([0xFF, 0x00])),
+      ]);
+    });
+
+    test('stat sizes the file by INVOKING the read callback', () async {
+      var reads = 0;
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.txt',
+            read: (_) {
+              reads++;
+
+              return VfsText('héllo');
+            },
+            write: _discard,
+          ),
+        ],
+      );
+
+      // 'héllo' is 5 codepoints and 6 UTF-8 bytes; st_size is bytes.
+      final st = await h('Path.stat', ['/mnt/live.txt'], null);
+      expect(_stat(st! as MontyNamedTuple, 'st_size'), const MontyInt(6));
+      // Upstream does the same (os_access.py:1024): sizing means reading.
+      expect(reads, 1);
+    });
+
+    test('the path is clamped at construction', () {
+      final f = VfsCallbackFile(
+        '/mnt/../../../etc/passwd',
+        read: (_) => VfsText(''),
+        write: _discard,
+      );
+
+      expect(f.seededPath, '/etc/passwd');
+      expect(f.path, '/etc/passwd');
+    });
+
+    // THE SECURITY CASE. Sandboxed Python can rename a file, and a rename
+    // rewrites the live `path` of every file in the moved subtree. If the
+    // callback were handed that live path, untrusted code would choose the
+    // argument the host callback receives.
+    test('rename does NOT change the path handed to the callback', () async {
+      final seen = <String>[];
+      final f = VfsCallbackFile(
+        '/mnt/config.txt',
+        read: (p) {
+          seen.add(p);
+
+          return VfsText('x');
+        },
+        write: _discard,
+      );
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [f],
+      );
+
+      await h('Path.rename', ['/mnt/config.txt', '/mnt/secrets.txt'], null);
+      await h('Path.read_text', ['/mnt/secrets.txt'], null);
+
+      // The tree moved the file, so `path` tracks it...
+      expect(f.path, '/mnt/secrets.txt');
+      // ...but the HOST still sees only where it was seeded.
+      expect(seen, ['/mnt/config.txt']);
+    });
+
+    test('a DIRECTORY rename also cannot redirect the callback', () async {
+      final seen = <String>[];
+      final f = VfsCallbackFile(
+        '/mnt/sub/config.txt',
+        read: (p) {
+          seen.add(p);
+
+          return VfsText('x');
+        },
+        write: _discard,
+      );
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [f],
+      );
+
+      await h('Path.rename', ['/mnt/sub', '/mnt/other'], null);
+      await h('Path.read_text', ['/mnt/other/config.txt'], null);
+
+      expect(f.path, '/mnt/other/config.txt');
+      expect(seen, ['/mnt/sub/config.txt']);
+    });
+
+    test('a read-only mount still refuses the write callback', () async {
+      var writes = 0;
+      final h = memoryMountedOsHandler(
+        mounts: const [
+          MountDir(virtualPath: '/mnt', mode: MountMode.readOnly),
+        ],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.txt',
+            read: (_) => VfsText(''),
+            write: (_, _) => writes++,
+          ),
+        ],
+      );
+
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/live.txt', 'x'], null),
+        raises('PermissionError', 'Mount is read-only: /mnt/live.txt'),
+      );
+      expect(writes, 0);
+    });
+
+    test('sandboxed code cannot MINT a callback file', () async {
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: [
+          VfsCallbackFile(
+            '/mnt/live.txt',
+            read: (_) => VfsText(''),
+            write: _discard,
+          ),
+        ],
+      );
+
+      // A file Monty creates is always a plain in-memory file, so no callback
+      // can come into existence from inside the sandbox.
+      await h('Path.write_text', ['/mnt/fresh.txt', 'hi'], null);
+      expect(await h('Path.read_text', ['/mnt/fresh.txt'], null), 'hi');
+    });
+  });
+}

--- a/test/unit/mount/vfs_limits_test.dart
+++ b/test/unit/mount/vfs_limits_test.dart
@@ -1,0 +1,217 @@
+@Tags(['unit'])
+library;
+
+import 'package:dart_monty_core/dart_monty_core.dart';
+import 'package:test/test.dart';
+
+Matcher raises(String excType, String message) => throwsA(
+  isA<OsCallException>()
+      .having((e) => e.pythonExceptionType, 'excType', excType)
+      .having((e) => e.message, 'message', message),
+);
+
+OsCallHandler withLimits({int? write, int? memory}) => memoryMountedOsHandler(
+  mounts: [
+    MountDir(
+      virtualPath: '/mnt',
+      writeBytesLimit: write,
+      memoryUsageLimit: memory,
+    ),
+  ],
+  files: const [],
+);
+
+void main() {
+  // Upstream keeps two limits because they bound different things
+  // (`_monty.pyi:111-118`): write_bytes_limit is CUMULATIVE and monotonic,
+  // memory_usage_limit is RETAINED and refundable.
+  group('writeBytesLimit is cumulative, not per-write', () {
+    test('a single oversize write still fails', () async {
+      final h = withLimits(write: 10);
+
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/big.txt', 'x' * 100], null),
+        raises('OSError', 'disk write limit of 10 bytes exceeded'),
+      );
+    });
+
+    // THE REGRESSION. Each write is well under the cap; the TOTAL is not.
+    // Under the old per-write check this loop ran forever and exhausted host
+    // memory, which is precisely what an attacker does.
+    test('many small writes that together exceed it fail', () async {
+      final h = withLimits(write: 100);
+
+      // 10 files x 30 bytes = 300 > 100, but no single write exceeds 100.
+      var wrote = 0;
+      Object? failure;
+      for (var i = 0; i < 10; i++) {
+        try {
+          await h('Path.write_text', ['/mnt/f$i.txt', 'x' * 30], null);
+          wrote++;
+        } on OsCallException catch (e) {
+          failure = e.message;
+          break;
+        }
+      }
+
+      expect(failure, 'disk write limit of 100 bytes exceeded');
+      // 3 x 30 = 90 fits, the 4th would reach 120.
+      expect(wrote, 3);
+    });
+
+    test('appending accumulates against the cap', () async {
+      final h = withLimits(write: 25);
+
+      await h('Path.append_text', ['/mnt/log.txt', 'x' * 10], null);
+      await h('Path.append_text', ['/mnt/log.txt', 'x' * 10], null);
+
+      await expectLater(
+        () => h('Path.append_text', ['/mnt/log.txt', 'x' * 10], null),
+        raises('OSError', 'disk write limit of 25 bytes exceeded'),
+      );
+    });
+
+    test('deleting does NOT buy write budget back — it is monotonic', () async {
+      final h = withLimits(write: 100);
+
+      await h('Path.write_text', ['/mnt/a.txt', 'x' * 60], null);
+      await h('Path.unlink', ['/mnt/a.txt'], null);
+
+      // The bytes were still written, so the second 60 must not fit.
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/b.txt', 'x' * 60], null),
+        raises('OSError', 'disk write limit of 100 bytes exceeded'),
+      );
+    });
+
+    test('null means unlimited', () async {
+      // Both limits left null on purpose — `withLimits` defaults them to null,
+      // which is the unlimited case, unlike `MountDir` itself which defaults
+      // memoryUsageLimit to 100 MB.
+      final h = withLimits();
+
+      for (var i = 0; i < 50; i++) {
+        await h('Path.write_text', ['/mnt/f$i.txt', 'x' * 1000], null);
+      }
+      expect(await h('Path.read_text', ['/mnt/f49.txt'], null), 'x' * 1000);
+    });
+  });
+
+  group('memoryUsageLimit bounds RETAINED bytes and is refundable', () {
+    test('a large live tree is refused with MemoryError', () async {
+      final h = withLimits(memory: 2000);
+
+      await expectLater(() async {
+        for (var i = 0; i < 50; i++) {
+          await h('Path.write_text', ['/mnt/f$i.txt', 'x' * 100], null);
+        }
+      }, raises('MemoryError', 'mount memory usage limit of 2 KB exceeded'));
+    });
+
+    // The per-entry charge is why: 1000 empty files cost no content bytes and
+    // a great deal of real memory. Upstream charges 256 each
+    // (`overlay_state.rs:22`), and so do we.
+    test('empty files are charged the per-entry cost', () async {
+      final h = withLimits(memory: entryMemoryUsage * 3);
+
+      // Zero content bytes each, so only the entry charge can stop this.
+      await h('Path.write_text', ['/mnt/a.txt', ''], null);
+      await h('Path.write_text', ['/mnt/b.txt', ''], null);
+      await h('Path.write_text', ['/mnt/c.txt', ''], null);
+
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/d.txt', ''], null),
+        raises(
+          'MemoryError',
+          'mount memory usage limit of 768 bytes exceeded',
+        ),
+      );
+    });
+
+    test('deleting DOES give the budget back', () async {
+      final h = withLimits(memory: entryMemoryUsage + 100);
+
+      await h('Path.write_text', ['/mnt/a.txt', 'x' * 100], null);
+      // Full. A second file of the same size cannot fit...
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/b.txt', 'x' * 100], null),
+        throwsA(isA<OsCallException>()),
+      );
+      // ...until the first is removed.
+      await h('Path.unlink', ['/mnt/a.txt'], null);
+      await h('Path.write_text', ['/mnt/b.txt', 'x' * 100], null);
+
+      expect(await h('Path.read_text', ['/mnt/b.txt'], null), 'x' * 100);
+    });
+
+    test('overwriting in place is not double-counted', () async {
+      final h = withLimits(memory: entryMemoryUsage + 100);
+
+      // Rewriting the same path 20 times must not accumulate.
+      for (var i = 0; i < 20; i++) {
+        await h('Path.write_text', ['/mnt/a.txt', 'x' * 100], null);
+      }
+      expect(await h('Path.read_text', ['/mnt/a.txt'], null), 'x' * 100);
+    });
+
+    test('mkdir is charged, and rmdir refunds it', () async {
+      final h = withLimits(memory: entryMemoryUsage * 2);
+
+      await h('Path.mkdir', ['/mnt/one'], null);
+      await h('Path.mkdir', ['/mnt/two'], null);
+      await expectLater(
+        () => h('Path.mkdir', ['/mnt/three'], null),
+        raises(
+          'MemoryError',
+          'mount memory usage limit of 512 bytes exceeded',
+        ),
+      );
+
+      await h('Path.rmdir', ['/mnt/two'], null);
+      await h('Path.mkdir', ['/mnt/three'], null);
+      expect(await h('Path.is_dir', ['/mnt/three'], null), true);
+    });
+
+    test('a refused write leaves the tree untouched', () async {
+      final h = withLimits(memory: entryMemoryUsage + 10);
+
+      await expectLater(
+        () => h('Path.write_text', ['/mnt/big.txt', 'x' * 500], null),
+        throwsA(isA<OsCallException>()),
+      );
+      // The node must not exist — we refused to charge it.
+      expect(await h('Path.exists', ['/mnt/big.txt'], null), false);
+    });
+
+    test('the default is 100 MB and does not disturb normal work', () async {
+      expect(defaultMemoryUsageLimit, 100000000);
+
+      // A plain mount takes the default; ordinary writes are unaffected.
+      final h = memoryMountedOsHandler(
+        mounts: const [MountDir(virtualPath: '/mnt')],
+        files: const [],
+      );
+      await h('Path.write_text', ['/mnt/a.txt', 'x' * 10000], null);
+      expect(await h('Path.read_text', ['/mnt/a.txt'], null), 'x' * 10000);
+    });
+  });
+
+  // Upstream's wording, so a consumer reading either project sees the same
+  // strings (`monty-fs/src/error.rs:207-234`). Decimal units, not binary.
+  group('formatBytesPretty matches upstream', () {
+    test('under 1 KB is plain bytes', () {
+      expect(formatBytesPretty(0), '0 bytes');
+      expect(formatBytesPretty(512), '512 bytes');
+      expect(formatBytesPretty(999), '999 bytes');
+    });
+
+    test('decimal units, with a trailing .0 dropped', () {
+      expect(formatBytesPretty(1000), '1 KB');
+      expect(formatBytesPretty(1500), '1.5 KB');
+      expect(formatBytesPretty(1000000), '1 MB');
+      expect(formatBytesPretty(100000000), '100 MB');
+      expect(formatBytesPretty(1000000000), '1 GB');
+      expect(formatBytesPretty(1000000000000), '1 TB');
+    });
+  });
+}

--- a/test/unit/mount/vfs_rename_test.dart
+++ b/test/unit/mount/vfs_rename_test.dart
@@ -125,5 +125,96 @@ void main() {
       expect(await h('Path.read_text', ['/mnt/src/moved.txt'], null), 'moved');
       expect(await h('Path.read_text', ['/mnt/full/a.txt'], null), 'a');
     });
+
+    // A TARGET outside every mount used to decline, which with no fallthrough
+    // surfaced as `PermissionError: Permission denied: '<target>'` — telling
+    // sandboxed code exactly which paths lie outside the sandbox, the secret
+    // the SOURCE path was changed to stop telling (FB-11 P5). Upstream does
+    // not pin this: monty-fs/tests/fs_security.rs:1078 accepts either outcome.
+    group('a target outside every mount is absent, not denied', () {
+      test('it raises FileNotFoundError, never PermissionError', () async {
+        final h = handler();
+
+        await expectLater(
+          () => h('Path.rename', ['/mnt/hello.txt', '/etc/passwd'], null),
+          raises(
+            'FileNotFoundError',
+            "[Errno 2] No such file or directory: '/etc/passwd'",
+          ),
+        );
+      });
+
+      test('a `..` escape normalises and gets the same answer', () async {
+        final h = handler();
+
+        await expectLater(
+          () => h('Path.rename', [
+            '/mnt/hello.txt',
+            '/mnt/../../../etc/passwd',
+          ], null),
+          raises(
+            'FileNotFoundError',
+            "[Errno 2] No such file or directory: '/etc/passwd'",
+          ),
+        );
+      });
+
+      // The point of the change: outside-a-mount and merely-missing must be
+      // INDISTINGUISHABLE, or the exception itself maps the sandbox.
+      test('it is indistinguishable from a missing parent inside', () async {
+        final h = handler();
+
+        Future<Object?> err(String target) async {
+          try {
+            await h('Path.rename', ['/mnt/hello.txt', target], null);
+
+            return 'no throw';
+          } on OsCallException catch (e) {
+            return '${e.pythonExceptionType}|${e.message}';
+          }
+        }
+
+        // Identical modulo the path itself, which is the whole property: one
+        // target is outside all mounts, the other is inside a mount but under
+        // a directory that does not exist, and nothing in the answer says
+        // which.
+        String sameExcept(String p) =>
+            "FileNotFoundError|[Errno 2] No such file or directory: '$p'";
+
+        expect(await err('/outside/x.txt'), sameExcept('/outside/x.txt'));
+        expect(await err('/mnt/nope/x.txt'), sameExcept('/mnt/nope/x.txt'));
+      });
+
+      test('the source is left untouched', () async {
+        final h = handler();
+
+        await expectLater(
+          () => h('Path.rename', ['/mnt/hello.txt', '/etc/passwd'], null),
+          throwsA(isA<OsCallException>()),
+        );
+        expect(await h('Path.read_text', ['/mnt/hello.txt'], null), 'hi');
+      });
+
+      // Declining used to rewrite the call to `[target]`, so a fallthrough
+      // handler received Path.rename with its SOURCE dropped.
+      test('declining to a fallthrough keeps BOTH arguments', () async {
+        final seen = <List<Object?>>[];
+        final h = memoryMountedOsHandler(
+          mounts: const [MountDir(virtualPath: '/mnt')],
+          files: [MontyMemoryFile('/mnt/hello.txt', 'hi')],
+          fallthrough: (op, args, kwargs) async {
+            seen.add(args);
+
+            return null;
+          },
+        );
+
+        await h('Path.rename', ['/mnt/hello.txt', '/etc/passwd'], null);
+
+        expect(seen, [
+          ['/mnt/hello.txt', '/etc/passwd'],
+        ]);
+      });
+    });
   });
 }

--- a/tool/breaking-ledger.tsv
+++ b/tool/breaking-ledger.tsv
@@ -31,3 +31,4 @@ cb6a997	`rename` follows CPython's full matrix
 b418cae	CPython path semantics: name length, codepoint counts, `resolve` returns a Path
 430779f	A path outside every mount is reported as absent, not denied
 51e4e8e	`ReplPlatform` now rejects per-call `limits` and `scriptName`
+f8c530a	`open()` parses its mode, and rejects a malformed one

--- a/tool/breaking-ledger.tsv
+++ b/tool/breaking-ledger.tsv
@@ -33,4 +33,4 @@ b418cae	CPython path semantics: name length, codepoint counts, `resolve` returns
 51e4e8e	`ReplPlatform` now rejects per-call `limits` and `scriptName`
 f8c530a	`open()` parses its mode, and rejects a malformed one
 7be9680	A `rename` TARGET outside every mount is absent too, not denied
-70e24e4	`MountDir.writeBytesLimit` is now CUMULATIVE, not per-write
+a21f47d	`MountDir.writeBytesLimit` is now CUMULATIVE, not per-write

--- a/tool/breaking-ledger.tsv
+++ b/tool/breaking-ledger.tsv
@@ -32,3 +32,4 @@ b418cae	CPython path semantics: name length, codepoint counts, `resolve` returns
 430779f	A path outside every mount is reported as absent, not denied
 51e4e8e	`ReplPlatform` now rejects per-call `limits` and `scriptName`
 f8c530a	`open()` parses its mode, and rejects a malformed one
+7be9680	A `rename` TARGET outside every mount is absent too, not denied

--- a/tool/breaking-ledger.tsv
+++ b/tool/breaking-ledger.tsv
@@ -33,3 +33,4 @@ b418cae	CPython path semantics: name length, codepoint counts, `resolve` returns
 51e4e8e	`ReplPlatform` now rejects per-call `limits` and `scriptName`
 f8c530a	`open()` parses its mode, and rejects a malformed one
 7be9680	A `rename` TARGET outside every mount is absent too, not denied
+70e24e4	`MountDir.writeBytesLimit` is now CUMULATIVE, not per-write

--- a/tool/serve_demo.sh
+++ b/tool/serve_demo.sh
@@ -3,7 +3,9 @@
 # dart_monty_core — build and serve the REPL web demo locally
 #
 # Usage:
-#   bash tool/serve_demo.sh [--skip-build] [--dart2wasm]
+#   bash tool/serve_demo.sh [--skip-build] [--dart2wasm] [--test-hooks]
+#
+#   --test-hooks and --skip-build are MUTUALLY EXCLUSIVE — see the guard below.
 #
 # Options:
 #   --skip-build   Skip npm + cargo + dart compile steps (use existing assets).
@@ -51,6 +53,33 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown flag: $1" >&2; exit 1 ;;
   esac
 done
+
+# --test-hooks needs BOTH halves rebuilt, so it cannot be combined with
+# --skip-build. Two independent axes have to agree:
+#
+#   the engine   built with the `test-hooks` cargo feature
+#   the Dart     compiled with -DMONTY_TEST_HOOKS=true (line ~152)
+#
+# --skip-build reuses whatever is staged in web/, and `tool/check_pages.sh`
+# legitimately overwrites both — it copies the SHIPPED engine from lib/assets/
+# and recompiles the Dart without the define. So after any gate run, a
+# --skip-build --test-hooks serve silently downgrades: the matrix reports
+# "8 needs test-hooks build" and 521/531 instead of 529/531, with nothing
+# saying why. Measured 2026-08-03; it cost real debugging time.
+#
+# Refusing is better than warning: the flag's whole purpose is to make those
+# eight fixtures RUN, and honouring it while not doing so is the worst outcome.
+if [ "$TEST_HOOKS" = true ] && [ "$SKIP_BUILD" = true ]; then
+  echo "ERROR: --test-hooks cannot be combined with --skip-build." >&2
+  echo "" >&2
+  echo "  --test-hooks needs a test-hooks ENGINE and Dart compiled with" >&2
+  echo "  -DMONTY_TEST_HOOKS=true. --skip-build reuses whatever is in" >&2
+  echo "  packages/dart_monty_web/web/, which tool/check_pages.sh overwrites" >&2
+  echo "  with the shipped engine and a no-define compile." >&2
+  echo "" >&2
+  echo "  Drop --skip-build (a test-hooks cargo build takes ~2-3 min)." >&2
+  exit 1
+fi
 
 echo "=== dart_monty_core REPL demo ==="
 echo ""


### PR DESCRIPTION
VFS Phase 5 plus §6c, on their own branch as the checklist required.

## Phase 5 — `VfsCallbackFile`

`VfsCallbackFile(path, read:, write:)` ships in its own library,
`package:dart_monty_core/unsafe_callback_file.dart`, with upstream's warning
repeated on the class.

**Box 2 is deleted, not implemented.** The checklist asked that *"the default
entry point cannot accept one without that import"*. Dart cannot express it —
`VfsFile` is an open interface and the entry point takes `List<VfsFile>`, so the
import gates construction, not passing.

Worse, it described a property this library never had. A separate package with a
path dep, importing only the main library, ~20 lines:

```dart
class HostFile implements VfsFile {
  @override
  VfsContent get content => VfsText(File(hostPath).readAsStringSync());
}
```

analyses clean and reads host content out through `Path.read_text`. A checkbox
promising the entry point *cannot* accept an unsafe file teaches a reviewer the
`files:` list needs no scrutiny, which is backwards. The honest rule replaces
it: **audit every `VfsFile` that is not a `MontyMemoryFile`.**

**The callback receives the seeded path, never the live one.** A rename rewrites
the live `path` of every file in the moved subtree, so handing that to the
callback would let sandboxed Python choose the argument the host receives.
Watched red first:

```
Expected: ['/mnt/config.txt']   Actual: ['/mnt/secrets.txt']
```

Two bounds, measured and tested: sandboxed code cannot leave the mount, and
cannot mint a callback file.

Alternatives (sealed marker supertype, runtime whitelist, a declared
`reachesHost` bit) were killed adversarially by two model families
independently.

## §6c — and the defect it found

Porting upstream's `test_os_access.py` surfaced a live bug in exported API:
`resolveOpenCall` treated every unrecognised mode as append, so
`open(p, 'wxyz')` **silently created a file**. Upstream's own test for this is a
named data-loss regression guard.

The mode is now parsed before any side effect. `b`/`t`/`+` become orthogonal to
the action as upstream has them, so `r+` is a read action that no longer
creates, and `x` is rejected rather than invented.

Also pinned: empty-vs-missing `iterdir`, `append_text` chars vs `append_bytes`
bytes, and root as a directory.

## Verification

- Gate `20260803T053035Z` (Phase 5) and the §6c run: **25/25 PASS, exit 0** each
- 437 unit tests green; `unit_web` runs them on VM + dart2js + dart2wasm
- `check_vfs_regression.sh` green, both `mount_fs` targets still met
- DCM 176 vs 206 baseline, ratchet passing without a baseline bump

## Phase 6 is deliberately deferred, not outstanding

Overlay mode is "only if a consumer needs it" and the VFS API has **zero**
downstream consumers (measured). Boundary-enforced host mounts is settled
against — a solo-maintained Dart re-derivation of upstream's Rust boundary
module is more dangerous than a callback the consumer wrote deliberately.